### PR TITLE
network: Add types and deserializer for NetworkOptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +71,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +105,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +124,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lazy_static"
@@ -103,10 +144,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "netavark"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "clap",
+ "serde",
+ "serde-value",
+ "serde_derive",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c9d06878b3a851e8026ef94bf7fef9ba93062cd412601da4d9cf369b1cc62d"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -114,6 +195,12 @@ name = "os_str_bytes"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "proc-macro-error"
@@ -158,6 +245,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "serde"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +327,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +386,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +409,12 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,15 @@ authors = ["github.com/containers"]
 description = "A container network stack"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["serde", "deps-serde"]
+deps-serde = ["chrono/serde", "url/serde"]
 
 [dependencies]
 clap = "3.0.0-beta.4"
+chrono = "0.4.7"
+serde = { version = "1.0.124", features = ["derive"], optional = true }
+url = "2.1.0"
+serde-value = "0.7.0"
+serde_json = "1.0.64"
+serde_derive = "1.0.125"

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1,6 +1,7 @@
 //! Configures the given network namespace with provided specs
 use std::path::PathBuf;
 use clap::{self, Clap};
+use crate::network;
 
 #[derive(Clap, Debug)]
 pub struct Setup {
@@ -18,6 +19,13 @@ impl Setup {
     }
 
     pub fn exec(&self, input_file: PathBuf) {
+
+        //TODO: Can we be more safe while converting PathBuf to string
+        let _network_options = match network::NetworkOptions::load(&input_file.into_os_string().into_string().unwrap()) {
+            Ok(opts) => opts,
+            Err(e) => panic!("{}", e),
+        };
+
         ()
     }
 }

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use clap::{self, Clap};
+use crate::network;
 
 #[derive(Clap, Debug)]
 pub struct Teardown {
@@ -17,6 +18,12 @@ impl Teardown {
     }
 
     pub fn exec(&self, input_file: PathBuf) {
+        //TODO: Can we be more safe while converting PathBuf to string
+        let _network_options = match network::NetworkOptions::load(&input_file.into_os_string().into_string().unwrap()) {
+            Ok(opts) => opts,
+            Err(e) => panic!("{}", e),
+        };
+
         ()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,17 @@
+#[macro_use]
+extern crate serde;
+extern crate serde_derive;
+extern crate serde_json;
+
+pub mod serialize;
+pub mod network;
 pub mod commands;
+
+impl network::NetworkOptions {
+    pub fn load(path: &str) -> Result<network::NetworkOptions, serialize::SerializeError> {
+        serialize::deserialize(path)
+    }
+    pub fn save(&self, path: &str) -> Result<(), serialize::SerializeError> {
+        serialize::serialize(self, path)
+    }
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,0 +1,55 @@
+// Crate contains the types which are accepted by netvark.
+
+extern crate serde_derive;
+use std::collections::HashMap;
+
+// NetworkOptions for a given container.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetworkOptions {
+    #[serde(rename = "container_id")]
+    pub container_id: String,
+
+    #[serde(rename = "container_name")]
+    pub container_name: String,
+
+    #[serde(rename = "networks")]
+    pub networks: HashMap<String, PerNetworkOptions>,
+
+    #[serde(rename = "port_mappings")]
+    pub port_mappings: Option<Vec<PortMapping>>,
+}
+
+// PerNetworkOptions are options which should be set on a per network basis
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PerNetworkOptions {
+    #[serde(rename = "aliases")]
+    pub aliases: Option<Vec<String>>,
+
+    #[serde(rename = "interface_name")]
+    pub interface_name: String,
+
+    #[serde(rename = "static_ips")]
+    pub static_ips: Option<Vec<String>>,
+
+    #[serde(rename = "static_mac")]
+    pub static_mac: Option<String>,
+}
+
+// PortMapping is one or more ports that will be mapped into the container.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PortMapping {
+    #[serde(rename = "container_port")]
+    pub container_port: u16,
+
+    #[serde(rename = "host_ip")]
+    pub host_ip: String,
+
+    #[serde(rename = "host_port")]
+    pub host_port: u16,
+
+    #[serde(rename = "protocol")]
+    pub protocol: String,
+
+    #[serde(rename = "range")]
+    pub range: u16,
+}

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,0 +1,68 @@
+use serde;
+use serde_json;
+
+use std::{fmt, io, error::Error, fs::File};
+
+#[derive(Debug)]
+pub enum SerializeError {
+    Io(io::Error),
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for SerializeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SerializeError::Io(ref err) => err.fmt(f),
+            SerializeError::Json(ref err) => err.fmt(f),
+        }
+    }
+}
+
+#[allow(deprecated)]
+impl Error for SerializeError {
+    fn description(&self) -> &str {
+        match *self {
+            SerializeError::Io(ref err) => err.description(),
+            SerializeError::Json(ref err) => err.description(),
+        }
+    }
+    fn cause(&self) -> Option<&dyn Error> {
+        match *self {
+            SerializeError::Io(ref err) => Some(err),
+            SerializeError::Json(ref err) => Some(err),
+        }
+    }
+}
+
+impl From<io::Error> for SerializeError {
+    fn from(err: io::Error) -> SerializeError {
+        SerializeError::Io(err)
+    }
+}
+
+impl From<serde_json::Error> for SerializeError {
+    fn from(err: serde_json::Error) -> SerializeError {
+        SerializeError::Json(err)
+    }
+}
+
+pub fn serialize<T: serde::Serialize>(obj: &T, path: &str) -> Result<(), SerializeError> {
+    let mut file = File::create(path)?;
+    Ok(serde_json::to_writer_pretty(&mut file, &obj)?)
+}
+
+pub fn deserialize<T>(path: &str) -> Result<T, SerializeError>
+    where for<'de> T: serde::Deserialize<'de>
+{
+    let file = File::open(path)?;
+    Ok(serde_json::from_reader(&file)?)
+}
+
+pub fn to_writer<W: io::Write, T: serde::Serialize>(obj: &T, mut writer: W) -> Result<(), SerializeError> {
+    Ok(serde_json::to_writer(&mut writer, &obj)?)
+}
+
+pub fn to_string<T: serde::Serialize>(obj: &T) -> Result<String, SerializeError> {
+    Ok(serde_json::to_string(&obj)?)
+}
+


### PR DESCRIPTION
Following PR contains types which will be consumed by netavark.

* Types
* Deserializer to consume types from files.
* Serializer incase we need to flush back types back to json. (We can remove this later if not needed).