### PR TITLE
tests: Add tests for Network Setup Options deserializer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ build:
 clean:
 	rm -rf bin
 
+test:
+	cargo test
+
 all: build
 
 help:

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,3 +34,6 @@ fn main() {
         SubCommand::Teardown(teardown) => teardown.exec(opts.file.unwrap()),
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/src/test/config/setupopts.test.json
+++ b/src/test/config/setupopts.test.json
@@ -1,0 +1,18 @@
+{
+   "container_id":"6ce776ea58b5",
+   "container_name":"testcontainer",
+   "port_mappings":[
+      {
+         "host_ip":"127.0.0.1",
+         "container_port":5000,
+         "host_port":5001,
+         "range":3,
+         "protocol":"tcp"
+      }
+   ],
+   "networks":{
+      "defaultNetwork":{
+         "interface_name":"eth0"
+      }
+   }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,0 +1,2 @@
+pub mod test;
+

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -1,0 +1,23 @@
+//use super::*;
+
+#[cfg(test)]
+mod tests {
+  use netavark::network;
+  #[test]
+  // Test setup options loader
+  fn test_setup_opts_load(){
+    match network::NetworkOptions::load("src/test/config/setupopts.test.json")  {
+        Ok(_) => {},
+        Err(e) => panic!("{}", e),
+    }
+  }
+
+  // Test if we can deserialize values correctly
+  #[test]
+  fn test_setup_opts_assert(){
+    match network::NetworkOptions::load("src/test/config/setupopts.test.json") {
+        Ok(setupopts) => {assert_eq!(setupopts.container_name, "testcontainer")},
+        Err(e) => panic!("{}", e),
+    }
+  }
+}


### PR DESCRIPTION
Initial tests setup.
* Covers deserialize and struct loading test for network options.

Usage
```console
make test
```