### PR TITLE
Add cirrus testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,18 @@
+---
+
+test_task:
+  alias: "build_and_test"
+  name: "Build and Test"
+  container:
+    image: docker.io/library/rust
+  install_script: cargo build
+  test_script: cargo test
+
+success_task:
+  name: "Total success"
+  depends_on:
+    - "build_and_test"
+  clone_script: /bin/true
+  script: /bin/true
+  container: 
+    image: docker.io/library/alpine


### PR DESCRIPTION
Basic wireup for testing in the cirrus container.  At first, we just use
a container.

Signed-off-by: Brent Baude <bbaude@redhat.com>