### PR TITLE
Makefile: silence debug line when debug unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,8 @@
 
 debug ?=
 
-$(info debug is $(debug))
-
 ifdef debug
+$(info debug is $(debug))
   release :=
   target :=debug
   extension :=debug


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@flouthoc @mheon @baude @Luap99 PTAL

I find the `debug is` to be annoying when debug isn't set. But, not a particularly strong opinion.