### PR TITLE
adapter: Add network manager adapter currently supports `nmstate`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+
+[[package]]
 name = "async-io"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +64,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cache-padded"
@@ -143,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "enumflags2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +195,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethtool"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c44940f74f15d9808a7f09a01204de9dc8f52783d9b9530f2cc561a6c9a1414"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "futures",
+ "genetlink",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-generic",
+ "netlink-packet-utils",
+ "netlink-proto",
+ "netlink-sys",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +231,16 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -305,6 +353,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "genetlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e451387bb63a80eed5deb340882a1460688a8a7cb4452c540b80eba21f639e8e"
+dependencies = [
+ "futures",
+ "netlink-packet-core",
+ "netlink-packet-generic",
+ "netlink-packet-utils",
+ "netlink-proto",
+ "thiserror",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,7 +453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5451d970ceaf1d94b287f060eda6c553b0bd93412986765e3274c28a89b50830"
 dependencies = [
  "lazy_static",
- "nix",
+ "nix 0.20.2",
  "regex",
 ]
 
@@ -398,9 +471,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -433,6 +512,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nb-connect"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,16 +550,115 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "fs2",
  "ipnet",
  "iptables",
  "log",
+ "nmstate",
  "serde",
  "serde-value",
  "serde_derive",
  "serde_json",
+ "serde_yaml",
  "simple-error",
  "url",
  "zbus",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac48279d5062bdf175bdbcb6b58ff1d6b0ecd54b951f7a0ff4bc0550fe903ccb"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-generic"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9988c370bd04827d9b29c0a54e5a460c3e54618d4c811cfa37a3c2b47808aaf"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76aed5d3b6e3929713bf1e1334a11fd65180b6d9f5d7c8572664c48b122604f8"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fcfb6f758b66e964b2339596d94078218d96aad5b32003e8e2a1d23c27a6784"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd06e90449ae973fe3888c1ff85949604ef5189b4ac9a2ae39518da1e00762d"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48ea34ea0678719815c3753155067212f853ad2d8ef4a49167bae7f7c254188"
+dependencies = [
+ "futures",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "nispor"
+version = "1.2.0"
+source = "git+https://github.com/nispor/nispor?branch=base#0b273d528128e4babded5d3b4138ba4918ea369c"
+dependencies = [
+ "ethtool",
+ "futures",
+ "libc",
+ "log",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-sys",
+ "rtnetlink",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -472,6 +672,51 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3bb9a13fa32bc5aeb64150cd3f32d6cf4c748f8f8a417cce5d2eb976a8370ba"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nm-dbus"
+version = "0.1.0"
+source = "git+https://github.com/nmstate/nmstate#df89b76ddeb46ab691c29012d8af6cddf67ce64b"
+dependencies = [
+ "log",
+ "uuid",
+ "zbus",
+ "zvariant",
+]
+
+[[package]]
+name = "nmstate"
+version = "2.0.0"
+source = "git+https://github.com/nmstate/nmstate#df89b76ddeb46ab691c29012d8af6cddf67ce64b"
+dependencies = [
+ "log",
+ "nispor",
+ "nm-dbus",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -519,6 +764,12 @@ name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "percent-encoding"
@@ -608,18 +859,18 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -640,6 +891,21 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "rtnetlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9a6200d18ec1acfc218ce71363dcc9b6075f399220f903fdfeacd476a876ef"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-route",
+ "netlink-proto",
+ "nix 0.22.2",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "ryu"
@@ -706,6 +972,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
+dependencies = [
+ "dtoa",
+ "indexmap",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "simple-error"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,9 +1019,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -790,20 +1068,19 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi",
  "winapi",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -813,6 +1090,47 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "pin-project-lite",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -825,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -870,6 +1188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,9 +1216,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wepoll-ffi"
@@ -934,6 +1261,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "zbus"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,7 +1282,7 @@ dependencies = [
  "fastrand",
  "futures",
  "nb-connect",
- "nix",
+ "nix 0.20.2",
  "once_cell",
  "polling",
  "scoped-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ serde_json = "1.0.64"
 simple-error = "0.1.9"
 url = "2.1.0"
 zbus = "1.9.1"
+nmstate = { git = "https://github.com/nmstate/nmstate"}
+serde_yaml = "0.8"
+fs2 = "0.4.3"

--- a/src/network/adapter.rs
+++ b/src/network/adapter.rs
@@ -1,0 +1,218 @@
+extern crate fs2;
+use fs2::FileExt;
+use std::fs::File;
+use nmstate::NetworkState;
+use nmstate::NmstateError;
+extern crate serde_derive;
+use serde_yaml::{self, Value};
+
+const IFACE_TOP_PRIORTIES: [&str; 2] = ["name", "type"];
+const ADAPTER_LOCK_FILE: &str = "/var/tmp/netvark.adapter.lock";
+
+/* Adapter: Is a genric adapter to any NetworkManager
+ * Currently supports: nmstate-rs
+ */
+pub struct Adapter {
+    _input: NmStateAdapterInterface,
+}
+
+pub struct AdapterError {
+    pub(crate) msg: String,
+}
+
+impl std::fmt::Display for AdapterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl From<std::io::Error> for AdapterError {
+    fn from(e: std::io::Error) -> Self {
+        Self { msg: format!("std::io::Error: {}", e) }
+    }
+}
+
+impl From<NmstateError> for AdapterError {
+    fn from(e: NmstateError) -> Self {
+        Self { msg: format!("NmstateError: {}", e) }
+    }
+}
+
+impl From<serde_yaml::Error> for AdapterError {
+    fn from(e: serde_yaml::Error) -> Self {
+        Self { msg: format!("serde_yaml::Error: {}", e) }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NmStateAdapterInterface {
+    #[serde(rename = "interfaces")]
+    pub interfaces: Vec<Interface>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Interface {
+    #[serde(rename = "name")]
+    pub name: String,
+
+    #[serde(rename = "type")]
+    pub interface_type: String,
+
+    #[serde(rename = "state")]
+    pub state: String,
+
+    #[serde(rename = "bridge")]
+    pub bridge: Option<Bridge>,
+
+    #[serde(rename = "ipv4")]
+    pub ipv4: Option<NmIp>,
+
+    #[serde(rename = "ipv6")]
+    pub ipv6: Option<NmIp>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Bridge {
+    #[serde(rename = "port")]
+    pub port: Vec<Port>,
+
+    #[serde(rename = "options")]
+    pub options: Options,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Options {
+    #[serde(rename = "stp")]
+    pub stp: Stp,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Stp {
+    #[serde(rename = "enabled")]
+    pub enabled: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Port {
+    #[serde(rename = "name")]
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NmIp {
+    #[serde(rename = "address")]
+    pub address: Vec<Address>,
+
+    #[serde(rename = "dhcp")]
+    pub dhcp: bool,
+
+    #[serde(rename = "enabled")]
+    pub enabled: bool,
+
+    #[serde(rename = "autoconf")]
+    pub autoconf: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Address {
+    #[serde(rename = "ip")]
+    pub ip: String,
+
+    #[serde(rename = "prefix-length")]
+    pub prefix_length: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct SortedNetworkState {
+    interfaces: Vec<Value>,
+}
+
+impl Adapter {
+    fn sort_netstate(net_state: NetworkState) -> Result<SortedNetworkState, AdapterError> {
+        let mut ifaces = net_state.interfaces.to_vec();
+        ifaces.sort_by(|a, b| a.name().cmp(b.name()));
+
+        if let Value::Sequence(ifaces) = serde_yaml::to_value(&ifaces)? {
+            let mut new_ifaces = Vec::new();
+            for iface_v in ifaces {
+                if let Value::Mapping(iface) = iface_v {
+                    let mut new_iface = serde_yaml::Mapping::new();
+                    for top_property in &IFACE_TOP_PRIORTIES {
+                        if let Some(v) = iface.get(&Value::String(top_property.to_string())) {
+                            new_iface.insert(Value::String(top_property.to_string()), v.clone());
+                        }
+                    }
+                    for (k, v) in iface.iter() {
+                        if let Value::String(ref name) = k {
+                            if IFACE_TOP_PRIORTIES.contains(&name.as_str()) {
+                                continue;
+                            }
+                        }
+                        new_iface.insert(k.clone(), v.clone());
+                    }
+
+                    new_ifaces.push(Value::Mapping(new_iface));
+                }
+            }
+            return Ok(SortedNetworkState { interfaces: new_ifaces });
+        }
+
+        Ok(SortedNetworkState { interfaces: Vec::new() })
+    }
+
+    pub fn nmstate_adapter_apply_file(
+        file_path: &str,
+        kernel_only: bool,
+        no_verify: bool,
+    ) -> Result<String, AdapterError> {
+        // create lockfile or truncate
+        let _lockfile_create = File::open(&ADAPTER_LOCK_FILE)?;
+        let lockfile = File::open(&ADAPTER_LOCK_FILE)?;
+        lockfile.lock_exclusive()?;
+        let fd = std::fs::File::open(file_path)?;
+        let mut net_state: NetworkState = serde_yaml::from_reader(fd)?;
+        net_state.set_kernel_only(kernel_only);
+        net_state.set_verify_change(!no_verify);
+        net_state.apply()?;
+        lockfile.unlock()?;
+        let sorted_net_state = Adapter::sort_netstate(net_state)?;
+        Ok(serde_yaml::to_string(&sorted_net_state)?)
+    }
+
+    pub fn nmstate_adapter_apply(
+        input: &NmStateAdapterInterface,
+        kernel_only: bool,
+        no_verify: bool,
+    ) -> Result<String, AdapterError> {
+        // create lockfile or truncate
+        let _lockfile_create = File::open(&ADAPTER_LOCK_FILE)?;
+        let lockfile = File::open(&ADAPTER_LOCK_FILE)?;
+        lockfile.lock_exclusive()?;
+        let value = serde_yaml::to_value(&input).unwrap();
+        let mut net_state: NetworkState = serde_yaml::from_value(value).unwrap();
+        net_state.set_kernel_only(kernel_only);
+        net_state.set_verify_change(!no_verify);
+        net_state.apply()?;
+        lockfile.unlock()?;
+        let sorted_net_state = Adapter::sort_netstate(net_state)?;
+        Ok(serde_yaml::to_string(&sorted_net_state)?)
+    }
+
+    pub fn nmstate_adapter_apply_directly(
+        input: NetworkState,
+        kernel_only: bool,
+        no_verify: bool,
+    ) -> Result<String, AdapterError> {
+        // create lockfile or truncate
+        let _lockfile_create = File::open(&ADAPTER_LOCK_FILE)?;
+        let lockfile = File::open(&ADAPTER_LOCK_FILE)?;
+        lockfile.lock_exclusive()?;
+        let mut net_state: NetworkState = input;
+        net_state.set_kernel_only(kernel_only);
+        net_state.set_verify_change(!no_verify);
+        net_state.apply()?;
+        lockfile.unlock()?;
+        let sorted_net_state = Adapter::sort_netstate(net_state)?;
+        Ok(serde_yaml::to_string(&sorted_net_state)?)
+    }
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,4 +1,5 @@
 pub mod types;
+pub mod adapter;
 use crate::serialize;
 
 impl types::NetworkOptions {


### PR DESCRIPTION
Add a generic top level network manager adapter for Netavark.
Netavark uses network manager to interact with embedded or external
network manager via API.

Primary reason is to easily offload host network state to network
manager.

Currently only scoped to nmstate.