### PR TITLE
Add network information to setupopts

### DIFF
--- a/src/test/config/setupopts.test.json
+++ b/src/test/config/setupopts.test.json
@@ -22,7 +22,14 @@
          "id":"53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
          "internal":false,
          "ipv6_enabled":true,
-         "name":"defaultNetwork"
+         "name":"defaultNetwork",
+	  "network_interface": "podman0",
+	  "subnets": [
+		 {
+			 "gateway":"192.168.43.1",
+			 "subnet": "192.168.43.0/24"
+		 }
+	 ]
       }
    }
 }


### PR DESCRIPTION
Adding more/required information for network setup to the test config
file.  For now, I use 192.168 to avoid collision with the 10.8* subnets
that cni uses.

Signed-off-by: Brent Baude <bbaude@redhat.com>