### PR TITLE
CI and Makefile updates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,15 +5,15 @@ test_task:
   name: "Build and Test"
   container:
     image: quay.io/libpod/netavark-devel
-  install_script: cargo build
-  test_script: cargo test
+  install_script: make all
+  test_script: make test
 
 test_task:
   alias: "validate_test"
   name: "Validate Code"
   container:
     image: quay.io/libpod/netavark-devel
-  test_script: cargo clippy -p netavark -- -D warnings
+  test_script: make validate
 
 success_task:
   name: "Total success"

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ test:
 	cargo test
 
 validate:
+	cargo fmt --all -- --check
 	cargo clippy -p netavark -- -D warnings
+
 all: build docs
 
 help:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
-PREFIX := /usr/local
-DATADIR := ${PREFIX}/share
-MANDIR := $(DATADIR)/man
-GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
+PREFIX ?= /usr/local
+DATADIR ?= ${PREFIX}/share
+MANDIR ?= $(DATADIR)/man
+MANDOWN ?= $(shell command -v mandown)
 
 docs: $(patsubst %.md,%,$(wildcard *.md))
 
@@ -15,7 +15,7 @@ docs: $(patsubst %.md,%,$(wildcard *.md))
 	 -e 's/\[\([^]]*\)](http[^)]\+)/\1/g' \
 	 -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \
 	 -e 's/\\$$/  /g' $<  | \
-	$(GOMD2MAN) -in /dev/stdin -out  $@
+	$(MANDOWN) /dev/stdin > $@
 
 .PHONY: install
 install:


### PR DESCRIPTION
- Run rustfmt in `make validate` and CI validation
- Makefile: allow modification of PREFIX, DATADIR and MANDIR
- .cirrus.yml uses make targets instead of cargo commands
- Use `mandown` for manpage generation instead of `go-md2man`

Needs rustfmt(-nightly) and mandown crates installed in CI image.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@flouthoc @baude @mheon @Luap99 @ashcrow PTAL


We'll need rustfmt crate in quay.io/libpod/netavark-devel to get this working. 

Also, once this is merged, I expect a few things to go kaboom.