### PR TITLE
default to stdin for the config

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -3,7 +3,6 @@ use crate::firewall;
 use crate::network;
 use clap::{self, Clap};
 use log::debug;
-use std::path::PathBuf;
 
 #[derive(Clap, Debug)]
 pub struct Setup {
@@ -20,14 +19,11 @@ impl Setup {
         }
     }
 
-    pub fn exec(&self, input_file: PathBuf) {
+    pub fn exec(&self, input_file: String) {
         debug!("{:?}", "Setting up...");
 
         let network_options = match network::types::NetworkOptions::load(
             &input_file
-                .into_os_string()
-                .into_string()
-                .expect("Failed to convert PathBuf to string during network setup"),
         ) {
             Ok(opts) => opts,
             Err(e) => panic!("{}", e),

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -1,7 +1,6 @@
 use crate::network;
 use clap::{self, Clap};
 use log::debug;
-use std::path::PathBuf;
 
 #[derive(Clap, Debug)]
 pub struct Teardown {
@@ -18,14 +17,10 @@ impl Teardown {
         }
     }
 
-    pub fn exec(&self, input_file: PathBuf) {
+    pub fn exec(&self, input_file: String) {
         debug!("{:?}", "Tearing down..");
-        //TODO: Can we be more safe while converting PathBuf to string
         let _network_options = match network::types::NetworkOptions::load(
             &input_file
-                .into_os_string()
-                .into_string()
-                .expect("Failed to convert PathBuf to string during network teardown"),
         ) {
             Ok(opts) => opts,
             Err(e) => panic!("{}", e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use clap::{crate_version, Clap};
 
 use netavark::commands::setup;
@@ -9,7 +8,7 @@ use netavark::commands::teardown;
 struct Opts {
     /// Instead of reading from STDIN, read the configuration to be applied from the given file.
     #[clap(short, long)]
-    file: Option<PathBuf>,
+    file: Option<String>,
     /// Netavark trig command
     #[clap(subcommand)]
     subcmd: SubCommand,
@@ -29,12 +28,14 @@ fn main() {
     env_logger::init();
     let opts = Opts::parse();
 
+    let file = opts.file.unwrap_or_else(|| String::from("/dev/stdin"));
+
     match opts.subcmd {
         SubCommand::Setup(setup) => {
-            setup.exec(opts.file.expect("Failed to read file for network setup"))
+            setup.exec(file)
         }
         SubCommand::Teardown(teardown) => {
-            teardown.exec(opts.file.expect("Failed to read file for network teardown"))
+            teardown.exec(file)
         }
     }
 }


### PR DESCRIPTION
Netavark should not panic when --file is not set, instead it should read
from stdin. Also convert the type to String to avoid unnecessary type
conversions.