### PR TITLE
Add rustfmt to netavark image

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,3 +1,3 @@
 # Container image for validating and building netavark
 FROM docker.io/library/rust
-RUN rustup component add clippy
+RUN rustup component add clippy rustfmt && cargo install mandown


### PR DESCRIPTION
We want to be able to run rustfmt to validate code.

Signed-off-by: Brent Baude <bbaude@redhat.com>