### PR TITLE
Ignore EEXIST for ip assignment to bridge.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,7 @@ dependencies = [
  "ipnet",
  "ipnetwork",
  "iptables",
+ "libc",
  "log",
  "nix 0.23.0",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap = "3.0.0-beta.4"
 env_logger = "0.9.0"
 ipnet = { version = "2", features = ["serde"] }
 iptables = "0.4.3"
+libc = "0.2"
 log = "0.4.14"
 serde = { version = "1.0.124", features = ["derive"], optional = true }
 serde-value = "0.7.0"


### PR DESCRIPTION
If we try to add the ips to the interface netlink will answer with
EEXIST when the ip is already assignment to the interface. Lets make sure
to ignore this because this is not an error for us.