### PR TITLE
core: turn up  `lo` adapter in ctr namespace during setup

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -168,6 +168,13 @@ impl Core {
                         container_veth_name_clone
                     );
 
+                    if let Err(er) = core_utils::CoreUtils::turn_up_interface("lo") {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("failed while turning up `lo` in container namespace {}", er),
+                        ));
+                    }
+
                     //return MAC address to status block could use this
                     match core_utils::CoreUtils::get_interface_address(&container_veth_name_clone) {
                         Ok(addr) => Ok(addr),

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -192,6 +192,27 @@ impl CoreUtils {
         Ok(())
     }
 
+    #[tokio::main]
+    pub async fn turn_up_interface(ifname: &str) -> Result<(), Error> {
+        let (connection, handle, _) = match rtnetlink::new_connection() {
+            Ok((conn, handle, messages)) => (conn, handle, messages),
+            Err(err) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("failed to connect: {}", err),
+                ))
+            }
+        };
+
+        tokio::spawn(connection);
+
+        if let Err(err) = CoreUtils::set_link_up(&handle, ifname).await {
+            return Err(err);
+        }
+
+        Ok(())
+    }
+
     async fn remove_link(handle: &rtnetlink::Handle, ifname: &str) -> Result<(), std::io::Error> {
         let mut links = handle
             .link()


### PR DESCRIPTION
We must turn up loopback while `setup` cause podman will not do that for
us.