### PR TITLE
Fix POSTROUTING rule exists check

### DIFF
--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -77,9 +77,7 @@ impl firewall::FirewallDriver for IptablesDriver {
                     network_name
                 )
                 .to_string();
-                let jump_check = self
-                    .conn
-                    .exists(&network_name, POSTROUTING, &jump_podman_rule);
+                let jump_check = self.conn.exists(NAT, POSTROUTING, &jump_podman_rule);
                 match jump_check {
                     Ok(true) => debug_rule_exists(NAT, POSTROUTING, jump_podman_rule),
                     Ok(false) => {


### PR DESCRIPTION
There was a typo in the iptables rule exists check, we have to read the NAT table.