### PR TITLE
netlink add ecmp route

### DIFF
--- a/src/test/config/twoNetworks.json
+++ b/src/test/config/twoNetworks.json
@@ -1,0 +1,58 @@
+{
+    "container_id": "2d0fe608dc86d7ba65dcec724a335b618328f08daa62afd2ee7fa9d41f74e5a9",
+    "container_name": "",
+    "networks": {
+        "podman1": {
+            "static_ips": [
+                "10.0.0.2"
+            ],
+            "interface_name": "eth0"
+        },
+        "podman2": {
+            "static_ips": [
+                "10.1.0.2"
+            ],
+            "interface_name": "eth1"
+        }
+    },
+    "network_info": {
+        "podman1": {
+            "name": "podman1",
+            "id": "4937f73ac0df011d4f2848d5f83f5c20b707e71a8d98789bbe80d8f64a815e79",
+            "driver": "bridge",
+            "network_interface": "podman1",
+            "created": "2021-11-04T19:08:39.124321192+01:00",
+            "subnets": [
+                {
+                    "subnet": "10.0.0.0/24",
+                    "gateway": "10.0.0.1"
+                }
+            ],
+            "ipv6_enabled": false,
+            "internal": false,
+            "dns_enabled": false,
+            "ipam_options": {
+                "driver": "host-local"
+            }
+        },
+        "podman2": {
+            "name": "podman2",
+            "id": "488a7d9be4fa72a5b80811bd847aac1d99d1a09060739b4e08687949c957cda8",
+            "driver": "bridge",
+            "network_interface": "podman2",
+            "created": "2021-11-04T19:08:39.124800596+01:00",
+            "subnets": [
+                {
+                    "subnet": "10.1.0.0/24",
+                    "gateway": "10.1.0.1"
+                }
+            ],
+            "ipv6_enabled": false,
+            "internal": false,
+            "dns_enabled": false,
+            "ipam_options": {
+                "driver": "host-local"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The default route will be added for each connected network, so when you
would try to use two networks it would fail because the default route
was already added. While we could ignore eexist error this is not what
we want.
If we only have one route and disconnect the network with the default
route we will loose internet connectivity. To best way is to have each
network create the default route. This can be done by not setting the
NLM_F_EXCL flag for the netlink request.

Also see this CNI bridge plugin PR which does the same there: https://github.com/containernetworking/plugins/pull/615
