### PR TITLE
network setup use proper ip types instead of strings

### DIFF
--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -127,7 +127,7 @@ pub struct NetInterface {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NetAddress {
     #[serde(rename = "gateway")]
-    pub gateway: Option<String>,
+    pub gateway: Option<IpAddr>,
 
     #[serde(rename = "subnet")]
     pub subnet: IpNet,
@@ -136,7 +136,7 @@ pub struct NetAddress {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Subnet {
     #[serde(rename = "gateway")]
-    pub gateway: Option<String>,
+    pub gateway: Option<IpAddr>,
 
     #[serde(rename = "lease_range")]
     pub lease_range: Option<LeaseRange>,


### PR DESCRIPTION
We should parse the types early so that we do not run in unexpected
errors later.
This commit also fixes the following issues:
The gateway ip can be empty for internal networks.
The subnet parsing was broken for ipv6.
