### PR TITLE
Drop unnecessary `serde_derive` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,6 @@ dependencies = [
  "rtnetlink",
  "serde",
  "serde-value",
- "serde_derive",
  "serde_json",
  "simple-error",
  "sysctl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ libc = "0.2"
 log = "0.4.14"
 serde = { version = "1.0.124", features = ["derive"], optional = true }
 serde-value = "0.7.0"
-serde_derive = "1.0.125"
 serde_json = "1.0.69"
 simple-error = "0.2.3"
 sysctl = "0.4.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate serde;
-extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate simple_error;

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -1,6 +1,5 @@
 // Crate contains the types which are accepted by netavark.
 
-extern crate serde_derive;
 use ipnet::IpNet;
 use std::collections::HashMap;
 use std::net::IpAddr;


### PR DESCRIPTION
We're already doing it the (IMO more preferred) way of using
`serde = ... features = ["derive"]` so this was just unused.