### PR TITLE
core: add methods to configure `macvlan` interface for container and point to latest `rtnetlink`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,8 +932,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 [[package]]
 name = "rtnetlink"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9a6200d18ec1acfc218ce71363dcc9b6075f399220f903fdfeacd476a876ef"
+source = "git+https://github.com/little-dude/netlink?branch=master#8288e1736756a893ed9018f48ca3e9b0568d211f"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ simple-error = "0.2.3"
 sysctl = "0.4.3"
 url = "2.1.0"
 zbus = "1.9.1"
-rtnetlink = "0.8.1"
+rtnetlink = { git = "https://github.com/little-dude/netlink", branch = "master" }
 futures = "0.3.17"
 nix = "0.23.0"
 rand = "0.8.3"


### PR DESCRIPTION
Following PR makes these following changes

Adds core methods to create macvlan interface.
    
    * Creates macvlan for specified master veth with given mode.
    * Moves and rename macvlan to container namespace.
    * Turn up macvlan interface.

* Update `Cargo.toml` to point to `master` of `rtnetlink`. After https://github.com/little-dude/netlink/pull/194


