### PR TITLE
netavark: fix error wrapping and formatting

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -108,7 +108,7 @@ impl Core {
             Err(err) => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("failed configure bridge and veth interface: {:?}", err),
+                    format!("failed configure bridge and veth interface: {}", err),
                 ))
             }
         };
@@ -141,7 +141,7 @@ impl Core {
             Err(err) => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("Error while configuring network interface {}:", err),
+                    format!("failed while configuring network interface {}:", err),
                 ))
             }
         };
@@ -161,11 +161,11 @@ impl Core {
                 // otherwise cleanup would become mess
                 // try removing leaking interfaces from host
                 if let Err(er) = core_utils::CoreUtils::remove_interface(&host_veth_name) {
-                    warn!("Failed while cleaning up interfaces: {}", er);
+                    warn!("failed while cleaning up interfaces: {}", er);
                 }
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("Error while configuring network interface {}:", err),
+                    format!("failed while configuring network interface {}:", err),
                 ));
             }
         };
@@ -250,7 +250,7 @@ impl Core {
         if let Err(err) = Core::remove_container_veth(&container_veth_name, netns) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                format!("unable to remove container veth: {:?}", err),
+                format!("unable to remove container veth: {}", err),
             ));
         }
 

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -504,7 +504,7 @@ impl CoreUtils {
                 if let Err(err) = thread_handle.join().unwrap() {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::Other,
-                        format!("from container namespace: {:?}", err),
+                        format!("from container namespace: {}", err),
                     ));
                 }
             }
@@ -749,7 +749,7 @@ impl CoreUtils {
                 if let Err(err) = thread_handle.join().unwrap() {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::Other,
-                        format!("from container namespace: {:?}", err),
+                        format!("from container namespace: {}", err),
                     ));
                 }
             }


### PR DESCRIPTION
Fix error wrapping and formatting. Remove unnecessary `{:?}` debug which escapes and prints entire `struct` for debugging.
formatter from errors.

Tidy up errors.

Final `Error: Custom` gets removed after https://github.com/containers/netavark/pull/47

Before:
```console
Error: Custom { kind: Other, error: "failed configure bridge and veth interface: Custom { kind: Other, error: \"Error while configuring network interface from container namespace: Custom { kind: Other, error: \\\"interface ethsomething0 already exists on container namespace\\\" }:\" }" }
```
### After

* with https://github.com/containers/netavark/pull/47
```console
{"error":"failed configure bridge and veth interface: failed while configuring network interface from container namespace: interface ethsomething0 already exists on container namespace:","errno":1}
```
* without #47 
```console
Error: Custom { kind: Other, error: "failed configure bridge and veth interface: failed while configuring network interface from container namespace: interface ethsomething0 already exists on container namespace:" }
```

