### PR TITLE
core: add support for setting up `macvlan` driver from config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "iptables",
  "libc",
  "log",
+ "netlink-packet-route",
  "nix 0.23.0",
  "rand",
  "rtnetlink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ faccess = "0.2.3"
 tokio = { version = "1.5.0", features = ["full"] }
 zvariant = "2.9.0"
 sha2 = "0.9.8"
+netlink-packet-route = "0.8.0"

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -136,7 +136,7 @@ impl Setup {
                 }
                 "macvlan" => {
                     let per_network_opts =
-                        network_options.networks.get(&net_name).ok_or_else(|| {
+                        network_options.networks.get(net_name).ok_or_else(|| {
                             std::io::Error::new(
                                 std::io::ErrorKind::Other,
                                 format!("network options for network {} not found", net_name),
@@ -145,13 +145,10 @@ impl Setup {
                     //Configure Bridge and veth_pairs
                     let status_block = network::core::Core::macvlan_per_podman_network(
                         per_network_opts,
-                        &network,
+                        network,
                         &self.network_namespace_path,
                     )?;
-                    response.insert(net_name, status_block);
-                    // Setup basic firewall rules for each network.
-                    firewall_driver.setup_network(network)?;
-                    // TODO: Set up port forwarding. How? What network do we point to?
+                    response.insert(net_name.to_owned(), status_block);
                 }
                 // unknown driver
                 _ => {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -134,6 +134,25 @@ impl Setup {
                         }
                     }
                 }
+                "macvlan" => {
+                    let per_network_opts =
+                        network_options.networks.get(&net_name).ok_or_else(|| {
+                            std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                format!("network options for network {} not found", net_name),
+                            )
+                        })?;
+                    //Configure Bridge and veth_pairs
+                    let status_block = network::core::Core::macvlan_per_podman_network(
+                        per_network_opts,
+                        &network,
+                        &self.network_namespace_path,
+                    )?;
+                    response.insert(net_name, status_block);
+                    // Setup basic firewall rules for each network.
+                    firewall_driver.setup_network(network)?;
+                    // TODO: Set up port forwarding. How? What network do we point to?
+                }
                 // unknown driver
                 _ => {
                     return Err(std::io::Error::new(

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -62,6 +62,21 @@ impl Teardown {
 
                     // TODO teardown firewall if no interfaces connected to bridge!
                 }
+                "macvlan" => {
+                    let per_network_opts =
+                        network_options.networks.get(&net_name).ok_or_else(|| {
+                            std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                format!("network options for network {} not found", net_name),
+                            )
+                        })?;
+                    //Remove container interfaces
+                    network::core::Core::remove_interface_per_podman_network(
+                        per_network_opts,
+                        &network,
+                        &self.network_namespace_path,
+                    )?;
+                }
                 // unknown driver
                 _ => {
                     return Err(std::io::Error::new(

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -1,0 +1,9 @@
+//Following module contains all the network constants
+
+// Available macvlan modes
+// TODO: remove constants from here after https://github.com/little-dude/netlink/pull/200
+pub const MACVLAN_MODE_PRIVATE: u32 = 1;
+pub const MACVLAN_MODE_VEPA: u32 = 2;
+pub const MACVLAN_MODE_BRIDGE: u32 = 4;
+pub const MACVLAN_MODE_PASSTHRU: u32 = 8;
+pub const MACVLAN_MODE_SOURCE: u32 = 16;

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -232,6 +232,173 @@ impl Core {
         }
     }
 
+    pub fn macvlan_per_podman_network(
+        per_network_opts: &types::PerNetworkOptions,
+        network: &types::Network,
+        netns: &str,
+    ) -> Result<types::StatusBlock, std::io::Error> {
+        //  StatusBlock response
+        let mut response = types::StatusBlock {
+            dns_search_domains: Some(Vec::new()),
+            dns_server_ips: Some(Vec::new()),
+            interfaces: Some(HashMap::new()),
+        };
+        // Does config have a macvlan mode ? I think not
+        // Important !! Hardcode MACVLAN_MODE to bridge
+        let macvlan_mode: u32 = 4u32;
+        // get master interface name
+        let master_ifname: String = network.network_interface.as_ref().unwrap().to_owned();
+        // static ip vector
+        let mut address_vector = Vec::new();
+        // network addresses for response
+        let mut response_net_addresses: Vec<NetAddress> = Vec::new();
+        // interfaces map, but we only ever expect one, for response
+        let mut interfaces: HashMap<String, types::NetInterface> = HashMap::new();
+
+        let container_macvlan_name: String = per_network_opts.interface_name.to_owned();
+        let static_ips: &Vec<IpAddr> = per_network_opts.static_ips.as_ref().unwrap();
+
+        // prepare a vector of static ips with appropriate cidr
+        // we only need static ips so do not process gateway,
+        for (idx, subnet) in network.subnets.iter().flatten().enumerate() {
+            let subnet_mask_cidr = subnet.subnet.prefix_len();
+
+            // Build up response information
+            let container_address: ipnet::IpNet =
+                match format!("{}/{}", static_ips[idx].to_string(), subnet_mask_cidr).parse() {
+                    Ok(i) => i,
+                    Err(e) => {
+                        return Err(Error::new(std::io::ErrorKind::Other, e));
+                    }
+                };
+            // Add the IP to the address_vector
+            address_vector.push(container_address);
+            response_net_addresses.push(types::NetAddress {
+                gateway: subnet.gateway, // I dont think we need this in response vector for macvlan ? But let it be for now.
+                subnet: container_address,
+            });
+        }
+        debug!("Container macvlan name: {:?}", container_macvlan_name);
+        debug!("Master interface name: {:?}", master_ifname);
+        debug!("IP address for macvlan: {:?}", address_vector);
+
+        // create macvlan
+        let container_macvlan_mac = match Core::add_macvlan(
+            &master_ifname,
+            &container_macvlan_name,
+            macvlan_mode,
+            address_vector,
+            netns,
+        ) {
+            Ok(addr) => addr,
+            Err(err) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("failed configure macvlan: {}", err),
+                ))
+            }
+        };
+        debug!("Container macvlan mac: {:?}", container_macvlan_mac);
+        let interface = types::NetInterface {
+            mac_address: container_macvlan_mac,
+            networks: Option::from(response_net_addresses),
+        };
+        // Add interface to interfaces (part of StatusBlock)
+        interfaces.insert(container_macvlan_name, interface);
+        let _ = response.interfaces.insert(interfaces);
+        Ok(response)
+    }
+
+    pub fn add_macvlan(
+        master_ifname: &str,
+        container_macvlan: &str,
+        macvlan_mode: u32,
+        netns_ipaddr: Vec<ipnet::IpNet>,
+        netns: &str,
+    ) -> Result<String, std::io::Error> {
+        let _ = match core_utils::CoreUtils::configure_macvlan_async(
+            master_ifname,
+            container_macvlan,
+            macvlan_mode,
+            netns,
+        ) {
+            Ok(_) => (),
+            Err(err) => {
+                // it seems something went wrong
+                // we must not leave dangling interfaces
+                // otherwise cleanup would become mess
+                // try removing leaking interfaces from host
+                if let Err(er) = core_utils::CoreUtils::remove_interface(container_macvlan) {
+                    warn!("failed while cleaning up interfaces: {}", er);
+                }
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("failed while configuring macvlan {}:", err),
+                ));
+            }
+        };
+
+        match File::open(&netns) {
+            Ok(netns_file) => {
+                let netns_fd = netns_file.as_raw_fd();
+                //clone values before spwaning thread in new namespace
+                let container_macvlan_clone: String = container_macvlan.to_owned();
+                // So complicated cloning for threads ?
+                // TODO: simplify this later
+                let _gw_ipaddr_empty = Vec::new(); // we are not using this for macvlan but arg is needed.
+                let mut netns_ipaddr_clone = Vec::new();
+                for ip in &netns_ipaddr {
+                    netns_ipaddr_clone.push(*ip)
+                }
+                let handle = thread::spawn(move || -> Result<String, Error> {
+                    if let Err(err) = sched::setns(netns_fd, sched::CloneFlags::CLONE_NEWNET) {
+                        panic!("failed to setns to fd={}: {}", netns_fd, err);
+                    }
+
+                    if let Err(err) = core_utils::CoreUtils::configure_netns_interface_async(
+                        &container_macvlan_clone,
+                        netns_ipaddr_clone,
+                        _gw_ipaddr_empty,
+                    ) {
+                        return Err(err);
+                    }
+                    debug!(
+                        "Configured static up address for {}",
+                        container_macvlan_clone
+                    );
+
+                    if let Err(er) = core_utils::CoreUtils::turn_up_interface("lo") {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("failed while turning up `lo` in container namespace {}", er),
+                        ));
+                    }
+
+                    //return MAC address to status block could use this
+                    match core_utils::CoreUtils::get_interface_address(&container_macvlan_clone) {
+                        Ok(addr) => Ok(addr),
+                        Err(err) => Err(err),
+                    }
+                });
+                match handle.join() {
+                    Ok(interface_address) => interface_address,
+                    Err(err) => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("failed to join: {:?}", err),
+                        ))
+                    }
+                }
+            }
+            Err(err) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("failed to open the netns file: {}", err),
+                ))
+            }
+        }
+    }
+
     pub fn remove_interface_per_podman_network(
         per_network_opts: &types::PerNetworkOptions,
         network: &types::Network,

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -1,3 +1,4 @@
+use crate::network::constants;
 use futures::stream::TryStreamExt;
 use futures::StreamExt;
 use libc;
@@ -32,6 +33,23 @@ impl CoreUtils {
             final_slice.push(a);
         }
         final_slice.join(":")
+    }
+
+    pub fn get_macvlan_mode_from_string(mode: &str) -> Result<u32, std::io::Error> {
+        // Replace to constant from library once this gets merged.
+        // TODO: use actual constants after https://github.com/little-dude/netlink/pull/200
+        match mode {
+            "bridge" => Ok(constants::MACVLAN_MODE_BRIDGE),
+            "private" => Ok(constants::MACVLAN_MODE_PRIVATE),
+            "vepa" => Ok(constants::MACVLAN_MODE_VEPA),
+            "passthru" => Ok(constants::MACVLAN_MODE_PASSTHRU),
+            "source" => Ok(constants::MACVLAN_MODE_SOURCE),
+            // default to bridge
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "invalid macvlan mode".to_string(),
+            )),
+        }
     }
 
     #[tokio::main]

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -464,7 +464,6 @@ impl CoreUtils {
         master_ifname: &str,
         macvlan_ifname: &str,
         macvlan_mode: u32,
-        ips: Vec<ipnet::IpNet>,
         netns_path: &str,
     ) -> Result<(), Error> {
         let (_connection, handle, _) = match rtnetlink::new_connection() {
@@ -517,13 +516,6 @@ impl CoreUtils {
                     std::io::ErrorKind::Other,
                     format!("failed to get interface {}: {}", &master_ifname, err),
                 ))
-            }
-        }
-
-        //assign ip to mac_vlan interface
-        for ip_net in ips.into_iter() {
-            if let Err(err) = CoreUtils::add_ip_address(&handle, &macvlan_tmp_name, &ip_net).await {
-                return Err(err);
             }
         }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -2,6 +2,7 @@ pub mod types;
 pub mod validation;
 use anyhow::Result;
 use std::fs::File;
+pub mod constants;
 pub mod core;
 pub mod core_utils;
 

--- a/src/test/config/setupoptsmacvlan.test.json
+++ b/src/test/config/setupoptsmacvlan.test.json
@@ -1,0 +1,33 @@
+{
+   "container_id": "someID",
+   "container_name": "someName",
+   "networks": {
+      "podman": {
+         "static_ips": [
+            "10.88.0.2"
+         ],
+         "interface_name": "ethsomething0"
+      }
+   },
+   "network_info": {
+      "podman": {
+         "name": "podman",
+         "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+         "driver": "macvlan",
+         "network_interface": "wlp0s20f3",
+         "created": "2021-10-26T16:42:48.769170534+02:00",
+         "subnets": [
+            {
+               "subnet": "10.88.0.0/16",
+               "gateway": "10.88.0.1"
+            }
+         ],
+         "ipv6_enabled": false,
+         "internal": false,
+         "dns_enabled": false,
+         "ipam_options": {
+            "driver": "host-local"
+         }
+      }
+   }
+}


### PR DESCRIPTION
Following PR adds extends `setup` command to allow configuring `macvlan`
if specified in config as a `driver`.

When merged following should work with `macvlan` config.
```console
sudo ./bin/netavark -f <config_with_macvlan> setup /var/run/netns/netnstest
```
