### PR TITLE
Fix non working netns path check

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -28,7 +28,12 @@ impl Setup {
     }
 
     pub fn exec(&self, input_file: String) -> Result<(), Box<dyn Error>> {
-        network::validation::ns_checks(&self.network_namespace_path);
+        match network::validation::ns_checks(&self.network_namespace_path) {
+            Ok(_) => (),
+            Err(e) => {
+                bail!("invalid namespace path: {}", e);
+            }
+        }
 
         debug!("{:?}", "Setting up...");
 

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -20,8 +20,6 @@ impl Teardown {
     }
 
     pub fn exec(&self, input_file: String) -> Result<(), Box<dyn Error>> {
-        network::validation::ns_checks(&self.network_namespace_path);
-
         debug!("{:?}", "Tearing down..");
         let network_options = match network::types::NetworkOptions::load(&input_file) {
             Ok(opts) => opts,

--- a/src/network/validation.rs
+++ b/src/network/validation.rs
@@ -2,10 +2,8 @@ use faccess::{AccessMode, PathExt};
 use log::debug;
 use std::path::Path;
 
-pub fn ns_checks(file: &str) -> bool {
+pub fn ns_checks(file: &str) -> std::io::Result<()> {
     debug!("{:?}", "Checking network namespace permissions...");
-    let path_validate = Path::new(&file)
-        .access(AccessMode::EXISTS & AccessMode::WRITE)
-        .is_ok();
-    path_validate
+    // TODO check for FS_MAGIC
+    Path::new(&file).access(AccessMode::EXISTS & AccessMode::WRITE)
 }

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -40,9 +40,6 @@ mod tests {
     // Test commands::setup::ns_checks works correctly
     #[test]
     fn test_ns_checks() {
-        assert_eq!(
-            network::validation::ns_checks("src/test/config/setupopts.test.json"),
-            true
-        );
+        assert!(network::validation::ns_checks("src/test/config/setupopts.test.json").is_ok());
     }
 }


### PR DESCRIPTION
The return result of `ns_checks()` was not used. It also only returns an
bool which is not helpful because it hides the actual error message.

Second, the teardown command should not check for a valid netns and just
try to cleanup as much as possible.