### PR TITLE
Enabled portfw'ing for iptables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +176,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -331,6 +358,16 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -533,6 +570,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
+ "sha2",
  "simple-error",
  "sysctl",
  "tokio",
@@ -700,6 +738,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "ordered-float"
@@ -1023,6 +1067,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1269,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ rand = "0.8.3"
 faccess = "0.2.3"
 tokio = { version = "1.5.0", features = ["full"] }
 zvariant = "2.9.0"
+sha2 = "0.9.8"

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -1,8 +1,10 @@
 use crate::firewall;
 use crate::network::types;
+use ipnet::IpNet;
 use log::debug;
 use std::collections::HashMap;
 use std::error::Error;
+use std::net::IpAddr;
 use std::vec::Vec;
 use zbus::Connection;
 use zvariant::{Array, Value};
@@ -20,7 +22,11 @@ pub fn new(conn: Connection) -> Result<Box<dyn firewall::FirewallDriver>, Box<dy
 }
 
 impl firewall::FirewallDriver for FirewallD {
-    fn setup_network(&self, net: types::Network) -> Result<(), Box<dyn Error>> {
+    fn setup_network(
+        &self,
+        net: types::Network,
+        _network_hash: String,
+    ) -> Result<(), Box<dyn Error>> {
         let mut need_reload = false;
 
         need_reload |= match create_zone_if_not_exist(&self.conn, ZONENAME) {
@@ -63,7 +69,10 @@ impl firewall::FirewallDriver for FirewallD {
         &self,
         _container_id: &str,
         _port_mappings: Vec<types::PortMapping>,
-        _container_ip: &str,
+        _container_ip: IpAddr,
+        _network: IpNet,
+        _network_name: &str,
+        _id_network_hash: &str,
     ) -> Result<(), Box<dyn Error>> {
         todo!();
     }

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -1,15 +1,33 @@
 use crate::firewall;
 use crate::network::types;
+use ipnet::IpNet;
 use iptables;
 use iptables::IPTables;
 use log::debug;
 use std::error::Error;
+use std::net::IpAddr;
 
-//  NAT constant for iptables
+const HEXMARK: &str = "0x2000";
+pub(crate) const MAX_HASH_SIZE: usize = 13;
+
+//  CHAIN NAMES
 const NAT: &str = "nat";
-const POSTROUTING: &str = "POSTROUTING";
 const PRIV_CHAIN_NAME: &str = "NETAVARK_FORWARD";
-const FILTER: &str = "filter";
+const HOSTPORT_DNAT_CHAIN: &str = "NETAVARK-HOSTPORT-DNAT";
+const HOSTPORT_SETMARK_CHAIN: &str = "NETAVARK-HOSTPORT-SETMARK";
+const NETAVARK_HOSTPORT_MASK_CHAIN: &str = "NETAVARK-HOSTPORT-MASQ";
+const CONTAINER_DN_CHAIN: &str = "NETAVARK-DN-";
+const CONTAINER_CHAIN: &str = "NETAVARK-";
+const PREROUTING_CHAIN: &str = "PREROUTING";
+const OUTPUT_CHAIN: &str = "OUTPUT";
+
+// JUMP DEST
+const POSTROUTING_JUMP: &str = "POSTROUTING";
+const FILTER_JUMP: &str = "filter";
+const MARK_JUMP: &str = "MARK";
+const DNAT_JUMP: &str = "DNAT";
+const MASQ_JUMP: &str = "MASQUERADE";
+const ACCEPT_JUMP: &str = "ACCEPT";
 
 // Iptables driver - uses direct iptables commands via the iptables crate.
 pub struct IptablesDriver {
@@ -24,92 +42,38 @@ pub fn new() -> Result<Box<dyn firewall::FirewallDriver>, Box<dyn Error>> {
 }
 
 impl firewall::FirewallDriver for IptablesDriver {
-    fn setup_network(&self, net: types::Network) -> Result<(), Box<dyn Error>> {
-        let network_name = net.network_interface.unwrap();
+    fn setup_network(
+        &self,
+        net: types::Network,
+        network_hash_name: String,
+    ) -> Result<(), Box<dyn Error>> {
         if let Some(subnet) = net.subnets {
             for network in subnet {
-                // Check if the chain exists, if not - create it
-                // Note: while there is an API provided to check if a chain exists in a table
-                // by iptables, it, for some reason, is slow.  Instead we just get a list of
-                // chains in a table and iterate.  Same is being done in golang implementations
-                let nat_chains = self.conn.list_chains(NAT)?;
-                if !nat_chains.iter().any(|i| i == &network_name) {
-                    self.conn
-                        .new_chain(NAT, &network_name)
-                        .map(|_| debug_chain_create(NAT, &network_name))?;
-                } else {
-                    debug_chain_exists(NAT, &network_name);
-                }
+                let prefixed_network_hash_name = format!("{}-{}", "NETAVARK", network_hash_name);
+                add_chain_unique(&self.conn, NAT, &prefixed_network_hash_name)?;
 
                 // declare the rule
-                let nat_rule = format!("-d {} -j ACCEPT", network.subnet.to_string()).to_string();
-                let nat_check = self.conn.exists(NAT, &network_name, &nat_rule);
-                match nat_check {
-                    Ok(true) => debug_rule_exists(NAT, &network_name, nat_rule),
-                    Ok(false) => {
-                        // nat rule does not exists
-                        self.conn
-                            .append(NAT, &network_name, &nat_rule)
-                            .map(|_| debug_rule_create(NAT, &network_name, nat_rule))?;
-                    }
-                    Err(e) => return Err(e),
-                }
+                let nat_rule =
+                    format!("-d {} -j {}", network.subnet.to_string(), ACCEPT_JUMP).to_string();
+                append_unique(&self.conn, NAT, &prefixed_network_hash_name, &nat_rule)?;
 
                 //  Add first rule for the network
                 let masq_rule = "! -d 224.0.0.0/4 -j MASQUERADE".to_string();
-                debug!("{}", masq_rule);
-                let masq_check = self.conn.exists(NAT, &network_name, &masq_rule);
-                match masq_check {
-                    Ok(true) => debug_rule_exists(NAT, &network_name, masq_rule),
-                    Ok(false) => {
-                        // Need to create the masq rule
-                        self.conn
-                            .append(NAT, &network_name, &masq_rule)
-                            .map(|_| debug_rule_create(NAT, &network_name, masq_rule))?;
-                    }
-                    Err(e) => return Err(e),
-                }
+                append_unique(&self.conn, NAT, &prefixed_network_hash_name, &masq_rule)?;
 
-                //  Add POSTROUTING rule
-                let jump_podman_rule = format!(
-                    "--source {} --jump {}",
-                    network.subnet.to_string(),
-                    network_name
-                )
-                .to_string();
-                let jump_check = self.conn.exists(NAT, POSTROUTING, &jump_podman_rule);
-                match jump_check {
-                    Ok(true) => debug_rule_exists(NAT, POSTROUTING, jump_podman_rule),
-                    Ok(false) => {
-                        self.conn
-                            .append(NAT, POSTROUTING, &jump_podman_rule)
-                            .map(|_| debug_rule_create(NAT, POSTROUTING, jump_podman_rule))?;
-                    }
-                    Err(e) => return Err(e),
-                }
-
-                // Check if our private chain exists, if not create
-                // Note: while there is an API provided to check if a chain exists in a table
-                // by iptables, it, for some reason, is slow.  Instead we just get a list of
-                // chains in a table and iterate.  Same is being done in golang implementations
-                let filter_chains = self.conn.list_chains(FILTER)?;
-                if !filter_chains.iter().any(|i| i == PRIV_CHAIN_NAME) {
-                    self.conn
-                        .new_chain(FILTER, PRIV_CHAIN_NAME)
-                        .map(|_| debug_chain_create(FILTER, PRIV_CHAIN_NAME))?;
-                } else {
-                    debug_chain_exists(FILTER, PRIV_CHAIN_NAME);
-                }
+                //  Add private chain name if it does not exist
+                add_chain_unique(&self.conn, FILTER_JUMP, PRIV_CHAIN_NAME)?;
 
                 //  Create netavark firewall rule
                 let netavark_fw = format!(
                     "-m comment --comment 'netavark firewall plugin rules' -j {}",
                     PRIV_CHAIN_NAME
                 );
-                if !self.conn.exists(FILTER, "FORWARD", &netavark_fw)? {
+                // Insert the rule into the first position
+                if !self.conn.exists(FILTER_JUMP, "FORWARD", &netavark_fw)? {
                     self.conn
-                        .insert(FILTER, "FORWARD", &netavark_fw, 1)
-                        .map(|_| debug_rule_create(FILTER, "FORWARD", netavark_fw))?;
+                        .insert(FILTER_JUMP, "FORWARD", &netavark_fw, 1)
+                        .map(|_| debug_rule_create(FILTER_JUMP, "FORWARD", netavark_fw))?;
                 }
                 // Create incoming traffic rule
                 // CNI did this by IP address, this is implemented per subnet
@@ -117,31 +81,23 @@ impl firewall::FirewallDriver for IptablesDriver {
                     "-d {} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
                     network.subnet.to_string()
                 );
-                if !self
-                    .conn
-                    .exists(FILTER, PRIV_CHAIN_NAME, &allow_incoming_rule)?
-                {
-                    let _ = self
-                        .conn
-                        .append(FILTER, PRIV_CHAIN_NAME, &allow_incoming_rule)
-                        .map(|_| debug_rule_create(FILTER, PRIV_CHAIN_NAME, allow_incoming_rule))?;
-                } else {
-                    debug_rule_exists(FILTER, PRIV_CHAIN_NAME, allow_incoming_rule);
-                }
+
+                append_unique(
+                    &self.conn,
+                    FILTER_JUMP,
+                    PRIV_CHAIN_NAME,
+                    &allow_incoming_rule,
+                )?;
 
                 // Create outgoing traffic rule
                 // CNI did this by IP address, this is implemented per subnet
                 let allow_outgoing_rule = format!("-s {} -j ACCEPT", network.subnet.to_string());
-                if !self
-                    .conn
-                    .exists(FILTER, PRIV_CHAIN_NAME, &allow_outgoing_rule)?
-                {
-                    self.conn
-                        .append(FILTER, PRIV_CHAIN_NAME, &allow_outgoing_rule)
-                        .map(|_| debug_rule_create(FILTER, PRIV_CHAIN_NAME, allow_outgoing_rule))?;
-                } else {
-                    debug_rule_exists(FILTER, PRIV_CHAIN_NAME, allow_outgoing_rule);
-                }
+                append_unique(
+                    &self.conn,
+                    FILTER_JUMP,
+                    PRIV_CHAIN_NAME,
+                    &allow_outgoing_rule,
+                )?;
             }
         }
         Ok(())
@@ -153,11 +109,126 @@ impl firewall::FirewallDriver for IptablesDriver {
 
     fn setup_port_forward(
         &self,
-        _container_id: &str,
-        _port_mappings: Vec<types::PortMapping>,
-        _container_ip: &str,
+        container_id: &str,
+        port_mappings: Vec<types::PortMapping>,
+        container_ip: IpAddr,
+        network: IpNet,
+        network_name: &str,
+        id_network_hash: &str,
     ) -> Result<(), Box<dyn Error>> {
-        todo!();
+        // Set up all chains
+        let network_dn_chain_name = CONTAINER_DN_CHAIN.to_owned() + id_network_hash;
+        let network_chain_name = CONTAINER_CHAIN.to_owned() + id_network_hash;
+
+        let comment_network_cid = format!(
+            "-m comment --comment 'name: {} id: {}'",
+            network_name, container_id
+        );
+        let comment_dn_network_cid = format!(
+            "-m comment --comment 'dnat name: {} id: {}'",
+            network_name, container_id
+        );
+        // Make sure chains exist or create them
+        add_chain_unique(&self.conn, NAT, HOSTPORT_DNAT_CHAIN)?;
+        add_chain_unique(&self.conn, NAT, HOSTPORT_SETMARK_CHAIN)?;
+        add_chain_unique(&self.conn, NAT, NETAVARK_HOSTPORT_MASK_CHAIN)?;
+        add_chain_unique(&self.conn, NAT, &network_dn_chain_name)?;
+
+        // Setup one-off rules that have nothing to do with ports
+        // PREROUTING
+        let prerouting_rule = format!("-j {} -m addrtype --dst-type LOCAL", HOSTPORT_DNAT_CHAIN);
+        append_unique(&self.conn, NAT, PREROUTING_CHAIN, &prerouting_rule)?;
+
+        // OUTPUT
+        let portmap_output_rule =
+            format!("-j {} -m addrtype --dst-type LOCAL", HOSTPORT_DNAT_CHAIN);
+        append_unique(&self.conn, NAT, OUTPUT_CHAIN, &portmap_output_rule)?;
+
+        //  SETMARK-CHAIN
+        let setmark_rule = format!("-j {}  --set-xmark {}/{}", MARK_JUMP, HEXMARK, HEXMARK);
+        append_unique(&self.conn, NAT, HOSTPORT_SETMARK_CHAIN, &setmark_rule)?;
+
+        //  HOSTPORT-MASQ
+        let hostport_masq_rule = format!(
+            "-j {} -m comment --comment 'netavark portfw masq mark' -m mark --mark {}/{}",
+            MASQ_JUMP, HEXMARK, HEXMARK
+        );
+        append_unique(
+            &self.conn,
+            NAT,
+            NETAVARK_HOSTPORT_MASK_CHAIN,
+            &hostport_masq_rule,
+        )?;
+
+        // POSTROUTING
+        append_unique(
+            &self.conn,
+            NAT,
+            POSTROUTING_JUMP,
+            &format!("-j {} ", NETAVARK_HOSTPORT_MASK_CHAIN),
+        )?;
+        append_unique(
+            &self.conn,
+            NAT,
+            POSTROUTING_JUMP,
+            &format!(
+                "-j {} -s {} {}",
+                network_chain_name,
+                container_ip.to_string(),
+                comment_network_cid
+            ),
+        )?;
+
+        // FOR EACH PORT
+        for i in port_mappings {
+            // hostport dnat
+            let hostport_dnat_rule = format!(
+                "-j {} -p tcp -m multiport --destination-ports {} {}",
+                network_dn_chain_name,
+                i.host_port.to_string(),
+                comment_dn_network_cid
+            );
+            append_unique(&self.conn, NAT, HOSTPORT_DNAT_CHAIN, &hostport_dnat_rule)?;
+            // dn container (the actual port usages)
+            let setmark_network_rule = format!(
+                "-j {} -s {} -p tcp --dport {}",
+                HOSTPORT_SETMARK_CHAIN,
+                network.to_string(),
+                i.host_port.to_string()
+            );
+            append_unique(
+                &self.conn,
+                NAT,
+                &network_dn_chain_name,
+                &setmark_network_rule,
+            )?;
+            let setmark_localhost_rule = format!(
+                "-j {} -s 127.0.0.1 -p tcp --dport {}",
+                HOSTPORT_SETMARK_CHAIN,
+                i.host_port.to_string()
+            );
+            append_unique(
+                &self.conn,
+                NAT,
+                &network_dn_chain_name,
+                &setmark_localhost_rule,
+            )?;
+            let container_dest_rule = format!(
+                "-j {} -p tcp --to-destination {}:{} --destination-port {}",
+                DNAT_JUMP,
+                container_ip.to_string(),
+                i.container_port.to_string(),
+                i.host_port.to_string()
+            );
+            append_unique(
+                &self.conn,
+                NAT,
+                &network_dn_chain_name,
+                &container_dest_rule,
+            )?;
+        }
+
+        Result::Ok(())
     }
 
     fn teardown_port_forward(
@@ -169,6 +240,51 @@ impl firewall::FirewallDriver for IptablesDriver {
         todo!();
     }
 }
+// append a rule to chain if it does not exist
+// Note: While there is an API provided for this exact thing, the API returns
+// an error that is not defined if the rule exists.  This function just returns
+// an error if there is a problem.
+fn append_unique(
+    driver: &IPTables,
+    table: &str,
+    chain: &str,
+    rule: &str,
+) -> Result<(), Box<dyn Error>> {
+    let exists = driver.exists(table, chain, rule)?;
+    if exists {
+        return Ok(());
+    }
+    debug_rule_exists(table, chain, rule.to_string());
+    driver
+        .append(table, chain, rule)
+        .map(|_| debug_rule_create(table, chain, rule.to_string()))
+}
+
+// add a chain if it does not exist, else do nothing
+fn add_chain_unique(driver: &IPTables, table: &str, new_chain: &str) -> Result<(), Box<dyn Error>> {
+    // Note: while there is an API provided to check if a chain exists in a table
+    // by iptables, it, for some reason, is slow.  Instead we just get a list of
+    // chains in a table and iterate.  Same is being done in golang implementations
+    let exists = chain_exists(driver, table, new_chain)?;
+    if exists {
+        debug_chain_exists(table, new_chain);
+        return Ok(());
+    }
+    driver
+        .new_chain(table, new_chain)
+        .map(|_| debug_chain_create(table, new_chain))
+}
+
+// returns a bool as to whether the chain exists
+fn chain_exists(driver: &IPTables, table: &str, chain: &str) -> Result<bool, Box<dyn Error>> {
+    let c = driver.list_chains(table)?;
+    if c.iter().any(|i| i == chain) {
+        debug_chain_exists(table, chain);
+        return serde::__private::Result::Ok(true);
+    }
+    serde::__private::Result::Ok(false)
+}
+
 fn debug_chain_create(table: &str, chain: &str) {
     debug!("chain {} created on table {}", chain, table);
 }

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -1,7 +1,9 @@
 use crate::network::types;
+use ipnet::IpNet;
 use log::{debug, info};
 use std::env;
 use std::error::Error;
+use std::net::IpAddr;
 use zbus::Connection;
 
 pub mod firewalld;
@@ -11,7 +13,11 @@ pub mod iptables;
 // and port mappings.
 pub trait FirewallDriver {
     // Set up firewall rules for the given network,
-    fn setup_network(&self, net: types::Network) -> Result<(), Box<dyn Error>>;
+    fn setup_network(
+        &self,
+        net: types::Network,
+        network_hash_name: String,
+    ) -> Result<(), Box<dyn Error>>;
     // Tear down firewall rules for the given network.
     fn teardown_network(&self, net: types::Network) -> Result<(), Box<dyn Error>>;
 
@@ -20,7 +26,10 @@ pub trait FirewallDriver {
         &self,
         container_id: &str,
         port_mappings: Vec<types::PortMapping>,
-        container_ip: &str,
+        container_ip: IpAddr,
+        network: IpNet,
+        network_name: &str,
+        id_network_hash: &str,
     ) -> Result<(), Box<dyn Error>>;
     // Tear down port-forwarding firewall rules for a single container.
     fn teardown_port_forward(

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -8,6 +8,7 @@ use rtnetlink::packet::constants::*;
 use rtnetlink::packet::rtnl::link::nlas::Nla;
 use rtnetlink::packet::NetlinkPayload;
 use rtnetlink::packet::RouteMessage;
+use sha2::{Digest, Sha512};
 use std::fmt::Write;
 use std::fs::File;
 use std::io::Error;
@@ -876,5 +877,14 @@ impl CoreUtils {
         }
 
         Ok(())
+    }
+
+    pub fn create_network_hash(network_name: &str, length: usize) -> String {
+        let mut hasher = Sha512::new();
+        hasher.update(network_name.as_bytes());
+        let result = hasher.finalize();
+        let hash_string = format!("{:X}", result);
+        let response = &hash_string[0..length];
+        response.to_string()
     }
 }

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -4,8 +4,8 @@ use ipnet::IpNet;
 use std::collections::HashMap;
 use std::net::IpAddr;
 
-/// Network describes the Network attributes.
-#[derive(Debug, Serialize, Deserialize)]
+// Network describes the Network attributes.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Network {
     /// Set up dns for this network
     #[serde(rename = "dns_enabled")]
@@ -101,7 +101,7 @@ pub struct PerNetworkOptions {
 }
 
 // PortMapping is one or more ports that will be mapped into the container.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PortMapping {
     /// ContainerPort is the port number that will be exposed from the
     /// container.
@@ -180,7 +180,7 @@ pub struct NetAddress {
 }
 
 /// Subnet for a network.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Subnet {
     /// Subnet for this Network in CIDR form.
     #[serde(rename = "gateway")]
@@ -196,7 +196,7 @@ pub struct Subnet {
 }
 
 // LeaseRange contains the range where IP are leased.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LeaseRange {
     /// EndIP last IP in the subnet which should be used to assign ips.
     #[serde(rename = "end_ip")]


### PR DESCRIPTION
when using the iptables firewall driver, we can no forward ports from
the container host to the container.

i.e. curl http://localhost:8080

Signed-off-by: Brent Baude <bbaude@redhat.com>