### PR TITLE
Initial checkin for teardown iptables

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -3,13 +3,12 @@ use crate::error::NetavarkError;
 use crate::firewall;
 use crate::firewall::iptables::MAX_HASH_SIZE;
 use crate::network;
-use crate::network::types;
+use crate::network::core_utils::CoreUtils;
+use crate::network::{core_utils, types};
 use clap::{self, Clap};
 use log::debug;
 use std::collections::HashMap;
 use std::error::Error;
-use sysctl::Sysctl;
-use sysctl::SysctlError;
 
 const IPV4_FORWARD: &str = "net.ipv4.ip_forward";
 
@@ -35,7 +34,6 @@ impl Setup {
                 bail!("invalid namespace path: {}", e);
             }
         }
-
         debug!("{:?}", "Setting up...");
 
         let network_options = match network::types::NetworkOptions::load(&input_file) {
@@ -54,11 +52,8 @@ impl Setup {
         };
 
         // Sysctl setup
-        // set ip forwarding to 1 if not already
-        let sysctl_ipv4 = get_sysctl_value(IPV4_FORWARD)?;
-        if sysctl_ipv4 != *"1" {
-            set_sysctl_value(IPV4_FORWARD, "1")?;
-        }
+        // set ip forwarding to 1
+        core_utils::CoreUtils::apply_sysctl_value(IPV4_FORWARD, "1")?;
 
         let mut response: HashMap<String, types::StatusBlock> = HashMap::new();
 
@@ -86,50 +81,21 @@ impl Setup {
                     )?;
                     response.insert(net_name.to_owned(), status_block);
 
-                    let id_network_hash = network::core_utils::CoreUtils::create_network_hash(
-                        net_name,
-                        MAX_HASH_SIZE,
-                    );
-
+                    let id_network_hash = CoreUtils::create_network_hash(net_name, MAX_HASH_SIZE);
                     firewall_driver.setup_network(network.clone(), id_network_hash.clone())?;
+
                     let port_bindings = network_options.port_mappings.clone();
                     match port_bindings {
                         None => {}
                         Some(i) => {
-                            // Need to enable sysctl localnet so that traffic can pass
-                            // through localhost to containers
-                            let network_interface = &network.network_interface;
-                            match network_interface {
-                                None => {}
-                                Some(i) => {
-                                    let localnet_path =
-                                        format!("net.ipv4.conf.{}.route_localnet", i);
-                                    let sysctl_localnet = get_sysctl_value(localnet_path.as_str())?;
-                                    if sysctl_localnet != *"1" {
-                                        set_sysctl_value(localnet_path.as_str(), "1")?;
-                                    }
-                                }
-                            }
-                            let container_ips =
-                                &per_network_opts.static_ips.as_ref().ok_or_else(|| {
-                                    std::io::Error::new(
-                                        std::io::ErrorKind::Other,
-                                        "no container ip provided",
-                                    )
-                                })?;
-                            let networks = &network.subnets.as_ref().ok_or_else(|| {
-                                std::io::Error::new(
-                                    std::io::ErrorKind::Other,
-                                    "no network address provided",
-                                )
-                            })?;
                             firewall_driver.setup_port_forward(
+                                network.clone(),
                                 &network_options.container_id,
                                 i,
-                                container_ips[0],
-                                networks[0].subnet,
                                 net_name,
-                                &id_network_hash.as_str()[0..MAX_HASH_SIZE],
+                                &id_network_hash,
+                                per_network_opts,
+                                // &id_network_hash.as_str()[0..MAX_HASH_SIZE],
                             )?;
                         }
                     }
@@ -151,17 +117,4 @@ impl Setup {
         debug!("{:?}", "Setup complete");
         Ok(())
     }
-}
-// get a sysctl value by the value's namespace
-fn get_sysctl_value(ns_value: &str) -> Result<String, SysctlError> {
-    debug!("Getting sysctl value for {}", ns_value);
-    let ctl = sysctl::Ctl::new(ns_value)?;
-    ctl.value_string()
-}
-
-// set a sysctl value by value's namespace
-fn set_sysctl_value(ns_value: &str, val: &str) -> Result<String, SysctlError> {
-    debug!("Setting sysctl value for {} to {}", ns_value, val);
-    let ctl = sysctl::Ctl::new(ns_value)?;
-    ctl.set_value_string(val)
 }

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -1,5 +1,7 @@
 use crate::error::NetavarkError;
 use crate::firewall::iptables::MAX_HASH_SIZE;
+use crate::network::core_utils::CoreUtils;
+use crate::network::types::TeardownPortForward;
 use crate::{firewall, network};
 use clap::{self, Clap};
 use log::debug;
@@ -42,6 +44,12 @@ impl Teardown {
                 "Setting up network {} with driver {}",
                 net_name, network.driver
             );
+            let interface_name: String = match network.network_interface.clone() {
+                None => "".to_string(),
+                Some(name) => name,
+            };
+            let count = CoreUtils::bridge_count_connected_interfaces(&interface_name)?;
+            let complete_teardown = count.len() == 1;
 
             match network.driver.as_str() {
                 "bridge" => {
@@ -69,19 +77,23 @@ impl Teardown {
                     match port_bindings {
                         None => {}
                         Some(i) => {
-                            firewall_driver.teardown_port_forward(
-                                network.clone(),
-                                &network_options.container_id,
-                                i,
-                                &net_name,
-                                &id_network_hash,
-                                per_network_opts,
-                                // &id_network_hash.as_str()[0..MAX_HASH_SIZE],
-                            )?;
+                            let td = TeardownPortForward {
+                                network: network.clone(),
+                                container_id: network_options.container_id.clone(),
+                                port_mappings: i,
+                                network_name: net_name,
+                                id_network_hash,
+                                options: (*per_network_opts).clone(),
+                                complete_teardown,
+                            };
+                            firewall_driver.teardown_port_forward(td)?;
                         }
                     }
-
-                    // TODO teardown firewall if no interfaces connected to bridge!
+                    if complete_teardown {
+                        firewall_driver.teardown_network(network, complete_teardown)?;
+                        // Teardown the interface now
+                        network::core_utils::CoreUtils::remove_interface(&interface_name)?;
+                    }
                 }
                 // unknown driver
                 _ => {

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -1,10 +1,9 @@
 use crate::firewall;
 use crate::network::types;
-use ipnet::IpNet;
+use crate::network::types::{Network, PerNetworkOptions};
 use log::debug;
 use std::collections::HashMap;
 use std::error::Error;
-use std::net::IpAddr;
 use std::vec::Vec;
 use zbus::Connection;
 use zvariant::{Array, Value};
@@ -67,21 +66,24 @@ impl firewall::FirewallDriver for FirewallD {
 
     fn setup_port_forward(
         &self,
+        _network: Network,
         _container_id: &str,
         _port_mappings: Vec<types::PortMapping>,
-        _container_ip: IpAddr,
-        _network: IpNet,
         _network_name: &str,
         _id_network_hash: &str,
+        _options: &PerNetworkOptions,
     ) -> Result<(), Box<dyn Error>> {
         todo!();
     }
 
     fn teardown_port_forward(
         &self,
+        _network: Network,
         _container_id: &str,
         _port_mappings: Vec<types::PortMapping>,
-        _container_ip: &str,
+        _network_name: &str,
+        _id_network_hash: &str,
+        _options: &PerNetworkOptions,
     ) -> Result<(), Box<dyn Error>> {
         todo!();
     }

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -1,6 +1,6 @@
 use crate::firewall;
 use crate::network::types;
-use crate::network::types::{Network, PerNetworkOptions};
+use crate::network::types::{Network, PerNetworkOptions, TeardownPortForward};
 use log::debug;
 use std::collections::HashMap;
 use std::error::Error;
@@ -60,7 +60,11 @@ impl firewall::FirewallDriver for FirewallD {
         Ok(())
     }
 
-    fn teardown_network(&self, _net: types::Network) -> Result<(), Box<dyn Error>> {
+    fn teardown_network(
+        &self,
+        _net: types::Network,
+        _complete_teardown: bool,
+    ) -> Result<(), Box<dyn Error>> {
         todo!();
     }
 
@@ -78,12 +82,7 @@ impl firewall::FirewallDriver for FirewallD {
 
     fn teardown_port_forward(
         &self,
-        _network: Network,
-        _container_id: &str,
-        _port_mappings: Vec<types::PortMapping>,
-        _network_name: &str,
-        _id_network_hash: &str,
-        _options: &PerNetworkOptions,
+        _teardown_pf: TeardownPortForward,
     ) -> Result<(), Box<dyn Error>> {
         todo!();
     }

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -1,11 +1,11 @@
 use crate::firewall;
+use crate::network::core_utils::CoreUtils;
 use crate::network::types;
-use ipnet::IpNet;
+use crate::network::types::{Network, PerNetworkOptions};
 use iptables;
 use iptables::IPTables;
 use log::debug;
 use std::error::Error;
-use std::net::IpAddr;
 
 const HEXMARK: &str = "0x2000";
 pub(crate) const MAX_HASH_SIZE: usize = 13;
@@ -109,13 +109,31 @@ impl firewall::FirewallDriver for IptablesDriver {
 
     fn setup_port_forward(
         &self,
+        network: Network,
         container_id: &str,
         port_mappings: Vec<types::PortMapping>,
-        container_ip: IpAddr,
-        network: IpNet,
         network_name: &str,
         id_network_hash: &str,
+        options: &PerNetworkOptions,
     ) -> Result<(), Box<dyn Error>> {
+        // Need to enable sysctl localnet so that traffic can pass
+        // through localhost to containers
+        let network_interface = network.network_interface;
+        match network_interface {
+            None => {}
+            Some(i) => {
+                let localnet_path = format!("net.ipv4.conf.{}.route_localnet", i);
+                CoreUtils::apply_sysctl_value(localnet_path.as_str(), "1")?;
+            }
+        }
+        let container_ips = options.static_ips.as_ref().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Other, "no container ip provided")
+        })?;
+        let container_ip = container_ips[0];
+        let networks = &network.subnets.as_ref().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Other, "no network address provided")
+        })?;
+        let container_network_address = networks[0].subnet;
         // Set up all chains
         let network_dn_chain_name = CONTAINER_DN_CHAIN.to_owned() + id_network_hash;
         let network_chain_name = CONTAINER_CHAIN.to_owned() + id_network_hash;
@@ -167,6 +185,7 @@ impl firewall::FirewallDriver for IptablesDriver {
             POSTROUTING_JUMP,
             &format!("-j {} ", NETAVARK_HOSTPORT_MASK_CHAIN),
         )?;
+
         append_unique(
             &self.conn,
             NAT,
@@ -193,7 +212,7 @@ impl firewall::FirewallDriver for IptablesDriver {
             let setmark_network_rule = format!(
                 "-j {} -s {} -p tcp --dport {}",
                 HOSTPORT_SETMARK_CHAIN,
-                network.to_string(),
+                container_network_address.to_string(),
                 i.host_port.to_string()
             );
             append_unique(
@@ -233,11 +252,99 @@ impl firewall::FirewallDriver for IptablesDriver {
 
     fn teardown_port_forward(
         &self,
-        _container_id: &str,
-        _port_mappings: Vec<types::PortMapping>,
-        _container_ip: &str,
+        network: Network,
+        container_id: &str,
+        port_mappings: Vec<types::PortMapping>,
+        network_name: &str,
+        id_network_hash: &str,
+        options: &PerNetworkOptions,
     ) -> Result<(), Box<dyn Error>> {
-        todo!();
+        let container_ips = options.static_ips.as_ref().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Other, "no container ip provided")
+        })?;
+        let networks = &network.subnets.as_ref().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::Other, "no network address provided")
+        })?;
+        let container_network_address = networks[0].subnet;
+        let network_dn_chain_name = CONTAINER_DN_CHAIN.to_owned() + id_network_hash;
+        let comment_dn_network_cid = format!(
+            "-m comment --comment 'dnat name: {} id: {}'",
+            network_name, container_id
+        );
+        let network_chain_name = CONTAINER_CHAIN.to_owned() + id_network_hash;
+        let container_ip = container_ips[0];
+        // First delete any container specific rules
+        // POSTROUTING
+        let comment_network_cid = format!(
+            "-m comment --comment 'name: {} id: {}'",
+            network_name, container_id
+        );
+        remove_if_rule_exists(
+            &self.conn,
+            NAT,
+            POSTROUTING_JUMP,
+            &format!(
+                "-j {} -s {} {}",
+                network_chain_name,
+                container_ip.to_string(),
+                comment_network_cid
+            ),
+        )?;
+
+        // Iterate on ports
+        for i in port_mappings {
+            // hostport dnat
+            let hostport_dnat_rule = format!(
+                "-j {} -p tcp -m multiport --destination-ports {} {}",
+                network_dn_chain_name,
+                i.host_port.to_string(),
+                comment_dn_network_cid
+            );
+            remove_if_rule_exists(&self.conn, NAT, HOSTPORT_DNAT_CHAIN, &hostport_dnat_rule)?;
+            // dn container (the actual port usages)
+            let setmark_network_rule = format!(
+                "-j {} -s {} -p tcp --dport {}",
+                HOSTPORT_SETMARK_CHAIN,
+                container_network_address.to_string(),
+                i.host_port.to_string()
+            );
+            remove_if_rule_exists(
+                &self.conn,
+                NAT,
+                &network_dn_chain_name,
+                &setmark_network_rule,
+            )?;
+            let setmark_localhost_rule = format!(
+                "-j {} -s 127.0.0.1 -p tcp --dport {}",
+                HOSTPORT_SETMARK_CHAIN,
+                i.host_port.to_string()
+            );
+            remove_if_rule_exists(
+                &self.conn,
+                NAT,
+                &network_dn_chain_name,
+                &setmark_localhost_rule,
+            )?;
+            let container_dest_rule = format!(
+                "-j {} -p tcp --to-destination {}:{} --destination-port {}",
+                DNAT_JUMP,
+                container_ip.to_string(),
+                i.container_port.to_string(),
+                i.host_port.to_string()
+            );
+            remove_if_rule_exists(
+                &self.conn,
+                NAT,
+                &network_dn_chain_name,
+                &container_dest_rule,
+            )?;
+        }
+
+        // TODO Once we have a function to detect if this is the last container
+        // on the network, we can rip down the additional iptables rules that are
+        // network based.
+
+        Result::Ok(())
     }
 }
 // append a rule to chain if it does not exist
@@ -285,6 +392,21 @@ fn chain_exists(driver: &IPTables, table: &str, chain: &str) -> Result<bool, Box
     serde::__private::Result::Ok(false)
 }
 
+fn remove_if_rule_exists(
+    driver: &IPTables,
+    table: &str,
+    chain: &str,
+    rule: &str,
+) -> Result<(), Box<dyn Error>> {
+    // If the rule is not present, do not error
+    let exists = driver.exists(table, chain, rule)?;
+    if !exists {
+        debug_rule_no_exists(table, chain, rule.to_string());
+        return Ok(());
+    }
+    driver.delete(table, chain, rule)
+}
+
 fn debug_chain_create(table: &str, chain: &str) {
     debug!("chain {} created on table {}", chain, table);
 }
@@ -303,6 +425,12 @@ fn debug_rule_create(table: &str, chain: &str, rule: String) {
 fn debug_rule_exists(table: &str, chain: &str, rule: String) {
     debug!(
         "rule {} exists on table {} and chain {}",
+        rule, table, chain
+    );
+}
+fn debug_rule_no_exists(table: &str, chain: &str, rule: String) {
+    debug!(
+        "no rule {} exists on table {} and chain {}",
         rule, table, chain
     );
 }

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -1,5 +1,5 @@
 use crate::network::types;
-use crate::network::types::{Network, PerNetworkOptions};
+use crate::network::types::{Network, PerNetworkOptions, TeardownPortForward};
 use log::{debug, info};
 use std::env;
 use std::error::Error;
@@ -18,7 +18,11 @@ pub trait FirewallDriver {
         network_hash_name: String,
     ) -> Result<(), Box<dyn Error>>;
     // Tear down firewall rules for the given network.
-    fn teardown_network(&self, net: types::Network) -> Result<(), Box<dyn Error>>;
+    fn teardown_network(
+        &self,
+        net: types::Network,
+        complete_teardown: bool,
+    ) -> Result<(), Box<dyn Error>>;
 
     // Set up port-forwarding firewall rules for a given container.
     fn setup_port_forward(
@@ -31,15 +35,8 @@ pub trait FirewallDriver {
         options: &PerNetworkOptions,
     ) -> Result<(), Box<dyn Error>>;
     // Tear down port-forwarding firewall rules for a single container.
-    fn teardown_port_forward(
-        &self,
-        network: Network,
-        container_id: &str,
-        port_mappings: Vec<types::PortMapping>,
-        network_name: &str,
-        id_network_hash: &str,
-        options: &PerNetworkOptions,
-    ) -> Result<(), Box<dyn Error>>;
+    fn teardown_port_forward(&self, teardown_pf: TeardownPortForward)
+        -> Result<(), Box<dyn Error>>;
 }
 
 // Types of firewall backend

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -1,9 +1,8 @@
 use crate::network::types;
-use ipnet::IpNet;
+use crate::network::types::{Network, PerNetworkOptions};
 use log::{debug, info};
 use std::env;
 use std::error::Error;
-use std::net::IpAddr;
 use zbus::Connection;
 
 pub mod firewalld;
@@ -24,19 +23,22 @@ pub trait FirewallDriver {
     // Set up port-forwarding firewall rules for a given container.
     fn setup_port_forward(
         &self,
+        network: Network,
         container_id: &str,
         port_mappings: Vec<types::PortMapping>,
-        container_ip: IpAddr,
-        network: IpNet,
         network_name: &str,
         id_network_hash: &str,
+        options: &PerNetworkOptions,
     ) -> Result<(), Box<dyn Error>>;
     // Tear down port-forwarding firewall rules for a single container.
     fn teardown_port_forward(
         &self,
+        network: Network,
         container_id: &str,
         port_mappings: Vec<types::PortMapping>,
-        container_ip: &str,
+        network_name: &str,
+        id_network_hash: &str,
+        options: &PerNetworkOptions,
     ) -> Result<(), Box<dyn Error>>;
 }
 

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -1,6 +1,7 @@
 use futures::stream::TryStreamExt;
 use futures::StreamExt;
 use libc;
+use log::debug;
 use nix::sched;
 use rand::Rng;
 use rtnetlink;
@@ -18,6 +19,7 @@ use std::net::Ipv6Addr;
 use std::os::unix::prelude::*;
 use std::process;
 use std::thread;
+use sysctl::{Sysctl, SysctlError};
 
 pub struct CoreUtils {
     pub networkns: String,
@@ -979,5 +981,19 @@ impl CoreUtils {
         let hash_string = format!("{:X}", result);
         let response = &hash_string[0..length];
         response.to_string()
+    }
+
+    // get a sysctl value by the value's namespace
+    pub fn lookup_sysctl_value(ns_value: &str) -> Result<String, SysctlError> {
+        debug!("Getting sysctl value for {}", ns_value);
+        let ctl = sysctl::Ctl::new(ns_value)?;
+        ctl.value_string()
+    }
+
+    // set a sysctl value by value's namespace
+    pub fn apply_sysctl_value(ns_value: &str, val: &str) -> Result<String, SysctlError> {
+        debug!("Setting sysctl value for {} to {}", ns_value, val);
+        let ctl = sysctl::Ctl::new(ns_value)?;
+        ctl.set_value_string(val)
     }
 }

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -1,5 +1,6 @@
 // Crate contains the types which are accepted by netavark.
 
+use crate::network::types;
 use ipnet::IpNet;
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -75,7 +76,7 @@ pub struct NetworkOptions {
 }
 
 // PerNetworkOptions are options which should be set on a per network basis
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PerNetworkOptions {
     /// Aliases contains a list of names which the dns server should resolve
     /// to this container. Should only be set when DNSEnabled is true on the Network.
@@ -205,4 +206,22 @@ pub struct LeaseRange {
     /// StartIP first IP in the subnet which should be used to assign ips.
     #[serde(rename = "start_ip")]
     pub start_ip: Option<String>,
+}
+//  Teardown contains options for tearing down behind a container
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TeardownPortForward {
+    // network object
+    pub network: Network,
+    // container id
+    pub container_id: String,
+    // portmappings
+    pub port_mappings: Vec<types::PortMapping>,
+    // name of network
+    pub network_name: String,
+    // network id
+    pub id_network_hash: String,
+    // pernetwork options
+    pub options: PerNetworkOptions,
+    // remove network related information
+    pub complete_teardown: bool,
 }

--- a/src/test/config/portmapping.json
+++ b/src/test/config/portmapping.json
@@ -1,0 +1,45 @@
+{
+  "container_id": "ad1df727792c3041dc82c5b7791365debce6f5ada7c7a0320a2d1368e1635d30",
+  "container_name": "ecstatic_lamarr",
+  "port_mappings": [
+    {
+      "host_ip": "",
+      "container_port": 80,
+      "host_port": 8080,
+      "range": 1,
+      "protocol": "tcp"
+    }
+  ],
+  "networks": {
+    "podman": {
+      "static_ips": [
+        "10.88.0.2"
+      ],
+      "aliases": [
+        "ad1df727792c"
+      ],
+      "interface_name": "eth0"
+    }
+  },
+  "network_info": {
+    "podman": {
+      "name": "podman",
+      "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+      "driver": "bridge",
+      "network_interface": "podman0",
+      "created": "2021-11-18T01:58:22.148419519Z",
+      "subnets": [
+        {
+          "subnet": "10.88.0.0/16",
+          "gateway": "10.88.0.1"
+        }
+      ],
+      "ipv6_enabled": false,
+      "internal": false,
+      "dns_enabled": false,
+      "ipam_options": {
+        "driver": "host-local"
+      }
+    }
+  }
+}


### PR DESCRIPTION
When a container is cleaned up, podman will call netavark to teardown
the network information.  We need to clean up any container specific
iptables rules.

Once we have a fn to detect if the container is the last on the network,
then we can also teardown network specific iptables rules.

Signed-off-by: Brent Baude <bbaude@redhat.com>