### PR TITLE
Do not log the timestamp

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ enum SubCommand {
 }
 
 fn main() {
-    env_logger::init();
+    env_logger::builder().format_timestamp(None).init();
     let opts = Opts::parse();
 
     let file = opts.file.unwrap_or_else(|| String::from("/dev/stdin"));


### PR DESCRIPTION
There is no value on logging the timestamp IMO. When I make the netavark
interface log to syslog in podman I get 3 timestamps. First the syslog
itself, then the logrus in podman and then netavark env logger.
I think we can just remove this one without breaking anything.
