### PR TITLE
Use structs for input

### DIFF
--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -1,7 +1,7 @@
 use crate::error::NetavarkError;
 use crate::firewall::iptables::MAX_HASH_SIZE;
 use crate::network::core_utils::CoreUtils;
-use crate::network::types::TeardownPortForward;
+use crate::network::internal_types::{TearDownNetwork, TeardownPortForward};
 use crate::{firewall, network};
 use clap::{self, Clap};
 use log::debug;
@@ -90,7 +90,11 @@ impl Teardown {
                         }
                     }
                     if complete_teardown {
-                        firewall_driver.teardown_network(network, complete_teardown)?;
+                        let ctd = TearDownNetwork {
+                            net: network,
+                            complete_teardown,
+                        };
+                        firewall_driver.teardown_network(ctd)?;
                         // Teardown the interface now
                         network::core_utils::CoreUtils::remove_interface(&interface_name)?;
                     }

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -1,6 +1,6 @@
 use crate::firewall;
-use crate::network::types;
-use crate::network::types::{Network, PerNetworkOptions, TeardownPortForward};
+use crate::network::internal_types::{SetupPortForward, TearDownNetwork, TeardownPortForward};
+use crate::network::{internal_types, types};
 use log::debug;
 use std::collections::HashMap;
 use std::error::Error;
@@ -23,8 +23,7 @@ pub fn new(conn: Connection) -> Result<Box<dyn firewall::FirewallDriver>, Box<dy
 impl firewall::FirewallDriver for FirewallD {
     fn setup_network(
         &self,
-        net: types::Network,
-        _network_hash: String,
+        network_setup: internal_types::SetupNetwork,
     ) -> Result<(), Box<dyn Error>> {
         let mut need_reload = false;
 
@@ -50,7 +49,7 @@ impl firewall::FirewallDriver for FirewallD {
 
         // MUST come after the reload; otherwise the zone we made might not be
         // in the running config.
-        if let Some(nets) = net.subnets {
+        if let Some(nets) = network_setup.net.subnets {
             match add_source_subnets_to_zone(&self.conn, ZONENAME, nets) {
                 Ok(_) => {}
                 Err(e) => bail!("Error adding source subnets to zone {}: {}", ZONENAME, e),
@@ -60,23 +59,11 @@ impl firewall::FirewallDriver for FirewallD {
         Ok(())
     }
 
-    fn teardown_network(
-        &self,
-        _net: types::Network,
-        _complete_teardown: bool,
-    ) -> Result<(), Box<dyn Error>> {
+    fn teardown_network(&self, _tear: TearDownNetwork) -> Result<(), Box<dyn Error>> {
         todo!();
     }
 
-    fn setup_port_forward(
-        &self,
-        _network: Network,
-        _container_id: &str,
-        _port_mappings: Vec<types::PortMapping>,
-        _network_name: &str,
-        _id_network_hash: &str,
-        _options: &PerNetworkOptions,
-    ) -> Result<(), Box<dyn Error>> {
+    fn setup_port_forward(&self, _setup_portfw: SetupPortForward) -> Result<(), Box<dyn Error>> {
         todo!();
     }
 

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -1,5 +1,6 @@
-use crate::network::types;
-use crate::network::types::{Network, PerNetworkOptions, TeardownPortForward};
+use crate::network::internal_types::{
+    SetupNetwork, SetupPortForward, TearDownNetwork, TeardownPortForward,
+};
 use log::{debug, info};
 use std::env;
 use std::error::Error;
@@ -12,28 +13,12 @@ pub mod iptables;
 // and port mappings.
 pub trait FirewallDriver {
     // Set up firewall rules for the given network,
-    fn setup_network(
-        &self,
-        net: types::Network,
-        network_hash_name: String,
-    ) -> Result<(), Box<dyn Error>>;
+    fn setup_network(&self, network_setup: SetupNetwork) -> Result<(), Box<dyn Error>>;
     // Tear down firewall rules for the given network.
-    fn teardown_network(
-        &self,
-        net: types::Network,
-        complete_teardown: bool,
-    ) -> Result<(), Box<dyn Error>>;
+    fn teardown_network(&self, tear: TearDownNetwork) -> Result<(), Box<dyn Error>>;
 
     // Set up port-forwarding firewall rules for a given container.
-    fn setup_port_forward(
-        &self,
-        network: Network,
-        container_id: &str,
-        port_mappings: Vec<types::PortMapping>,
-        network_name: &str,
-        id_network_hash: &str,
-        options: &PerNetworkOptions,
-    ) -> Result<(), Box<dyn Error>>;
+    fn setup_port_forward(&self, setup_pw: SetupPortForward) -> Result<(), Box<dyn Error>>;
     // Tear down port-forwarding firewall rules for a single container.
     fn teardown_port_forward(&self, teardown_pf: TeardownPortForward)
         -> Result<(), Box<dyn Error>>;

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -1,0 +1,54 @@
+use crate::network::types;
+use crate::network::types::{Network, PerNetworkOptions};
+
+//  Teardown contains options for tearing down behind a container
+#[derive(Clone, Debug)]
+pub struct TeardownPortForward {
+    // network object
+    pub network: Network,
+    // container id
+    pub container_id: String,
+    // portmappings
+    pub port_mappings: Vec<types::PortMapping>,
+    // name of network
+    pub network_name: String,
+    // network id
+    pub id_network_hash: String,
+    // pernetwork options
+    pub options: PerNetworkOptions,
+    // remove network related information
+    pub complete_teardown: bool,
+}
+
+//  SetupNetwork contains options for setting up a container
+#[derive(Clone, Debug)]
+pub struct SetupNetwork {
+    // network object
+    pub net: types::Network,
+    // hash id for the network
+    pub network_hash_name: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct TearDownNetwork {
+    //  network object
+    pub net: types::Network,
+    // complete teardown of network
+    pub complete_teardown: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct SetupPortForward {
+    //  network object
+    pub net: types::Network,
+    // id of container
+    pub container_id: String,
+    // port mappings
+    pub port_mappings: Vec<types::PortMapping>,
+    // name of network
+    pub network_name: String,
+    // hash id for the network
+    pub network_hash_name: String,
+    // per network options
+    pub options: PerNetworkOptions,
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use std::fs::File;
 pub mod core;
 pub mod core_utils;
+pub mod internal_types;
 
 impl types::NetworkOptions {
     pub fn load(path: &str) -> Result<types::NetworkOptions> {

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -1,6 +1,5 @@
 // Crate contains the types which are accepted by netavark.
 
-use crate::network::types;
 use ipnet::IpNet;
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -206,22 +205,4 @@ pub struct LeaseRange {
     /// StartIP first IP in the subnet which should be used to assign ips.
     #[serde(rename = "start_ip")]
     pub start_ip: Option<String>,
-}
-//  Teardown contains options for tearing down behind a container
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TeardownPortForward {
-    // network object
-    pub network: Network,
-    // container id
-    pub container_id: String,
-    // portmappings
-    pub port_mappings: Vec<types::PortMapping>,
-    // name of network
-    pub network_name: String,
-    // network id
-    pub id_network_hash: String,
-    // pernetwork options
-    pub options: PerNetworkOptions,
-    // remove network related information
-    pub complete_teardown: bool,
 }


### PR DESCRIPTION
When calling setup_network, teardown_network, setup_port_forward, and
teardown_port_forward we now use defined structs for input.

Signed-off-by: Brent Baude <bbaude@redhat.com>