### PR TITLE
Cirrus: Switch CI onto VMs from containers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,26 +1,141 @@
 ---
 
-test_task:
-  alias: "build_and_test"
-  name: "Build and Test"
-  container:
-    image: quay.io/libpod/netavark-devel
-  install_script: make all
-  test_script: make test
+# Format Ref: https://cirrus-ci.org/guide/writing-tasks/
 
-test_task:
-  alias: "validate_test"
-  name: "Validate Code"
-  container:
-    image: quay.io/libpod/netavark-devel
-  test_script: make validate
+# Main collection of env. vars to set for all tasks and scripts.
+env:
+    # Actual|intended branch for this run
+    DEST_BRANCH: "main"
+    # The default is 'sh' if unspecified
+    CIRRUS_SHELL: "/bin/bash"
+    # Location where source repo. will be cloned
+    CIRRUS_WORKING_DIR: "/var/tmp/netavark"
+    # Rust package cache also lives here
+    CARGO_HOME: "/usr/local/cargo"
+    # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
+    SCRIPT_BASE: "./contrib/cirrus"
+    FEDORA_NAME: "fedora-35"
+    IMAGE_SUFFIX: "c6226133906620416"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
+
+
+gcp_credentials: ENCRYPTED[d6efdb7d6d4c61e3831df2193ca6348bb02f26cd931695f69d41930b1965f7dab72a838ca0902f6ed8cde66c7deddae2]
+
+
+# Default VM to use unless set or modified by task
+gce_instance:
+    image_project: "libpod-218412"
+    zone: "us-central1-c"
+    cpu: 2
+    memory: "4Gb"
+    disk: 200  # GB, do not set <200 per gcloud warning re: I/O performance
+    image_name: "${FEDORA_CACHE_IMAGE_NAME}"
+
+
+build_task:
+  alias: "build"
+  pkg_cache: &pkg_cache # TODO: Remove when packages included in static VM images
+    # This cache is intended to avoid constantly re-downloading repo. metadata
+    # (~150mb) and necessary RPMs (~300mb) every time CI runs.  It will likely
+    # flap often, as the metadata and package DBs change on access.  This is
+    # okay, as the cache still provides a benefit vs constantly hitting the
+    # RPM repos.  Use of this cache depends on dnf arguments passed in setup.sh
+    folder: "/var/cache/dnf"
+    # This is significant, Cirrus-CI will automatically store separate
+    # caches for branches & PRs.  We use the branch-name here mainly to
+    # distinguish PR-level caches in order to properly support backport-PRs
+    # to release branches.  Otherwise all PRs & branches will share caches
+    # with other PRs and branches (for a given $DEST_BRANCH value).
+    fingerprint_key: "pkg_${DEST_BRANCH}"
+    reupload_on_changes: true  # required since fingerprint_key is defined
+  cargo_cache: &cargo_cache
+    # Populating this cache requires both setup.sh and `make all` to run
+    # an actual build.  It takes about 10-minutes when starting from scratch,
+    # so caching this folder is important.
+    folder: "$CARGO_HOME"
+    # This cache is only about 100mb, but involves compiling.  Make it
+    # available across all PR's and Branches (separately) based on the
+    # $DEST_BRANCH value.
+    fingerprint_key: "cargo_${DEST_BRANCH}"
+    reupload_on_changes: true
+  bin_cache: &bin_cache
+    # This isn't very significant, it simply prevents rebuilding the
+    # binaries for every subsequent task - Saving about 3-5 minutes.
+    folder: "$CIRRUS_WORKING_DIR/bin"
+    # This is likely to change frequently, keep cache limited to ONLY this
+    # specific CI run (a.k.a. "build").
+    fingerprint_key: "bin_${CIRRUS_BUILD_ID}" # Cache only within the same build
+    reupload_on_changes: true
+  setup_script: &setup "$SCRIPT_BASE/setup.sh"
+  upload_caches: [ "pkg" ]  # Upload now, in case of main_script failure
+  main_script: &main "$SCRIPT_BASE/runner.sh $CIRRUS_TASK_NAME"
+  upload_caches: [ "cargo", "bin" ]
+
+
+validate_task:
+  alias: "validate"
+  depends_on:
+    - "build"
+  # From this point forward, all cache's become read-only - meaning
+  # any changes made in this task aren't re-uploaded to the cache.
+  # This avoids some flapping between tasks, along with the upload time.
+  pkg_cache: &ro_pkg_cache # TODO: Remove when packages included in static VM images
+    <<: *pkg_cache
+    reupload_on_changes: false
+  cargo_cache: &ro_cargo_cache
+    <<: *cargo_cache
+    reupload_on_changes: false
+  bin_cache: &ro_bin_cache
+    <<: *bin_cache
+    reupload_on_changes: false
+  setup_script: *setup
+  main_script: *main
+
+
+unit_task:
+  alias: "unit"
+  depends_on:
+    - "validate"
+  pkg_cache: *ro_pkg_cache # TODO: Remove when packages included in static VM images
+  cargo_cache: *ro_cargo_cache
+  bin_cache: *ro_bin_cache
+  setup_script: *setup
+  main_script: *main
+
+
+# This task is critical.  It updates the "last-used by" timestamp stored
+# in metadata for all VM images.  This mechanism functions in tandem with
+# an out-of-band pruning operation to remove disused VM images.
+meta_task:
+    alias: meta
+    name: "VM img. keepalive"
+    container:
+        cpu: 2
+        memory: 2
+        image: quay.io/libpod/imgts:$IMAGE_SUFFIX
+    env:
+        # Space-separated list of images used by this repository state
+        IMGNAMES: "${FEDORA_CACHE_IMAGE_NAME}"
+        BUILDID: "${CIRRUS_BUILD_ID}"
+        REPOREF: "${CIRRUS_REPO_NAME}"
+        GCPJSON: ENCRYPTED[e7e6e13b98eb34f480a12412a048e3fb78a02239c229659e136b7a27e2ab25a5bbb61ab6016e322cb6f777fa2c9f9520]
+        GCPNAME: ENCRYPTED[f3fc6da8fe283ef506d7b18467a81153ea8e18b1d3cd76e79dcd6f566f20fdd3651522432d3d232f4d69eeb1502d1f6b]
+        GCPPROJECT: libpod-218412
+    clone_script: &noop /bin/true  # source not needed
+    script: /usr/local/bin/entrypoint.sh
+
 
 success_task:
   name: "Total success"
+  alias: success
   depends_on:
-    - "build_and_test"
-    - "validate_test"
-  clone_script: /bin/true
-  script: /bin/true
-  container: 
-    image: docker.io/library/alpine
+    - "build"
+    - "validate"
+    - "unit"
+    - "meta"
+  container:
+    image: quay.io/libpod/alpine:latest
+  env:
+    CIRRUS_SHELL: "/bin/sh"
+  clone_script: *noop
+  script: *noop

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,6 +103,17 @@ unit_task:
   main_script: *main
 
 
+# integration_task:
+#   alias: "integration"
+#   depends_on:
+#     - "unit"
+#   pkg_cache: *ro_pkg_cache # TODO: Remove when packages included in static VM images
+#   cargo_cache: *ro_cargo_cache
+#   bin_cache: *ro_bin_cache
+#   setup_script: *setup
+#   main_script: *main
+
+
 # This task is critical.  It updates the "last-used by" timestamp stored
 # in metadata for all VM images.  This mechanism functions in tandem with
 # an out-of-band pruning operation to remove disused VM images.
@@ -132,6 +143,7 @@ success_task:
     - "build"
     - "validate"
     - "unit"
+    # - "integration"
     - "meta"
   container:
     image: quay.io/libpod/alpine:latest

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,3 +1,0 @@
-# Container image for validating and building netavark
-FROM docker.io/library/rust
-RUN rustup component add clippy rustfmt && cargo install mandown

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -1,0 +1,62 @@
+
+
+# Library of common, shared utility functions.  This file is intended
+# to be sourced by other scripts, not called directly.
+
+# BEGIN Global export of all variables
+set -a
+
+# Automation library installed at image-build time,
+# defining $AUTOMATION_LIB_PATH in this file.
+if [[ -r "/etc/automation_environment" ]]; then
+    source /etc/automation_environment
+fi
+
+if [[ -n "$AUTOMATION_LIB_PATH" ]]; then
+        source $AUTOMATION_LIB_PATH/common_lib.sh
+else
+    (
+    echo "WARNING: It does not appear that containers/automation was installed."
+    echo "         Functionality of most of this library will be negatively impacted"
+    echo "         This ${BASH_SOURCE[0]} was loaded by ${BASH_SOURCE[1]}"
+    ) > /dev/stderr
+fi
+
+# Unsafe env. vars for display
+SECRET_ENV_RE='(ACCOUNT)|(GC[EP]..+)|(SSH)|(PASSWORD)|(TOKEN)'
+
+# setup.sh calls make_cienv() to cache these values for the life of the VM
+if [[ -r "/etc/ci_environment" ]]; then
+    source /etc/ci_environment
+else  # set default values - see make_cienv() below
+    # Install rust packages globally instead of per-user
+    CARGO_HOME="${CARGO_HOME:-/usr/local/cargo}"
+    # Ensure cargo packages can be executed
+    PATH="$PATH:$CARGO_HOME/bin"
+fi
+
+# END Global export of all variables
+set -a
+
+# Shortcut to automation library timeout/retry function
+retry() { err_retry 8 1000 "" "$@"; }  # just over 4 minutes max
+
+# Helper to ensure a consistent environment across multiple CI scripts
+# containers, and shell environments (e.g. hack/get_ci_vm.sh)
+make_cienv(){
+    local envname
+    local envval
+    local SETUP_ENVIRONMENT=1
+    for envname in CARGO_HOME PATH CIRRUS_WORKING_DIR SETUP_ENVIRONMENT; do
+        envval="${!envname}"
+        # Properly escape values to prevent injection
+        printf -- "$envname=%q\n" "$envval"
+    done
+}
+
+complete_setup(){
+    msg "************************************************************"
+    msg "Completing environment setup, writing vars:"
+    msg "************************************************************"
+    make_cienv | tee -a /etc/ci_environment
+}

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -28,6 +28,11 @@ _run_unit() {
     make test
 }
 
+_run_integration() {
+    # TODO: No Makefile target for these at the time of this commit
+    bats ./test/
+}
+
 show_env_vars
 
 msg "************************************************************"

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# This script runs in the Cirrus CI environment, invoked from .cirrus.yml .
+# It can also be invoked manually in a `hack/get_ci_cm.sh` environment,
+# documentation of said usage is TBI.
+#
+# The principal deciding factor is the first argument.  For any
+# given value 'xyz' there must be a function '_run_xyz' to handle that
+# argument.
+
+source $(dirname ${BASH_SOURCE[0]})/lib.sh
+
+_run_noarg() {
+    die "runner.sh must be called with a single argument"
+}
+
+_run_build() {
+    make all
+}
+
+_run_validate() {
+    make validate
+}
+
+_run_unit() {
+    make test
+}
+
+show_env_vars
+
+msg "************************************************************"
+msg "Toolchain details"
+msg "************************************************************"
+rustc --version
+cargo --version
+
+msg "************************************************************"
+msg "Runner executing '$1' on $OS_REL_VER"
+msg "************************************************************"
+
+((${SETUP_ENVIRONMENT:-0})) || \
+    die "Expecting setup.sh to have completed successfully"
+
+cd "${CIRRUS_WORKING_DIR}/"
+
+handler="_run_${1:-noarg}"
+
+if [ "$(type -t $handler)" != "function" ]; then
+    die "Unknown/Unsupported runner.sh argument '$1'"
+fi
+
+$handler

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This script configures the CI runtime environment.  It's intended
+# to be used by Cirrus-CI, not humans.
+
+set -e
+
+source $(dirname $0)/lib.sh
+
+# Only do this once
+if [[ -r "/etc/ci_environment" ]]; then
+    msg "It appears ${BASH_SOURCE[0]} already ran, exiting."
+    exit 0
+fi
+trap "complete_setup" EXIT
+
+msg "************************************************************"
+msg "Setting up runtime environment"
+msg "************************************************************"
+show_env_vars
+
+# To improve CI reliability and predictability, these operations
+# should be moved into the VM Image building process managed from
+# containers/automation_images repository.  For now, we do it here
+# for simplicity and expediency sake.  Long-term, operations
+# marked with calls to this function should be relocated.
+warntodo() { warn "$1 - TODO: Move into static VM image"; }
+
+warntodo "Updating OS"
+# Support Cirrus-CI /var/cache/dnf caching
+_dnf_opts="--exclude=kernel --setopt=keepcache=True --setopt=check_config_file_age=False --setopt=metadata_expire=14400"
+retry dnf $_dnf_opts update -y
+
+warntodo "Installing Rust toolchain"
+retry dnf $_dnf_opts install -y rust clippy rustfmt cargo
+
+# Oddly this is necessary to catch some corner-cases.
+warntodo "Upgrading packages"
+retry dnf $_dnf_opts update -y
+
+# This is made performant by caching $CARGO_HOME
+msg "Installing Rust packages (CARGO_HOME=$CARGO_HOME)"
+retry cargo install mandown
+
+# This database seems to change every time the above
+# dnf commands are run.  Remove it to avoid unnecessary
+# cache re-uploads, since it will be re-created next time
+# it's needed.  All we really care to cache is metadata and RPMs
+# anyway.  Everything else could be excluded from cache here,
+# but all this should be going away when dedicated VM images
+# are implemented.
+warntodo "Clobbering cache-flapping packages.db"
+rm -rf /var/cache/dnf/packages.db

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -32,7 +32,7 @@ _dnf_opts="--exclude=kernel --setopt=keepcache=True --setopt=check_config_file_a
 retry dnf $_dnf_opts update -y
 
 warntodo "Installing Rust toolchain"
-retry dnf $_dnf_opts install -y rust clippy rustfmt cargo
+retry dnf $_dnf_opts install -y rust clippy rustfmt cargo dbus-daemon firewalld
 
 # Oddly this is necessary to catch some corner-cases.
 warntodo "Upgrading packages"

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+#
+# For help and usage information, simply execute the script w/o any arguments.
+#
+# This script is intended to be run by Red Hat podman developers who need
+# to debug problems specifically related to Cirrus-CI automated testing.
+# It requires that you have been granted prior access to create VMs in
+# google-cloud.  For non-Red Hat contributors, VMs are available as-needed,
+# with supervision upon request.
+
+set -e
+
+SCRIPT_FILEPATH=$(realpath "${BASH_SOURCE[0]}")
+SCRIPT_DIRPATH=$(dirname "$SCRIPT_FILEPATH")
+REPO_DIRPATH=$(realpath "$SCRIPT_DIRPATH/../")
+
+# Help detect if we were called by get_ci_vm container
+GET_CI_VM="${GET_CI_VM:-0}"
+in_get_ci_vm() {
+    if ((GET_CI_VM==0)); then
+        echo "Error: $1 is not intended for use in this context"
+        exit 2
+    fi
+}
+
+# get_ci_vm APIv1 container entrypoint calls into this script
+# to obtain required repo. specific configuration options.
+if [[ "$1" == "--config" ]]; then
+    in_get_ci_vm "$1"
+    cat <<EOF
+DESTDIR="/var/tmp/netavark"
+UPSTREAM_REPO="https://github.com/containers/netavark.git"
+CI_ENVFILE="/etc/ci_environment"
+GCLOUD_PROJECT="netavark-2021"
+GCLOUD_IMGPROJECT="libpod-218412"
+GCLOUD_CFG="netavark"
+GCLOUD_ZONE="${GCLOUD_ZONE:-us-central1-c}"
+GCLOUD_CPUS="2"
+GCLOUD_MEMORY="4Gb"
+GCLOUD_DISK="200"
+EOF
+elif [[ "$1" == "--setup" ]]; then
+    in_get_ci_vm "$1"
+    # get_ci_vm container entrypoint calls us with this option on the
+    # Cirrus-CI environment instance, to perform repo.-specific setup.
+    cd $REPO_DIRPATH
+    echo "+ Running environment setup" > /dev/stderr
+    ./contrib/cirrus/setup.sh
+else
+    # Create and access VM for specified Cirrus-CI task
+    mkdir -p $HOME/.config/gcloud/ssh
+    podman run -it --rm \
+        --tz=local \
+        -e NAME="$USER" \
+        -e SRCDIR=/src \
+        -e GCLOUD_ZONE="$GCLOUD_ZONE" \
+        -e DEBUG="${DEBUG:-0}" \
+        -v $REPO_DIRPATH:/src:O \
+        -v $HOME/.config/gcloud:/root/.config/gcloud:z \
+        -v $HOME/.config/gcloud/ssh:/root/.ssh:z \
+        quay.io/libpod/get_ci_vm:latest "$@"
+fi


### PR DESCRIPTION
Prior to this commit, CI ran entirely in a container environment.  This
was very much less than ideal, since actual network/firewall
manipulations could not be exercised.  With this commit, everything will
execute on the same VM images and image-build workflow used by all the
other containers-org project automations.

Note: Given all other projects generally use golang, the VM images here
are *NOT* tailored to a rust project.  Unfortunately that means
performing runtime updates/installs and using cache to reduce the dnf
repo. Metadata/package downloading.  These aspects can be removed once
dedicated netavark VM images are realized and implemented in a future
commit.