### PR TITLE
Fix make: 'test' is up to date.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ uninstall:
 	rm -f $(DESTDIR)/$(LIBEXECPODMAN)/netavark
 	rm -f $(PREFIX)/share/man/man1/netavark*.1
 
+.PHONY: test
 test:
 	cargo test
 


### PR DESCRIPTION
Without this, running 'make test' will fail to execute if the `test` directory timestamp is current.