### PR TITLE
Fix double json in error message

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -41,7 +41,7 @@ impl Setup {
             Ok(opts) => opts,
             Err(e) => {
                 return Err(Box::new(NetavarkError {
-                    error: format!("{}", e),
+                    error: format!("failed to load network options: {}", e),
                     errno: 1,
                 }));
             }

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -28,7 +28,7 @@ impl Teardown {
             Ok(opts) => opts,
             Err(e) => {
                 return Err(Box::new(NetavarkError {
-                    error: format!("{}", e),
+                    error: format!("failed to load network options: {}", e),
                     errno: 1,
                 }));
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,9 +9,19 @@ pub struct NetavarkError {
     pub errno: i32,
 }
 
+impl NetavarkError {
+    pub fn print_json(&self) {
+        println!(
+            "{}",
+            serde_json::to_string(&self)
+                .unwrap_or(format!("Failed to serialize error message: {}", self.error))
+        )
+    }
+}
+
 impl fmt::Display for NetavarkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", serde_json::to_string(&self).unwrap())
+        write!(f, "{}", self.error)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,26 +29,20 @@ fn main() {
     let opts = Opts::parse();
 
     let file = opts.file.unwrap_or_else(|| String::from("/dev/stdin"));
-    match opts.subcmd {
-        SubCommand::Setup(setup) => {
-            if let Err(err) = setup.exec(file) {
-                let er = netavark::error::NetavarkError {
-                    error: format!("{}", err),
-                    errno: 1,
-                };
-                println!("{}", er.to_string());
-                std::process::exit(er.errno);
-            }
-        }
-        SubCommand::Teardown(teardown) => {
-            if let Err(err) = teardown.exec(file) {
-                let er = netavark::error::NetavarkError {
-                    error: format!("{}", err),
-                    errno: 1,
-                };
-                println!("{}", er.to_string());
-                std::process::exit(er.errno);
-            }
+    let result = match opts.subcmd {
+        SubCommand::Setup(setup) => setup.exec(file),
+        SubCommand::Teardown(teardown) => teardown.exec(file),
+    };
+
+    match result {
+        Ok(_) => {}
+        Err(err) => {
+            let er = netavark::error::NetavarkError {
+                error: format!("{}", err),
+                errno: 1,
+            };
+            er.print_json();
+            std::process::exit(er.errno);
         }
     }
 }


### PR DESCRIPTION
If the NetavarkError is wrapped twice so you get json in the actual error
message field. To fix this we need to keep the default string display
and use an explicit print_json function.

This is the current message `{"error":"{\"error\":\"No such file or directory (os error 2)\"}"}`
Now it looks like this `{"error":"No such file or directory (os error 2)"}`