### PR TITLE
Cargo.toml: exclude unnecessary files from crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 edition = "2018"
 authors = ["github.com/containers"]
 description = "A container network stack"
+exclude = ["/.cirrus.yml", "/.github/*", "/hack/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]


### PR DESCRIPTION
Fedora's Rust packaging guidelines recommend excluding unnecessary files
from Cargo.toml itself.

https://docs.fedoraproject.org/en-US/packaging-guidelines/Rust/#_excluding_unnecessary_files

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

PTAL