### PR TITLE
Downgrade nix to what exists in Fedora

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
  "libc",
  "log",
  "netlink-packet-route",
- "nix 0.23.0",
+ "nix 0.22.0",
  "rand",
  "rtnetlink",
  "serde",
@@ -670,19 +670,6 @@ name = "nix"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ url = "2.1.0"
 zbus = "1.9.1"
 rtnetlink = { git = "https://github.com/little-dude/netlink", branch = "master" }
 futures = "0.3.18"
-nix = "0.23.0"
+nix = "0.22.0" # DO NOT BUMP UNTIL ALREADY PACKAGED IN FEDORA
 rand = "0.8.3"
 faccess = "0.2.3"
 tokio = { version = "1.14.0", features = ["full"] }


### PR DESCRIPTION
It can be painful to bump the rust-nix package in Fedora.

Dependabot upgrades of nix should be blocked until the version is
packaged in Fedora.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@mheon @baude @Luap99 @flouthoc need to get this merged to make Fedora packaging happy.