### PR TITLE
add spec file for automated copr builds

### DIFF
--- a/.autocopr/README
+++ b/.autocopr/README
@@ -1,0 +1,5 @@
+Enable COPR:
+sudo dnf copr enable rhcontainerbot/podman-next
+
+Install netavark:
+sudo dnf install netavark -y

--- a/.autocopr/netavark.spec
+++ b/.autocopr/netavark.spec
@@ -1,0 +1,47 @@
+%global debug_package %{nil}
+
+Name: netavark
+Epoch: 100
+Version: 0
+%define build_timestamp %{lua: print(os.date("%Y%m%d"))}
+Release: %{build_timestamp}
+Summary: OCI network stack
+License: ASL 2.0
+URL: https://github.com/containers/%{name}
+Source: %{url}/archive/main.tar.gz#/%{name}-%{version}-%{release}.tar.gz
+BuildRequires: rust-packaging
+BuildRequires: go-md2man
+
+ExclusiveArch:  %{rust_arches}
+%if %{__cargo_skip_build}
+BuildArch:      noarch
+%endif
+
+%global _description %{expand:
+OCI network stack.}
+
+%description %{_description}
+
+%prep
+%autosetup -n %{name}-main
+sed -i 's/install: docs build/install:/' Makefile
+sed -i 's/\-C install/\-C docs install/' Makefile
+
+%build
+%{__make} build
+pushd docs
+go-md2man -in %{name}.1.md -out %{name}.1 
+popd
+
+%install
+%{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} install
+
+
+%files
+%license LICENSE
+%dir %{_libexecdir}/podman
+%{_libexecdir}/podman/%{name}
+%{_mandir}/man1/%{name}.1*
+
+%changelog
+%autochangelog


### PR DESCRIPTION
This commit along with an upstream  webhook
will automatically build an rpm at
`rhcontainerbot/podman-next` .

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@flouthoc @baude @mheon @Luap99 @rhatdan PTAL