### PR TITLE
Refactor iptables

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -4,7 +4,7 @@ use crate::firewall;
 use crate::firewall::iptables::MAX_HASH_SIZE;
 use crate::network;
 use crate::network::core_utils::CoreUtils;
-use crate::network::internal_types::{SetupNetwork, SetupPortForward};
+use crate::network::internal_types::{PortForwardConfig, SetupNetwork};
 use crate::network::{core_utils, types};
 use clap::{self, Clap};
 use log::debug;
@@ -124,7 +124,7 @@ impl Setup {
                                         "no network address provided",
                                     )
                                 })?;
-                                let spf = SetupPortForward {
+                                let spf = PortForwardConfig {
                                     net: network.clone(),
                                     container_id: network_options.container_id.clone(),
                                     port_mappings: i.clone(),

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -1,5 +1,5 @@
 use crate::firewall;
-use crate::network::internal_types::{SetupPortForward, TearDownNetwork, TeardownPortForward};
+use crate::network::internal_types::{PortForwardConfig, TearDownNetwork, TeardownPortForward};
 use crate::network::{internal_types, types};
 use log::debug;
 use std::collections::HashMap;
@@ -63,7 +63,7 @@ impl firewall::FirewallDriver for FirewallD {
         todo!();
     }
 
-    fn setup_port_forward(&self, _setup_portfw: SetupPortForward) -> Result<(), Box<dyn Error>> {
+    fn setup_port_forward(&self, _setup_portfw: PortForwardConfig) -> Result<(), Box<dyn Error>> {
         todo!();
     }
 

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -1,37 +1,18 @@
 use crate::firewall;
+use crate::firewall::varktables;
+use crate::firewall::varktables::types::TeardownPolicy::OnComplete;
+use crate::firewall::varktables::types::{
+    get_network_chains, get_port_forwarding_chains, TeardownPolicy,
+};
 use crate::network::core_utils::CoreUtils;
 use crate::network::internal_types::{
-    SetupNetwork, SetupPortForward, TearDownNetwork, TeardownPortForward,
+    PortForwardConfig, SetupNetwork, TearDownNetwork, TeardownPortForward,
 };
 use iptables;
 use iptables::IPTables;
-use log::debug;
 use std::error::Error;
 
-const HEXMARK: &str = "0x2000";
 pub(crate) const MAX_HASH_SIZE: usize = 13;
-
-//  CHAIN NAMES
-const NAT: &str = "nat";
-const PRIV_CHAIN_NAME: &str = "NETAVARK_FORWARD";
-const HOSTPORT_DNAT_CHAIN: &str = "NETAVARK-HOSTPORT-DNAT";
-const HOSTPORT_SETMARK_CHAIN: &str = "NETAVARK-HOSTPORT-SETMARK";
-const NETAVARK_HOSTPORT_MASK_CHAIN: &str = "NETAVARK-HOSTPORT-MASQ";
-const CONTAINER_DN_CHAIN: &str = "NETAVARK-DN-";
-const CONTAINER_CHAIN: &str = "NETAVARK-";
-const PREROUTING_CHAIN: &str = "PREROUTING";
-const OUTPUT_CHAIN: &str = "OUTPUT";
-
-// JUMP DEST
-const POSTROUTING_JUMP: &str = "POSTROUTING";
-const FILTER_JUMP: &str = "filter";
-const MARK_JUMP: &str = "MARK";
-const DNAT_JUMP: &str = "DNAT";
-const MASQ_JUMP: &str = "MASQUERADE";
-const ACCEPT_JUMP: &str = "ACCEPT";
-
-const MULTICAST_NET_V4: &str = "224.0.0.0/4";
-const MULTICAST_NET_V6: &str = "ff00::/8";
 
 // Iptables driver - uses direct iptables commands via the iptables crate.
 pub struct IptablesDriver {
@@ -59,61 +40,15 @@ impl firewall::FirewallDriver for IptablesDriver {
                 if is_ipv6 {
                     conn = &self.conn6;
                 }
+                let chains = varktables::types::get_network_chains(
+                    conn,
+                    network.subnet,
+                    network_setup.network_hash_name.clone(),
+                    is_ipv6,
+                );
 
-                let prefixed_network_hash_name =
-                    format!("{}-{}", "NETAVARK", network_setup.network_hash_name);
-                add_chain_unique(conn, NAT, &prefixed_network_hash_name)?;
-
-                let nat_chain_rule = format!(
-                    "-s {} -j {}",
-                    network.subnet.to_string(),
-                    prefixed_network_hash_name
-                )
-                .to_string();
-                append_unique(conn, NAT, POSTROUTING_JUMP, &nat_chain_rule)?;
-
-                // declare the rule
-                let nat_rule =
-                    format!("-d {} -j {}", network.subnet.to_string(), ACCEPT_JUMP).to_string();
-
-                append_unique(conn, NAT, &prefixed_network_hash_name, &nat_rule)?;
-
-                //  Add first rule for the network
-                let mut multicast_dest = MULTICAST_NET_V4;
-                if is_ipv6 {
-                    multicast_dest = MULTICAST_NET_V6;
-                }
-                let masq_rule = format!("! -d {} -j MASQUERADE", multicast_dest).to_string();
-                append_unique(conn, NAT, &prefixed_network_hash_name, &masq_rule)?;
-
-                if !is_ipv6 {
-                    //  Add private chain name if it does not exist
-                    add_chain_unique(conn, FILTER_JUMP, PRIV_CHAIN_NAME)?;
-
-                    //  Create netavark firewall rule
-                    let netavark_fw = format!(
-                        "-m comment --comment 'netavark firewall plugin rules' -j {}",
-                        PRIV_CHAIN_NAME
-                    );
-                    // Insert the rule into the first position
-                    if !conn.exists(FILTER_JUMP, "FORWARD", &netavark_fw)? {
-                        conn.insert(FILTER_JUMP, "FORWARD", &netavark_fw, 1)
-                            .map(|_| debug_rule_create(FILTER_JUMP, "FORWARD", netavark_fw))?;
-                    }
-                    // Create incoming traffic rule
-                    // CNI did this by IP address, this is implemented per subnet
-                    let allow_incoming_rule = format!(
-                        "-d {} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
-                        network.subnet.to_string()
-                    );
-
-                    append_unique(conn, FILTER_JUMP, PRIV_CHAIN_NAME, &allow_incoming_rule)?;
-
-                    // Create outgoing traffic rule
-                    // CNI did this by IP address, this is implemented per subnet
-                    let allow_outgoing_rule =
-                        format!("-s {} -j ACCEPT", network.subnet.to_string());
-                    append_unique(conn, FILTER_JUMP, PRIV_CHAIN_NAME, &allow_outgoing_rule)?;
+                for chain in chains {
+                    chain.add_rules()?;
                 }
             }
         }
@@ -124,48 +59,41 @@ impl firewall::FirewallDriver for IptablesDriver {
     // a complete teardown.
     fn teardown_network(&self, tear: TearDownNetwork) -> Result<(), Box<dyn Error>> {
         // Remove network specific general NAT rules
-        if let Some(subnet) = tear.net.subnets {
+        if let Some(subnet) = tear.config.net.subnets {
             for network in subnet {
                 let is_ipv6 = network.subnet.network().is_ipv6();
                 let mut conn = &self.conn;
                 if is_ipv6 {
                     conn = &self.conn6;
                 }
+                let chains = get_network_chains(
+                    conn,
+                    network.subnet,
+                    tear.config.network_hash_name.clone(),
+                    is_ipv6,
+                );
+                for chain in &chains {
+                    // Because we only call teardown_network on complete teardown, we
+                    // just send true here
+                    chain.remove_rules(true)?;
+                }
 
-                // Remove outgoing traffic rule
-                // CNI did this by IP address, this is implemented per subnet
-                let allow_outgoing_rule = format!("-s {} -j ACCEPT", network.subnet.to_string());
-                append_unique(conn, FILTER_JUMP, PRIV_CHAIN_NAME, &allow_outgoing_rule)?;
-                if tear.complete_teardown && !is_ipv6 {
-                    let allow_incoming_rule = format!(
-                        "-d {} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
-                        network.subnet.to_string()
-                    );
-
-                    remove_if_rule_exists(
-                        conn,
-                        FILTER_JUMP,
-                        PRIV_CHAIN_NAME,
-                        &allow_incoming_rule,
-                    )?;
-
-                    // CNI did this by IP address, this is implemented per subnet
-                    let allow_outgoing_rule =
-                        format!("-s {} -j ACCEPT", network.subnet.to_string());
-                    remove_if_rule_exists(
-                        conn,
-                        FILTER_JUMP,
-                        PRIV_CHAIN_NAME,
-                        &allow_outgoing_rule,
-                    )?;
+                for chain in chains {
+                    match &chain.td_policy {
+                        None => {}
+                        Some(policy) => {
+                            if tear.complete_teardown && *policy == OnComplete {
+                                chain.remove()?;
+                            }
+                        }
+                    }
                 }
             }
         }
-
         Result::Ok(())
     }
 
-    fn setup_port_forward(&self, setup_portfw: SetupPortForward) -> Result<(), Box<dyn Error>> {
+    fn setup_port_forward(&self, setup_portfw: PortForwardConfig) -> Result<(), Box<dyn Error>> {
         // Need to enable sysctl localnet so that traffic can pass
         // through localhost to containers
         let is_ipv6 = setup_portfw.container_ip.is_ipv6();
@@ -173,7 +101,7 @@ impl firewall::FirewallDriver for IptablesDriver {
         if is_ipv6 {
             conn = &self.conn6;
         }
-        let network_interface = setup_portfw.net.network_interface;
+        let network_interface = &setup_portfw.net.network_interface;
         match network_interface {
             None => {}
             Some(i) => {
@@ -181,323 +109,37 @@ impl firewall::FirewallDriver for IptablesDriver {
                 CoreUtils::apply_sysctl_value(localnet_path.as_str(), "1")?;
             }
         }
-        let container_network_address = setup_portfw.network_address.subnet;
-        // Set up all chains
-        let network_dn_chain_name = CONTAINER_DN_CHAIN.to_owned() + &setup_portfw.network_hash_name;
-        let network_chain_name = CONTAINER_CHAIN.to_owned() + &setup_portfw.network_hash_name;
+        // let container_network_address = setup_portfw.network_address.subnet;
+        let chains = get_port_forwarding_chains(conn, &setup_portfw, is_ipv6);
 
-        let comment_network_cid = format!(
-            "-m comment --comment 'name: {} id: {}'",
-            setup_portfw.network_name, setup_portfw.container_id
-        );
-        let comment_dn_network_cid = format!(
-            "-m comment --comment 'dnat name: {} id: {}'",
-            setup_portfw.network_name, setup_portfw.container_id
-        );
-        // Make sure chains exist or create them
-        add_chain_unique(conn, NAT, HOSTPORT_DNAT_CHAIN)?;
-        add_chain_unique(conn, NAT, HOSTPORT_SETMARK_CHAIN)?;
-        add_chain_unique(conn, NAT, NETAVARK_HOSTPORT_MASK_CHAIN)?;
-        add_chain_unique(conn, NAT, &network_dn_chain_name)?;
-
-        // Setup one-off rules that have nothing to do with ports
-        // PREROUTING
-        let prerouting_rule = format!("-j {} -m addrtype --dst-type LOCAL", HOSTPORT_DNAT_CHAIN);
-        append_unique(conn, NAT, PREROUTING_CHAIN, &prerouting_rule)?;
-
-        // OUTPUT
-        let portmap_output_rule =
-            format!("-j {} -m addrtype --dst-type LOCAL", HOSTPORT_DNAT_CHAIN);
-        append_unique(conn, NAT, OUTPUT_CHAIN, &portmap_output_rule)?;
-
-        //  SETMARK-CHAIN
-        let setmark_rule = format!("-j {}  --set-xmark {}/{}", MARK_JUMP, HEXMARK, HEXMARK);
-        append_unique(conn, NAT, HOSTPORT_SETMARK_CHAIN, &setmark_rule)?;
-
-        //  HOSTPORT-MASQ
-        let hostport_masq_rule = format!(
-            "-j {} -m comment --comment 'netavark portfw masq mark' -m mark --mark {}/{}",
-            MASQ_JUMP, HEXMARK, HEXMARK
-        );
-        append_unique(conn, NAT, NETAVARK_HOSTPORT_MASK_CHAIN, &hostport_masq_rule)?;
-
-        // POSTROUTING
-        append_unique(
-            conn,
-            NAT,
-            POSTROUTING_JUMP,
-            &format!("-j {} ", NETAVARK_HOSTPORT_MASK_CHAIN),
-        )?;
-
-        append_unique(
-            conn,
-            NAT,
-            POSTROUTING_JUMP,
-            &format!(
-                "-j {} -s {} {}",
-                network_chain_name,
-                setup_portfw.container_ip.to_string(),
-                comment_network_cid
-            ),
-        )?;
-
-        // FOR EACH PORT
-        for i in setup_portfw.port_mappings.clone() {
-            // hostport dnat
-            let hostport_dnat_rule = format!(
-                "-j {} -p {} -m multiport --destination-ports {} {}",
-                network_dn_chain_name,
-                i.protocol,
-                i.host_port.to_string(),
-                comment_dn_network_cid
-            );
-            append_unique(conn, NAT, HOSTPORT_DNAT_CHAIN, &hostport_dnat_rule)?;
-            // dn container (the actual port usages)
-            let setmark_network_rule = format!(
-                "-j {} -s {} -p {} --dport {}",
-                HOSTPORT_SETMARK_CHAIN,
-                container_network_address.to_string(),
-                i.protocol,
-                i.host_port.to_string()
-            );
-            append_unique(conn, NAT, &network_dn_chain_name, &setmark_network_rule)?;
-            if !is_ipv6 {
-                let setmark_localhost_rule = format!(
-                    "-j {} -s 127.0.0.1 -p {} --dport {}",
-                    HOSTPORT_SETMARK_CHAIN,
-                    i.protocol,
-                    i.host_port.to_string()
-                );
-                append_unique(conn, NAT, &network_dn_chain_name, &setmark_localhost_rule)?;
-            }
-            let mut container_ip_value = setup_portfw.container_ip.to_string();
-            if is_ipv6 {
-                container_ip_value = format!("[{}]", container_ip_value)
-            }
-            let container_dest_rule = format!(
-                "-j {} -p {} --to-destination {}:{} --destination-port {}",
-                DNAT_JUMP,
-                i.protocol,
-                container_ip_value,
-                i.container_port.to_string(),
-                i.host_port.to_string()
-            );
-            append_unique(conn, NAT, &network_dn_chain_name, &container_dest_rule)?;
+        for chain in chains {
+            chain.add_rules()?;
         }
-
         Result::Ok(())
     }
 
     fn teardown_port_forward(&self, tear: TeardownPortForward) -> Result<(), Box<dyn Error>> {
-        let mut localhost_ip = "127.0.0.1";
-        let is_ipv6 = tear.container_ip.is_ipv6();
+        let is_ipv6 = tear.config.container_ip.is_ipv6();
         let mut conn = &self.conn;
         if is_ipv6 {
             conn = &self.conn6;
-            localhost_ip = "::1";
         }
-        let networks = tear.network.subnets.as_ref().ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::Other, "no network address provided")
-        })?;
-        let container_network_address = networks[0].subnet;
-        let network_dn_chain_name = CONTAINER_DN_CHAIN.to_owned() + tear.id_network_hash.as_ref();
-        let comment_dn_network_cid = format!(
-            "-m comment --comment 'dnat name: {} id: {}'",
-            tear.network_name, tear.container_id
-        );
-        let network_chain_name = CONTAINER_CHAIN.to_owned() + tear.id_network_hash.as_ref();
-        // First delete any container specific rules
-        // POSTROUTING
-        let comment_network_cid = format!(
-            "-m comment --comment 'name: {} id: {}'",
-            tear.network_name, tear.container_id
-        );
-        remove_if_rule_exists(
-            conn,
-            NAT,
-            POSTROUTING_JUMP,
-            &format!(
-                "-j {} -s {} {}",
-                network_chain_name,
-                tear.container_ip.to_string(),
-                comment_network_cid
-            ),
-        )?;
-        // Iterate on ports
-        for i in tear.port_mappings {
-            // hostport dnat
-            let hostport_dnat_rule = format!(
-                "-j {} -p {} -m multiport --destination-ports {} {}",
-                network_dn_chain_name,
-                i.protocol,
-                i.host_port.to_string(),
-                comment_dn_network_cid
-            );
-            remove_if_rule_exists(conn, NAT, HOSTPORT_DNAT_CHAIN, &hostport_dnat_rule)?;
-            // dn container (the actual port usages)
-            let setmark_network_rule = format!(
-                "-j {} -s {} -p {} --dport {}",
-                HOSTPORT_SETMARK_CHAIN,
-                container_network_address.to_string(),
-                i.protocol,
-                i.host_port.to_string()
-            );
-            remove_if_rule_exists(conn, NAT, &network_dn_chain_name, &setmark_network_rule)?;
-            let setmark_localhost_rule = format!(
-                "-j {} -s {} -p {} --dport {}",
-                HOSTPORT_SETMARK_CHAIN,
-                localhost_ip,
-                i.protocol,
-                i.host_port.to_string()
-            );
-            remove_if_rule_exists(conn, NAT, &network_dn_chain_name, &setmark_localhost_rule)?;
-            let container_dest_rule = format!(
-                "-j {} -p {} --to-destination {}:{} --destination-port {}",
-                DNAT_JUMP,
-                i.protocol,
-                tear.container_ip.to_string(),
-                i.container_port.to_string(),
-                i.host_port.to_string()
-            );
-            remove_if_rule_exists(conn, NAT, &network_dn_chain_name, &container_dest_rule)?;
-        }
-        // If last container on the network, then teardown network based rules
-        if tear.complete_teardown {
-            debug!("performing complete teardown");
-            let prefixed_network_hash_name = format!("{}-{}", "NETAVARK", tear.id_network_hash);
-            // Remove the network nat rule from POSTROUTING so chains
-            // can be deleted
-            let nat_chain_rule = format!(
-                "-s {} -j {}",
-                tear.network_address.subnet.to_string(),
-                prefixed_network_hash_name
-            );
 
-            remove_if_rule_exists(conn, NAT, POSTROUTING_JUMP, &nat_chain_rule)?;
-            // Remove the entire NETAVARK-<HASH> chain
-            remove_chain_and_rules(conn, NAT, &network_chain_name)?;
-            // Remove the entire NETAVARK-DN-<HASH> chain
-            remove_chain_and_rules(conn, NAT, &network_dn_chain_name)?;
+        let chains = get_port_forwarding_chains(conn, &tear.config, is_ipv6);
+
+        for chain in &chains {
+            chain.remove_rules(tear.complete_teardown)?;
+        }
+        for chain in &chains {
+            match &chain.td_policy {
+                None => {}
+                Some(policy) => {
+                    if tear.complete_teardown && *policy == TeardownPolicy::OnComplete {
+                        chain.remove()?;
+                    }
+                }
+            }
         }
         Result::Ok(())
     }
-}
-// append a rule to chain if it does not exist
-// Note: While there is an API provided for this exact thing, the API returns
-// an error that is not defined if the rule exists.  This function just returns
-// an error if there is a problem.
-fn append_unique(
-    driver: &IPTables,
-    table: &str,
-    chain: &str,
-    rule: &str,
-) -> Result<(), Box<dyn Error>> {
-    let exists = driver.exists(table, chain, rule)?;
-    if exists {
-        return Ok(());
-    }
-    debug_rule_exists(table, chain, rule.to_string());
-    if let Err(e) = driver
-        .append(table, chain, rule)
-        .map(|_| debug_rule_create(table, chain, rule.to_string()))
-    {
-        bail!(
-            "unable to append rule '{}' to table '{}': {}",
-            rule,
-            table,
-            e
-        )
-    }
-    Result::Ok(())
-}
-
-// add a chain if it does not exist, else do nothing
-fn add_chain_unique(driver: &IPTables, table: &str, new_chain: &str) -> Result<(), Box<dyn Error>> {
-    // Note: while there is an API provided to check if a chain exists in a table
-    // by iptables, it, for some reason, is slow.  Instead we just get a list of
-    // chains in a table and iterate.  Same is being done in golang implementations
-    let exists = chain_exists(driver, table, new_chain)?;
-    if exists {
-        debug_chain_exists(table, new_chain);
-        return Ok(());
-    }
-    driver
-        .new_chain(table, new_chain)
-        .map(|_| debug_chain_create(table, new_chain))
-}
-
-// returns a bool as to whether the chain exists
-fn chain_exists(driver: &IPTables, table: &str, chain: &str) -> Result<bool, Box<dyn Error>> {
-    let c = driver.list_chains(table)?;
-    if c.iter().any(|i| i == chain) {
-        debug_chain_exists(table, chain);
-        return serde::__private::Result::Ok(true);
-    }
-    serde::__private::Result::Ok(false)
-}
-
-fn remove_chain_and_rules(
-    driver: &IPTables,
-    table: &str,
-    chain: &str,
-) -> Result<(), Box<dyn Error>> {
-    let exists = chain_exists(driver, table, chain)?;
-    // If the chain is not there, we cannot delete the rules.  This
-    // should not be fatal
-    if !exists {
-        return Result::Ok(());
-    }
-    driver.flush_chain(table, chain)?;
-    driver.delete_chain(table, chain)
-}
-
-fn remove_if_rule_exists(
-    driver: &IPTables,
-    table: &str,
-    chain: &str,
-    rule: &str,
-) -> Result<(), Box<dyn Error>> {
-    // If the rule is not present, do not error
-    let exists = driver.exists(table, chain, rule)?;
-    if !exists {
-        debug_rule_no_exists(table, chain, rule.to_string());
-        return Ok(());
-    }
-    if let Err(e) = driver.delete(table, chain, rule) {
-        bail!(
-            "failed to remove rule '{}' from table '{}': {}",
-            rule,
-            chain,
-            e
-        )
-    }
-    Result::Ok(())
-}
-
-fn debug_chain_create(table: &str, chain: &str) {
-    debug!("chain {} created on table {}", chain, table);
-}
-
-fn debug_chain_exists(table: &str, chain: &str) {
-    debug!("chain {} exists on table {}", chain, table);
-}
-
-fn debug_rule_create(table: &str, chain: &str, rule: String) {
-    debug!(
-        "rule {} created on table {} and chain {}",
-        rule, table, chain
-    );
-}
-
-fn debug_rule_exists(table: &str, chain: &str, rule: String) {
-    debug!(
-        "rule {} exists on table {} and chain {}",
-        rule, table, chain
-    );
-}
-fn debug_rule_no_exists(table: &str, chain: &str, rule: String) {
-    debug!(
-        "no rule {} exists on table {} and chain {}",
-        rule, table, chain
-    );
 }

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -1,5 +1,5 @@
 use crate::network::internal_types::{
-    SetupNetwork, SetupPortForward, TearDownNetwork, TeardownPortForward,
+    PortForwardConfig, SetupNetwork, TearDownNetwork, TeardownPortForward,
 };
 use log::{debug, info};
 use std::env;
@@ -8,6 +8,7 @@ use zbus::Connection;
 
 pub mod firewalld;
 pub mod iptables;
+mod varktables;
 
 // Firewall drivers have the ability to set up per-network firewall forwarding
 // and port mappings.
@@ -18,7 +19,7 @@ pub trait FirewallDriver {
     fn teardown_network(&self, tear: TearDownNetwork) -> Result<(), Box<dyn Error>>;
 
     // Set up port-forwarding firewall rules for a given container.
-    fn setup_port_forward(&self, setup_pw: SetupPortForward) -> Result<(), Box<dyn Error>>;
+    fn setup_port_forward(&self, setup_pw: PortForwardConfig) -> Result<(), Box<dyn Error>>;
     // Tear down port-forwarding firewall rules for a single container.
     fn teardown_port_forward(&self, teardown_pf: TeardownPortForward)
         -> Result<(), Box<dyn Error>>;

--- a/src/firewall/varktables/helpers.rs
+++ b/src/firewall/varktables/helpers.rs
@@ -1,0 +1,113 @@
+use iptables::IPTables;
+use log::debug;
+use std::error::Error;
+
+// append a rule to chain if it does not exist
+// Note: While there is an API provided for this exact thing, the API returns
+// an error that is not defined if the rule exists.  This function just returns
+// an error if there is a problem.
+pub fn append_unique(
+    driver: &IPTables,
+    table: &str,
+    chain: &str,
+    rule: &str,
+) -> Result<(), Box<dyn Error>> {
+    let exists = driver.exists(table, chain, rule)?;
+    if exists {
+        return Ok(());
+    }
+    debug_rule_exists(table, chain, rule.to_string());
+    if let Err(e) = driver
+        .append(table, chain, rule)
+        .map(|_| debug_rule_create(table, chain, rule.to_string()))
+    {
+        bail!(
+            "unable to append rule '{}' to table '{}': {}",
+            rule,
+            table,
+            e
+        )
+    }
+    Result::Ok(())
+}
+
+// add a chain if it does not exist, else do nothing
+pub fn add_chain_unique(
+    driver: &IPTables,
+    table: &str,
+    new_chain: &str,
+) -> Result<(), Box<dyn Error>> {
+    // Note: while there is an API provided to check if a chain exists in a table
+    // by iptables, it, for some reason, is slow.  Instead we just get a list of
+    // chains in a table and iterate.  Same is being done in golang implementations
+    let exists = chain_exists(driver, table, new_chain)?;
+    if exists {
+        debug_chain_exists(table, new_chain);
+        return Ok(());
+    }
+    driver
+        .new_chain(table, new_chain)
+        .map(|_| debug_chain_create(table, new_chain))
+}
+
+// returns a bool as to whether the chain exists
+fn chain_exists(driver: &IPTables, table: &str, chain: &str) -> Result<bool, Box<dyn Error>> {
+    let c = driver.list_chains(table)?;
+    if c.iter().any(|i| i == chain) {
+        debug_chain_exists(table, chain);
+        return serde::__private::Result::Ok(true);
+    }
+    serde::__private::Result::Ok(false)
+}
+
+pub fn remove_if_rule_exists(
+    driver: &IPTables,
+    table: &str,
+    chain: &str,
+    rule: &str,
+) -> Result<(), Box<dyn Error>> {
+    // If the rule is not present, do not error
+    let exists = driver.exists(table, chain, rule)?;
+    if !exists {
+        debug_rule_no_exists(table, chain, rule.to_string());
+        return Ok(());
+    }
+    if let Err(e) = driver.delete(table, chain, rule) {
+        bail!(
+            "failed to remove rule '{}' from table '{}': {}",
+            rule,
+            chain,
+            e
+        )
+    }
+    Result::Ok(())
+}
+
+fn debug_chain_create(table: &str, chain: &str) {
+    debug!("chain {} created on table {}", chain, table);
+}
+
+fn debug_chain_exists(table: &str, chain: &str) {
+    debug!("chain {} exists on table {}", chain, table);
+}
+
+pub fn debug_rule_create(table: &str, chain: &str, rule: String) {
+    debug!(
+        "rule {} created on table {} and chain {}",
+        rule, table, chain
+    );
+}
+
+fn debug_rule_exists(table: &str, chain: &str, rule: String) {
+    debug!(
+        "rule {} exists on table {} and chain {}",
+        rule, table, chain
+    );
+}
+
+fn debug_rule_no_exists(table: &str, chain: &str, rule: String) {
+    debug!(
+        "no rule {} exists on table {} and chain {}",
+        rule, table, chain
+    );
+}

--- a/src/firewall/varktables/mod.rs
+++ b/src/firewall/varktables/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod helpers;
+pub(crate) mod types;

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -1,0 +1,420 @@
+use crate::firewall::varktables::helpers::{
+    add_chain_unique, append_unique, remove_if_rule_exists,
+};
+use crate::firewall::varktables::types::TeardownPolicy::OnComplete;
+use crate::network::internal_types::PortForwardConfig;
+use ipnet::IpNet;
+use iptables::IPTables;
+use std::error::Error;
+
+//  Chain names
+const NAT: &str = "nat";
+const FILTER: &str = "filter";
+const POSTROUTING: &str = "POSTROUTING";
+const PREROUTING: &str = "PREROUTING";
+const NETAVARK_FORWARD: &str = "NETAVARK_FORWARD";
+const OUTPUT: &str = "OUTPUT";
+const FORWARD: &str = "FORWARD";
+const ACCEPT: &str = "ACCEPT";
+const NETAVARK_HOSTPORT_DNAT: &str = "NETAVARK-HOSTPORT-DNAT";
+const NETAVARK_HOSTPORT_SETMARK: &str = "NETAVARK-HOSTPORT-SETMARK";
+const NETAVARK_HOSTPORT_MASK: &str = "NETAVARK-HOSTPORT-MASQ";
+const MASQUERADE: &str = "MASQUERADE";
+const MARK: &str = "MARK";
+const DNAT: &str = "DNAT";
+
+const CONTAINER_DN_CHAIN: &str = "NETAVARK-DN-";
+const CONTAINER_CHAIN: &str = "NETAVARK-";
+
+const HEXMARK: &str = "0x2000";
+
+const MULTICAST_NET_V4: &str = "224.0.0.0/4";
+const MULTICAST_NET_V6: &str = "ff00::/8";
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum TeardownPolicy {
+    OnComplete,
+    Never,
+}
+
+#[derive(Clone, Debug)]
+pub struct VarkRule {
+    // Formatted string of the rule itself
+    pub rule: String,
+    pub td_policy: Option<TeardownPolicy>,
+    pub position: Option<i32>,
+}
+
+impl VarkRule {
+    fn new(rule: String, policy: Option<TeardownPolicy>) -> VarkRule {
+        VarkRule {
+            rule,
+            td_policy: policy,
+            position: None,
+        }
+    }
+    fn to_str(&self) -> &str {
+        &self.rule
+    }
+}
+// Varkchain is an iptable chain with extra info
+pub struct VarkChain<'a> {
+    // name of chain
+    pub chain_name: String,
+    // should the chain be created by us
+    pub create: bool,
+    // the connection to iptables, v4 or v6
+    pub driver: &'a IPTables,
+    // an array of iptables rules to be added to the chain
+    pub rules: Vec<VarkRule>,
+    // name of table
+    pub table: String,
+    // if the chain should be removed
+    pub td_policy: Option<TeardownPolicy>,
+}
+
+impl<'a> VarkChain<'a> {
+    fn new(
+        driver: &IPTables,
+        table: String,
+        chain_name: String,
+        td_policy: Option<TeardownPolicy>,
+    ) -> VarkChain {
+        VarkChain {
+            driver,
+            chain_name,
+            table,
+            rules: vec![],
+            create: false,
+            td_policy,
+        }
+    }
+
+    //  create a queue of rules in a vector
+    fn build_rule(&mut self, rule: VarkRule) {
+        self.rules.push(rule)
+    }
+
+    // actually add the rules to iptables
+    pub fn add_rules(&self) -> Result<(), Box<dyn Error>> {
+        // If the chain needs to be created, we make it
+        if self.create {
+            add_chain_unique(self.driver, &self.table, &self.chain_name)?;
+        }
+        for rule in &self.rules {
+            // If the rule comes with an optional position, then instead of append
+            // we should use insert if it does not already exist
+            match rule.position {
+                None => {
+                    append_unique(self.driver, &self.table, &self.chain_name, rule.to_str())?;
+                }
+                Some(pos) => {
+                    if !self
+                        .driver
+                        .exists(&self.table, &self.chain_name, &rule.rule)?
+                    {
+                        self.driver
+                            .insert(&self.table, &self.chain_name, &rule.rule, pos)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    //  remove a vector of rules
+    pub fn remove_rules(&self, complete_teardown: bool) -> Result<(), Box<dyn Error>> {
+        for rule in &self.rules.clone() {
+            // If the rule policy is Never or this is not a
+            // complete teardown of the network, then we skip removal
+            // of the rule
+            match rule.clone().td_policy {
+                None => {}
+                Some(policy) => {
+                    if policy == TeardownPolicy::Never || !complete_teardown {
+                        continue;
+                    }
+                }
+            }
+            remove_if_rule_exists(self.driver, &self.table, &self.chain_name, rule.to_str())?;
+        }
+        Ok(())
+    }
+
+    // remove the chain itself.
+    pub fn remove(&self) -> Result<(), Box<dyn Error>> {
+        // this might be a perf hit but we are going to start this
+        // way and think of faster AND logical approach.
+        let remaining_rules = self.driver.list(&self.table, &self.chain_name)?;
+
+        // if for some reason there is a rule left, dont remove the chain and
+        // also dont make this a fatal error.  The vec returned by list always
+        // reserves [0] for the chain name (-A chain_name), hence the <= 1
+        if remaining_rules.len() <= 1 {
+            self.driver.delete_chain(&self.table, &self.chain_name)?;
+        }
+        Result::Ok(())
+    }
+}
+
+pub fn get_network_chains(
+    conn: &'_ IPTables,
+    network: IpNet,
+    network_hash_name: String,
+    is_ipv6: bool,
+) -> Vec<VarkChain<'_>> {
+    let mut chains = Vec::new();
+    let prefixed_network_hash_name = format!("{}-{}", "NETAVARK", network_hash_name);
+
+    // NETAVARK-HASH
+    let mut hashed_network_chain = VarkChain::new(
+        conn,
+        NAT.to_string(),
+        prefixed_network_hash_name.clone(),
+        Some(OnComplete),
+    );
+    hashed_network_chain.create = true;
+
+    hashed_network_chain.build_rule(VarkRule::new(
+        format!("-d {} -j {}", network.to_string(), ACCEPT),
+        Some(TeardownPolicy::OnComplete),
+    ));
+
+    let mut multicast_dest = MULTICAST_NET_V4;
+    if is_ipv6 {
+        multicast_dest = MULTICAST_NET_V6;
+    }
+    hashed_network_chain.build_rule(VarkRule::new(
+        format!("! -d {} -j {}", multicast_dest, MASQUERADE),
+        Some(TeardownPolicy::Never),
+    ));
+    chains.push(hashed_network_chain);
+
+    // POSTROUTING
+    let mut postrouting_chain =
+        VarkChain::new(conn, NAT.to_string(), POSTROUTING.to_string(), None);
+    postrouting_chain.build_rule(VarkRule::new(
+        format!(
+            "-s {} -j {}",
+            network.to_string(),
+            prefixed_network_hash_name
+        ),
+        Some(TeardownPolicy::Never),
+    ));
+    chains.push(postrouting_chain);
+    if !is_ipv6 {
+        // NETAVARK_FORWARD
+        let mut netavark_forward_chain =
+            VarkChain::new(conn, FILTER.to_string(), NETAVARK_FORWARD.to_string(), None);
+        netavark_forward_chain.create = true;
+
+        // Create incoming traffic rule
+        // CNI did this by IP address, this is implemented per subnet
+        netavark_forward_chain.build_rule(VarkRule::new(
+            format!(
+                "-d {} -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
+                network.to_string()
+            ),
+            Some(TeardownPolicy::OnComplete),
+        ));
+
+        // Create outgoing traffic rule
+        // CNI did this by IP address, this is implemented per subnet
+        netavark_forward_chain.build_rule(VarkRule::new(
+            format!("-s {} -j ACCEPT", network.to_string()),
+            Some(TeardownPolicy::OnComplete),
+        ));
+        chains.push(netavark_forward_chain);
+
+        // FORWARD chain
+        // Insert the rule into the first position
+        let mut forward_chain = VarkChain::new(conn, FILTER.to_string(), FORWARD.to_string(), None);
+        forward_chain.build_rule(VarkRule {
+            rule: format!(
+                "-m comment --comment 'netavark firewall plugin rules' -j {}",
+                NETAVARK_FORWARD
+            ),
+            position: Some(1),
+            td_policy: Some(TeardownPolicy::OnComplete),
+        });
+        chains.push(forward_chain);
+    }
+
+    chains
+}
+
+pub fn get_port_forwarding_chains<'a>(
+    conn: &'a IPTables,
+    pfwd: &PortForwardConfig,
+    is_ipv6: bool,
+    // portmappings: Vec<PortMapping>,
+) -> Vec<VarkChain<'a>> {
+    let mut localhost_ip = "127.0.0.1";
+    if is_ipv6 {
+        localhost_ip = "::1";
+    }
+    let mut chains = Vec::new();
+
+    // Set up all chains
+    let network_dn_chain_name = CONTAINER_DN_CHAIN.to_owned() + &pfwd.network_hash_name;
+
+    let comment_network_cid = format!(
+        "-m comment --comment 'name: {} id: {}'",
+        pfwd.network_name, pfwd.container_id
+    );
+    let comment_dn_network_cid = format!(
+        "-m comment --comment 'dnat name: {} id: {}'",
+        pfwd.network_name, pfwd.container_id
+    );
+
+    // // NETAVARK-HASH
+
+    // NETAVARK-DN-HASH
+    let mut netavark_hashed_dn_chain = VarkChain::new(
+        conn,
+        NAT.to_string(),
+        CONTAINER_DN_CHAIN.to_string() + &pfwd.network_hash_name,
+        Some(OnComplete),
+    );
+
+    // NETAVARK_HOSTPORT_DNAT
+    // Determination to create the chain is done only
+    // if there are port mappings
+    let mut netavark_hostport_dn_chain = VarkChain::new(
+        conn,
+        NAT.to_string(),
+        NETAVARK_HOSTPORT_DNAT.to_string(),
+        None,
+    );
+
+    // Setup one-off rules that have nothing to do with ports
+    // PREROUTING
+    let mut prerouting_chain = VarkChain::new(conn, NAT.to_string(), PREROUTING.to_string(), None);
+    prerouting_chain.build_rule(VarkRule::new(
+        format!("-j {} -m addrtype --dst-type LOCAL", NETAVARK_HOSTPORT_DNAT),
+        Some(TeardownPolicy::Never),
+    ));
+
+    //  OUTPUT
+    let mut output_chain = VarkChain::new(conn, NAT.to_string(), OUTPUT.to_string(), None);
+    output_chain.build_rule(VarkRule::new(
+        format!("-j {} -m addrtype --dst-type LOCAL", NETAVARK_HOSTPORT_DNAT),
+        Some(TeardownPolicy::Never),
+    ));
+
+    // NETAVARK-HOSTPORT-SETMARK
+    let mut netavark_hostport_setmark = VarkChain::new(
+        conn,
+        NAT.to_string(),
+        NETAVARK_HOSTPORT_SETMARK.to_string(),
+        None,
+    );
+    netavark_hostport_setmark.create = true;
+    netavark_hostport_setmark.build_rule(VarkRule::new(
+        format!("-j {}  --set-xmark {}/{}", MARK, HEXMARK, HEXMARK),
+        Some(TeardownPolicy::Never),
+    ));
+    chains.push(netavark_hostport_setmark);
+
+    //  NETAVARK-HOSTPORT-MASQ
+    let mut netavark_hostport_masq_chain = VarkChain::new(
+        conn,
+        NAT.to_string(),
+        NETAVARK_HOSTPORT_MASK.to_string(),
+        None,
+    );
+    netavark_hostport_masq_chain.create = true;
+    netavark_hostport_masq_chain.build_rule(VarkRule::new(
+        format!(
+            "-j {} -m comment --comment 'netavark portfw masq mark' -m mark --mark {}/{}",
+            MASQUERADE, HEXMARK, HEXMARK
+        ),
+        Some(TeardownPolicy::Never),
+    ));
+    netavark_hostport_masq_chain.create = true;
+    chains.push(netavark_hostport_masq_chain);
+
+    //  POSTROUTING
+    let mut postrouting = VarkChain::new(conn, NAT.to_string(), POSTROUTING.to_string(), None);
+    postrouting.build_rule(VarkRule::new(
+        format!("-j {} ", NETAVARK_HOSTPORT_MASK),
+        None,
+    ));
+    let netavark_hashed_network_chain_name = CONTAINER_CHAIN.to_string() + &pfwd.network_hash_name;
+    postrouting.build_rule(VarkRule::new(
+        format!(
+            "-j {} -s {} {}",
+            netavark_hashed_network_chain_name,
+            pfwd.container_ip.to_string(),
+            comment_network_cid
+        ),
+        None,
+    ));
+    chains.push(postrouting);
+
+    //  Determine if we need to create chains
+    if !pfwd.port_mappings.is_empty() {
+        netavark_hostport_dn_chain.create = true;
+        netavark_hashed_dn_chain.create = true;
+    }
+
+    for i in pfwd.port_mappings.clone() {
+        // hostport dnat
+        netavark_hostport_dn_chain.build_rule(VarkRule::new(
+            format!(
+                "-j {} -p {} -m multiport --destination-ports {} {}",
+                network_dn_chain_name,
+                i.protocol,
+                i.host_port.to_string(),
+                comment_dn_network_cid
+            ),
+            None,
+        ));
+        // dn container (the actual port usages)
+        netavark_hashed_dn_chain.build_rule(VarkRule::new(
+            format!(
+                "-j {} -s {} -p {} --dport {}",
+                NETAVARK_HOSTPORT_SETMARK,
+                pfwd.network_address.subnet.to_string(),
+                i.protocol,
+                i.host_port.to_string()
+            ),
+            None,
+        ));
+
+        netavark_hashed_dn_chain.build_rule(VarkRule::new(
+            format!(
+                "-j {} -s {} -p {} --dport {}",
+                NETAVARK_HOSTPORT_SETMARK,
+                localhost_ip,
+                i.protocol,
+                i.host_port.to_string()
+            ),
+            None,
+        ));
+
+        let mut container_ip_value = pfwd.container_ip.to_string();
+        if is_ipv6 {
+            container_ip_value = format!("[{}]", container_ip_value)
+        }
+        netavark_hashed_dn_chain.build_rule(VarkRule::new(
+            format!(
+                "-j {} -p {} --to-destination {}:{} --destination-port {}",
+                DNAT,
+                i.protocol,
+                container_ip_value,
+                i.container_port.to_string(),
+                i.host_port.to_string()
+            ),
+            None,
+        ));
+    }
+
+    //  The order is important here.  Be certain before changing it
+    chains.push(netavark_hashed_dn_chain);
+    chains.push(netavark_hostport_dn_chain);
+    chains.push(prerouting_chain);
+    chains.push(output_chain);
+
+    chains
+}

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -1,26 +1,13 @@
 use crate::network::types;
-use crate::network::types::{Network, Subnet};
+use crate::network::types::Subnet;
 use std::net::IpAddr;
 
 //  Teardown contains options for tearing down behind a container
 #[derive(Clone, Debug)]
 pub struct TeardownPortForward {
-    // network object
-    pub network: Network,
-    // container id
-    pub container_id: String,
-    // portmappings
-    pub port_mappings: Vec<types::PortMapping>,
-    // name of network
-    pub network_name: String,
-    // network id
-    pub id_network_hash: String,
-    // ip address of container
-    pub container_ip: IpAddr,
+    pub config: PortForwardConfig,
     // remove network related information
     pub complete_teardown: bool,
-    // container ip
-    pub network_address: Subnet,
 }
 
 //  SetupNetwork contains options for setting up a container
@@ -34,14 +21,12 @@ pub struct SetupNetwork {
 
 #[derive(Clone, Debug)]
 pub struct TearDownNetwork {
-    //  network object
-    pub net: types::Network,
-    // complete teardown of network
+    pub config: SetupNetwork,
     pub complete_teardown: bool,
 }
 
 #[derive(Clone, Debug)]
-pub struct SetupPortForward {
+pub struct PortForwardConfig {
     //  network object
     pub net: types::Network,
     // id of container

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -48,16 +48,11 @@ fw_driver=iptables
 
     # TODO check iptables
     # iptables -L ...
+
+    run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json teardown $(get_container_netns_path)
 }
 
 @test "$fw_driver - ipv6 bridge" {
-
-    ### FIXME set sysctl in netavark
-    run_in_host_netns sh -c "echo 0 > /proc/sys/net/ipv6/conf/default/accept_dad"
-    #run_in_container_netns sh -c "echo 0 > /proc/sys/net/ipv6/conf/default/accept_dad"
-
-    #run_in_host_netns sh -c "echo 0 > /proc/sys/net/ipv6/conf/default/accept_ra"
-
     run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge.json setup $(get_container_netns_path)
     result="$output"
     assert_json "$result" 'has("podman1")' == "true" "object key exists"
@@ -90,6 +85,8 @@ fw_driver=iptables
     assert "$output" =~ "127.0.0.1" "Loopback adapter is up (has address)"
 
     run_in_host_netns ping6 -c 1 fd10:88:a::2
+
+    run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge.json teardown $(get_container_netns_path)
 }
 
 @test "$fw_driver - port forwarding ipv4 - tcp" {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -483,8 +483,7 @@ EOF
 
     done
 
-    ## FIXME cleanup is broken atm
-    #run_netavark teardown $(get_container_netns_path) <<<"$config"
+    run_netavark teardown $(get_container_netns_path) <<<"$config"
 }
 
 #################


### PR DESCRIPTION
Switch to a model where we use a rule generator approach for setup and
teardown.  This eliminates a significant amount duplicate code.

Signed-off-by: Brent Baude <bbaude@redhat.com>