### PR TITLE
Support internal networks

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -90,7 +90,6 @@ impl Core {
         //we have the bridge name but we must iterate for all the available gateways
         for (idx, subnet) in network.subnets.iter().flatten().enumerate() {
             let subnet_mask_cidr = subnet.subnet.prefix_len();
-
             if let Some(gw) = subnet.gateway {
                 let gw_net = match gw {
                     IpAddr::V4(gw4) => match ipnet::Ipv4Net::new(gw4, subnet_mask_cidr) {

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -12,6 +12,24 @@ fw_driver=iptables
     assert "${lines[0]}" "==" "[INFO  netavark::firewall] Using iptables firewall driver" "iptables driver is in use"
 }
 
+@test "$fw_driver - internal network" {
+   run_in_host_netns iptables -t nat -nvL
+   before="$output"
+
+   run_netavark --file ${TESTSDIR}/testfiles/internal.json setup $(get_container_netns_path)
+
+   run_in_host_netns iptables -t nat -nvL
+   after="$output"
+   assert "$before" == "$after" "make sure tables have not changed"
+
+   run_in_container_netns ip route show
+   assert "default" "!~" "$output" "No default route for internal networks"
+
+   run_in_container_netns ping -c 1 10.88.0.1
+
+   run_netavark --file ${TESTSDIR}/testfiles/internal.json teardown $(get_container_netns_path)
+}
+
 @test "$fw_driver - simple bridge" {
     run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json setup $(get_container_netns_path)
     result="$output"

--- a/test/testfiles/internal.json
+++ b/test/testfiles/internal.json
@@ -1,0 +1,29 @@
+{
+    "container_id": "6ce776ea58b5",
+    "container_name": "testcontainer",
+    "networks": {
+        "podman": {
+            "interface_name": "eth0",
+            "static_ips": [
+                "10.88.0.2"
+            ]
+        }
+    },
+    "network_info": {
+        "podman": {
+            "dns_enabled": true,
+            "driver": "bridge",
+            "id": "53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
+            "internal": true,
+            "ipv6_enabled": true,
+            "name": "podman",
+            "network_interface": "podman0",
+            "subnets": [
+                {
+                    "gateway": "10.88.0.1",
+                    "subnet": "10.88.0.0/16"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
An internal network should have no nat or port mappings as it is
supposed to a "closed" network.

Fixes #: 105

Signed-off-by: Brent Baude <bbaude@redhat.com>