### PR TITLE
Use `AsRef<str>` for sysctl bits

### DIFF
--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -106,7 +106,7 @@ impl firewall::FirewallDriver for IptablesDriver {
             None => {}
             Some(i) => {
                 let localnet_path = format!("net.ipv4.conf.{}.route_localnet", i);
-                CoreUtils::apply_sysctl_value(localnet_path.as_str(), "1")?;
+                CoreUtils::apply_sysctl_value(localnet_path, "1")?;
             }
         }
         // let container_network_address = setup_portfw.network_address.subnet;

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -866,8 +866,8 @@ impl CoreUtils {
         }
         if ipv6_enabled {
             // Do not accept Router Advertisements if ipv6 is enabled
-            let k = format!("net/ipv6/conf/{}/accept_ra", ifname);
-            match CoreUtils::apply_sysctl_value(&k, "0") {
+            match CoreUtils::apply_sysctl_value(format!("net/ipv6/conf/{}/accept_ra", ifname), "0")
+            {
                 Ok(_) => {}
                 Err(err) => {
                     return Err(std::io::Error::new(
@@ -1265,8 +1265,13 @@ impl CoreUtils {
         ctl.value_string()
     }
 
-    // set a sysctl value by value's namespace
-    pub fn apply_sysctl_value(ns_value: &str, val: &str) -> Result<String, SysctlError> {
+    /// Set a sysctl value by value's namespace.
+    pub fn apply_sysctl_value(
+        ns_value: impl AsRef<str>,
+        val: impl AsRef<str>,
+    ) -> Result<String, SysctlError> {
+        let ns_value = ns_value.as_ref();
+        let val = val.as_ref();
         debug!("Setting sysctl value for {} to {}", ns_value, val);
         let ctl = sysctl::Ctl::new(ns_value)?;
         ctl.set_value_string(val)


### PR DESCRIPTION
I was randomly looking at another PR, and noticed that in about
half the cases, we heap allocate a `String`, but then use `as_str()`
to borrow it briefly.  In other places we directly use `&str`.
It maximizes flexibility for the caller to use `AsRef<str>`; then
we don't need a `.as_str()` dance, we can just directly pass ownership
of the string into the function.

To pick one other random real world example of this, see:
https://github.com/rust-lang/rust/blob/9bb77da74dac4768489127d21e32db19b59ada5b/compiler/rustc_errors/src/diagnostic_builder.rs#L198