### PR TITLE
portmap to specific host ip address

### DIFF
--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -169,3 +169,25 @@ fw_driver=iptables
 @test "$fw_driver - port range forwarding dual - tcp" {
     test_port_fw ip=dual proto=tcp range=3
 }
+
+
+@test "$fw_driver - port forwarding with hostip ipv4 - tcp" {
+    add_dummy_interface_on_host dummy0 "172.16.0.1/24"
+    run_in_host_netns ip addr
+    test_port_fw hostip="172.16.0.1"
+}
+
+@test "$fw_driver - port range forwarding with hostip ipv6 - tcp" {
+    add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
+    test_port_fw ip=6 hostip="fd65:8371:648b:0c06::1"
+}
+
+@test "$fw_driver - port range forwarding with hostip ipv4 - udp" {
+    add_dummy_interface_on_host dummy0 "172.16.0.1/24"
+    test_port_fw proto=udp hostip="172.16.0.1"
+}
+
+@test "$fw_driver - port range forwarding with hostip ipv6 - udp" {
+    add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
+    test_port_fw ip=6 proto=udp hostip="fd65:8371:648b:0c06::1"
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -596,3 +596,20 @@ function gateway_from_subnet() {
 function setup_sctp_kernel_module() {
     modprobe sctp || skip "cannot load sctp kernel module"
 }
+
+
+#################################
+#  add_dummy_interface_on_host  #
+#################################
+# create a dummy interface with the given name and subnet
+# the first arg is the name
+# the second arg is the subnet (optional)
+function add_dummy_interface_on_host() {
+    name="$1"
+    ipaddr="$2"
+    run_in_host_netns ip link add "$name" type dummy
+    if [ -n "$ipaddr" ]; then
+        run_in_host_netns ip addr add "$ipaddr" dev "$name"
+    fi
+    run_in_host_netns ip link set "$name" up
+}


### PR DESCRIPTION
add the ability to handle port mapping to a specific host ip address
instead of 0.0.0.0.

Signed-off-by: Brent Baude <bbaude@redhat.com>