### PR TITLE
Change to making only a single call to setup/tear down

### DIFF
--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -3,9 +3,11 @@ use crate::firewall::varktables::helpers::{
 };
 use crate::firewall::varktables::types::TeardownPolicy::OnComplete;
 use crate::network::internal_types::PortForwardConfig;
+use crate::network::types::Subnet;
 use ipnet::IpNet;
 use iptables::IPTables;
 use std::error::Error;
+use std::net::IpAddr;
 
 //  Chain names
 const NAT: &str = "nat";
@@ -246,6 +248,8 @@ pub fn get_network_chains(
 pub fn get_port_forwarding_chains<'a>(
     conn: &'a IPTables,
     pfwd: &PortForwardConfig,
+    container_ip: &IpAddr,
+    network_address: &Subnet,
     is_ipv6: bool,
     // portmappings: Vec<PortMapping>,
 ) -> Vec<VarkChain<'a>> {
@@ -344,7 +348,7 @@ pub fn get_port_forwarding_chains<'a>(
         format!(
             "-j {} -s {} {}",
             netavark_hashed_network_chain_name,
-            pfwd.container_ip.to_string(),
+            container_ip.to_string(),
             comment_network_cid
         ),
         None,
@@ -383,7 +387,7 @@ pub fn get_port_forwarding_chains<'a>(
             format!(
                 "-j {} -s {} -p {} --dport {}",
                 NETAVARK_HOSTPORT_SETMARK,
-                pfwd.network_address.subnet.to_string(),
+                network_address.subnet.to_string(),
                 i.protocol,
                 &host_port
             ),
@@ -398,7 +402,7 @@ pub fn get_port_forwarding_chains<'a>(
             None,
         ));
 
-        let mut container_ip_value = pfwd.container_ip.to_string();
+        let mut container_ip_value = container_ip.to_string();
         if is_ipv6 {
             container_ip_value = format!("[{}]", container_ip_value)
         }

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -37,8 +37,20 @@ pub struct PortForwardConfig {
     pub network_name: String,
     // hash id for the network
     pub network_hash_name: String,
-    // ip addresses of the container
-    pub container_ip: IpAddr,
-    // network address (subnet)
-    pub network_address: Subnet,
+    // ipv4 address of the container to bind to.
+    // If multiple v4 addresses are present, use the first one for this.
+    // At least one of container_ip_v6 and container_ip_v6 must be set. Both can
+    // be set at the same time as well.
+    pub container_ip_v4: Option<IpAddr>,
+    // subnet associated with the IPv4 address.
+    // Must be set if v4 address is set.
+    pub subnet_v4: Option<Subnet>,
+    // ipv6 address of the container.
+    // If multiple v6 addresses are present, use the first one for this.
+    // At least one of container_ip_v6 and container_ip_v6 must be set. Both can
+    // be set at the same time as well.
+    pub container_ip_v6: Option<IpAddr>,
+    // subnet associated with the ipv6 address.
+    // Must be set if the v6 address is set.
+    pub subnet_v6: Option<Subnet>,
 }


### PR DESCRIPTION
This is necessary to simplify operation for port forwarding via firewalld. Instead of requiring two separate calls to add and remove port forward rules for v4 and v6, both are now carried in the struct, which means I don't have to worry about one of my DBus calls messing up the other. For iptables it's mostly a wash, the code gets a slight bit more complex, but not significantly.
