### PR TITLE
core: add support setting for `MTU` on `macvlan` interface from netavark config

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -322,6 +322,24 @@ impl Core {
             }
         }
 
+        // mtu to configure, 0 means it was not set do nothing.
+        let mut mtu_config: u32 = 0;
+        if let Some(options_map) = network.options.as_ref() {
+            if let Some(mtu) = options_map.get("mtu") {
+                match mtu.parse() {
+                    Ok(mtu) => {
+                        mtu_config = mtu;
+                    }
+                    Err(err) => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("unable to parse mtu: {}", err),
+                        ))
+                    }
+                }
+            }
+        }
+
         // get master interface name
         let mut master_ifname: String = match network.network_interface.as_ref() {
             None => {
@@ -402,6 +420,7 @@ impl Core {
             &master_ifname,
             &container_macvlan_name,
             macvlan_mode,
+            mtu_config,
             address_vector,
             netns,
         ) {
@@ -428,6 +447,7 @@ impl Core {
         master_ifname: &str,
         container_macvlan: &str,
         macvlan_mode: u32,
+        mtu: u32,
         netns_ipaddr: Vec<ipnet::IpNet>,
         netns: &str,
     ) -> Result<String, std::io::Error> {
@@ -435,6 +455,7 @@ impl Core {
             master_ifname,
             container_macvlan,
             macvlan_mode,
+            mtu,
             netns,
         ) {
             Ok(_) => (),

--- a/test/300-macvlan.bats
+++ b/test/300-macvlan.bats
@@ -24,6 +24,24 @@ function setup() {
     assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
     assert_json "$link_info" ".[].linkinfo.info_kind" "==" "macvlan" "Container interface is a macvlan device"
 
+    ipaddr="10.88.0.2/16"
+    run_in_container_netns ip addr show eth0
+    assert "$output" "=~" "$ipaddr" "IP address matches container address"
+    assert_json "$result" ".podman.interfaces.eth0.subnets[0].ipnet" "==" "$ipaddr" "Result contains correct IP address"
+}
+
+@test "macvlan setup with mtu" {
+    run_netavark --file ${TESTSDIR}/testfiles/macvlan-mtu.json setup $(get_container_netns_path)
+    result="$output"
+
+    mac=$(jq -r '.podman.interfaces.eth0.mac_address' <<< "$result" )
+    # check that interface exists
+    run_in_container_netns ip -j --details link show eth0
+    link_info="$output"
+    assert_json "$link_info" ".[].mtu" "=="  "1400" "MTU matches configured MTU"
+    assert_json "$link_info" ".[].address" "=="  "$mac" "MAC matches container mac"
+    assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
+    assert_json "$link_info" ".[].linkinfo.info_kind" "==" "macvlan" "Container interface is a macvlan device"
 
     ipaddr="10.88.0.2/16"
     run_in_container_netns ip addr show eth0

--- a/test/testfiles/macvlan-mtu.json
+++ b/test/testfiles/macvlan-mtu.json
@@ -1,0 +1,35 @@
+{
+    "container_id": "someID",
+    "container_name": "someName",
+    "networks": {
+       "podman": {
+          "static_ips": [
+             "10.88.0.2"
+          ],
+          "interface_name": "eth0"
+       }
+    },
+    "network_info": {
+       "podman": {
+          "name": "podman",
+          "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+          "driver": "macvlan",
+          "network_interface": "dummy0",
+          "subnets": [
+             {
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
+             }
+          ],
+          "ipv6_enabled": false,
+          "internal": false,
+          "dns_enabled": false,
+          "ipam_options": {
+             "driver": "host-local"
+          },
+          "options": {
+             "mtu":   "1400"
+          }
+       }
+    }
+ }


### PR DESCRIPTION
Netavark config accepts `MTU` as network option so allow users to
configure the same for `macvlan` interface.

See https://github.com/containernetworking/plugins/blob/master/plugins/main/macvlan/macvlan.go#L181

Follow up PR to: https://github.com/containers/netavark/pull/111

Closes: https://github.com/containers/netavark/issues/152