### PR TITLE
handle errors from the netns properly

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -202,7 +202,7 @@ impl Core {
             Err(err) => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("failed while configuring network interface {}:", err),
+                    format!("failed while configuring network interface: {}", err),
                 ))
             }
         };
@@ -226,7 +226,7 @@ impl Core {
                 }
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("failed while configuring network interface {}:", err),
+                    format!("failed while configuring network interface: {}", err),
                 ));
             }
         };

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -1095,11 +1095,22 @@ impl CoreUtils {
                     Ok(())
                 });
                 match thread_handle.join() {
-                    Ok(_) => {}
+                    Ok(ok) => {
+                        // read the result from the thread
+                        match ok {
+                            Ok(_) => {}
+                            Err(err) => {
+                                return Err(std::io::Error::new(
+                                    std::io::ErrorKind::Other,
+                                    format!("from network namespace: {}", err),
+                                ));
+                            }
+                        }
+                    }
                     Err(err) => {
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::Other,
-                            format!("from container namespace: {:?}", err),
+                            format!("error waiting for thread: {:?}", err),
                         ));
                     }
                 }

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -107,6 +107,14 @@ fw_driver=iptables
     run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge.json teardown $(get_container_netns_path)
 }
 
+@test "$fw_driver - check error message from netns thread" {
+    # create interface in netns to force error
+    run_in_container_netns ip link add eth0 type dummy
+
+    expected_rc=1 run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json setup $(get_container_netns_path)
+    assert_json ".error" "failed to configure bridge and veth interface: failed while configuring network interface: from network namespace: interface eth0 already exists on container namespace" "interface exists on netns"
+}
+
 @test "$fw_driver - port forwarding ipv4 - tcp" {
     test_port_fw
 }


### PR DESCRIPTION
thread.join() returns a result which contains the return result from the thread
so we have to get the actual error from the result.

Added a test to make sure it works.
