### PR TITLE
Makefile: install target independent of build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ docs: ## build the docs on the host
 	$(MAKE) -C docs
 
 .PHONY: install
-install: docs build
+install:
 	install ${SELINUXOPT} -D -m0755 bin/netavark $(DESTDIR)/$(LIBEXECPODMAN)/netavark
 	$(MAKE) -C install
 


### PR DESCRIPTION
You will need to run `make` and `make install` separately.

We will not need any `-nobuild` targets which should make life a little
easier for packagers.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@flouthoc @baude @mheon @cevich @Luap99 PTAL.