### PR TITLE
dns: support for container `aliases` if specified from container managers.

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -230,6 +230,7 @@ impl Setup {
                 if let Err(er) = aardvark_interface.commit_netavark_entries(
                     network_options.container_name,
                     network_options.container_id,
+                    network_options.networks,
                     response.clone(),
                 ) {
                     debug!("Error while applying dns entries {}", er);

--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -212,11 +212,13 @@ impl Aardvark {
         &mut self,
         container_name: String,
         container_id: String,
+        per_network_opts: HashMap<String, types::PerNetworkOptions>,
         netavark_res: HashMap<String, types::StatusBlock>,
     ) -> Result<()> {
         let entries = Aardvark::netavark_response_to_aardvark_entries(
             container_name,
             container_id,
+            per_network_opts,
             netavark_res,
         );
         self.commit_entries(entries)?;
@@ -227,6 +229,7 @@ impl Aardvark {
     pub fn netavark_response_to_aardvark_entries(
         container_name: String,
         container_id: String,
+        per_network_opts: HashMap<String, types::PerNetworkOptions>,
         netavark_res: HashMap<String, types::StatusBlock>,
     ) -> Vec<AardvarkEntry> {
         let mut result: Vec<AardvarkEntry> = Vec::<AardvarkEntry>::new();
@@ -265,6 +268,17 @@ impl Aardvark {
                                                 container_ip_v6 = container_ip.to_string();
                                             }
 
+                                            let mut name_vector =
+                                                Vec::from([container_name.clone()]);
+                                            if let Some(network_opt) =
+                                                &per_network_opts.get(&network_name)
+                                            {
+                                                if let Some(alias) = &network_opt.aliases {
+                                                    let aliases = alias.clone();
+                                                    name_vector.extend(aliases);
+                                                }
+                                            }
+
                                             result.push(AardvarkEntry {
                                                 network_name: network_name.clone(),
                                                 network_gateway_v4,
@@ -272,7 +286,7 @@ impl Aardvark {
                                                 container_id: container_id.clone(),
                                                 container_ip_v6,
                                                 container_ip_v4,
-                                                container_name: Vec::from([container_name.clone()]),
+                                                container_name: name_vector,
                                             });
                                         }
                                     }

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -84,8 +84,8 @@ pub struct PerNetworkOptions {
 
     // DNS is not yet implemented
 
-    // #[serde(rename = "aliases")]
-    // pub aliases: Option<Vec<String>>,
+    #[serde(rename = "aliases")]
+    pub aliases: Option<Vec<String>>,
 
     /// InterfaceName for this container. Required.
     #[serde(rename = "interface_name")]


### PR DESCRIPTION
Podman can pass network aliases via `--network-alias` so netavark should read it and pass
relevent config to aardvark

Supports DNS resolution with network aliases.