### PR TITLE
core: populate default search domain in `/etc/resolv.conf`

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -1,5 +1,8 @@
 //Following module contains all the network constants
 
+// default search domain
+pub static PODMAN_DEFAULT_SEARCH_DOMAIN: &str = "dns.podman";
+
 // Available macvlan modes
 // TODO: remove constants from here after https://github.com/little-dude/netlink/pull/200
 pub const MACVLAN_MODE_PRIVATE: u32 = 1;

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -25,6 +25,7 @@ impl Core {
         //  StatusBlock response
         let mut response = types::StatusBlock {
             dns_server_ips: Some(Vec::<IpAddr>::new()),
+            dns_search_domains: Some(Vec::<String>::new()),
             interfaces: Some(HashMap::new()),
         };
         // get bridge name
@@ -178,6 +179,11 @@ impl Core {
         let _ = response.interfaces.insert(interfaces);
         if network.dns_enabled {
             let _ = response.dns_server_ips.insert(nameservers);
+            // Note: this is being added so podman setup is backward compatible with the design
+            // which we had with dnsname/dnsmasq. I belive this can be fixed in later releases.
+            let _ = response
+                .dns_search_domains
+                .insert(vec![constants::PODMAN_DEFAULT_SEARCH_DOMAIN.to_string()]);
         }
         Ok(response)
     }
@@ -314,6 +320,7 @@ impl Core {
         //  StatusBlock response
         let mut response = types::StatusBlock {
             dns_server_ips: Some(Vec::<IpAddr>::new()),
+            dns_search_domains: Some(Vec::<String>::new()),
             interfaces: Some(HashMap::new()),
         };
         // Default MACVLAN_MODE to bridge or get from driver options

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -145,8 +145,8 @@ pub struct StatusBlock {
     // having fewer than ndots dots. So we dont
     // need this as of now.
     // DNS search domains for /etc/resolv.conf
-    // #[serde(rename = "dns_search_domains")]
-    // pub dns_search_domains: Option<Vec<String>>,
+    #[serde(rename = "dns_search_domains")]
+    pub dns_search_domains: Option<Vec<String>>,
 
     // DNS nameservers /etc/resolv.conf will be populated by these
     #[serde(rename = "dns_server_ips")]


### PR DESCRIPTION
Podman setup expects a default search domain in `/etc/resolv.conf` i.e
`dns.podman` lets supports that.
