### PR TITLE
Fix lint problems with rust v1.58

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -127,7 +127,7 @@ impl Core {
 
             // Build up response information
             let container_address: ipnet::IpNet =
-                match format!("{}/{}", static_ips[idx].to_string(), subnet_mask_cidr).parse() {
+                match format!("{}/{}", static_ips[idx], subnet_mask_cidr).parse() {
                     Ok(i) => i,
                     Err(e) => {
                         return Err(Error::new(std::io::ErrorKind::Other, e));
@@ -414,7 +414,7 @@ impl Core {
 
             // Build up response information
             let container_address: ipnet::IpNet =
-                match format!("{}/{}", static_ips[idx].to_string(), subnet_mask_cidr).parse() {
+                match format!("{}/{}", static_ips[idx], subnet_mask_cidr).parse() {
                     Ok(i) => i,
                     Err(e) => {
                         return Err(Error::new(std::io::ErrorKind::Other, e));

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -183,8 +183,7 @@ impl CoreUtils {
                         std::io::ErrorKind::Other,
                         format!(
                             "Unable to resolve physical address for interface {}: {}",
-                            ifname.to_string(),
-                            err
+                            ifname, err
                         ),
                     ));
                 }
@@ -852,9 +851,8 @@ impl CoreUtils {
                 if ipv6_enabled {
                     // Disable duplicate address detection if ipv6 enabled
                     // Do not accept Router Advertisements if ipv6 is enabled
-                    let br_accept_dad =
-                        format!("/proc/sys/net/ipv6/conf/{}/accept_dad", ifname.to_string());
-                    let br_accept_ra = format!("net/ipv6/conf/{}/accept_ra", ifname.to_string());
+                    let br_accept_dad = format!("/proc/sys/net/ipv6/conf/{}/accept_dad", ifname);
+                    let br_accept_ra = format!("net/ipv6/conf/{}/accept_ra", ifname);
                     if let Err(e) = CoreUtils::apply_sysctl_value(&br_accept_dad, "0") {
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::Other,


### PR DESCRIPTION
Unnecessary use of to_string() throws an lint error since v1.58 so we
should fix that.