### PR TITLE
Makefile: allow installation of debug binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ docs: ## build the docs on the host
 
 .PHONY: install
 install:
-	install ${SELINUXOPT} -D -m0755 bin/netavark $(DESTDIR)/$(LIBEXECPODMAN)/netavark
+	install ${SELINUXOPT} -D -m0755 bin/netavark$(if $(debug),.debug,) $(DESTDIR)/$(LIBEXECPODMAN)/netavark
 	$(MAKE) -C docs install
 
 .PHONY: uninstall


### PR DESCRIPTION
Distro packaging needs unstripped binaries to create its debuginfo
packages.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@flouthoc @mheon @baude @Luap99 PTAL