### PR TITLE
start aardvark only after we write config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "netavark"
-version = "0.0.1"
+version = "1.0.0-dev"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -32,6 +32,7 @@ impl Teardown {
         &self,
         input_file: String,
         config_dir: String,
+        aardvark_bin: String,
         rootless: bool,
     ) -> Result<(), Box<dyn Error>> {
         debug!("{:?}", "Tearing down..");
@@ -45,11 +46,11 @@ impl Teardown {
             }
         };
 
-        if Aardvark::check_aardvark_support() {
+        if Path::new(&aardvark_bin).exists() {
             // stop dns server first before netavark clears the interface
             let path = Path::new(&config_dir).join("aardvark-dns".to_string());
             if let Ok(path_string) = path.into_os_string().into_string() {
-                let mut aardvark_interface = Aardvark::new(path_string, rootless);
+                let mut aardvark_interface = Aardvark::new(path_string, rootless, aardvark_bin);
                 if let Err(er) =
                     aardvark_interface.delete_from_netavark_entries(network_options.clone())
                 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
         .unwrap_or_else(|| String::from("/usr/libexec/podman/aardvark-dns"));
     let result = match opts.subcmd {
         SubCommand::Setup(setup) => setup.exec(file, config, aardvark_bin, rootless),
-        SubCommand::Teardown(teardown) => teardown.exec(file, config, rootless),
+        SubCommand::Teardown(teardown) => teardown.exec(file, config, aardvark_bin,rootless),
         SubCommand::Version(version) => version.exec(),
     };
 


### PR DESCRIPTION
This saves startup time since aardvark does not have to read the same
config twice. Also improve the error handling. We should not ignore errors
such as EPERM, etc...