### PR TITLE
start aardvark only after we write config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "netavark"
-version = "0.0.1"
+version = "1.0.0-dev"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -9,9 +9,10 @@ use crate::network::internal_types::{PortForwardConfig, SetupNetwork};
 use crate::network::types::Subnet;
 use crate::network::{core_utils, types};
 use clap::Parser;
-use log::debug;
+use log::{debug, info};
 use std::collections::HashMap;
 use std::error::Error;
+use std::fs;
 use std::net::IpAddr;
 use std::path::Path;
 
@@ -215,29 +216,49 @@ impl Setup {
             }
         }
 
-        if Aardvark::check_aardvark_support() {
-            let path = Path::new(&config_dir).join("aardvark-dns".to_string());
+        if Path::new(&aardvark_bin).exists() {
+            let path = Path::new(&config_dir).join("aardvark-dns");
 
-            if let Ok(path_string) = path.into_os_string().into_string() {
-                let mut aardvark_interface = Aardvark::new(path_string, rootless);
-                if let Err(er) = aardvark_interface
-                    .clone()
-                    .start_aardvark_server_if_not_running(&aardvark_bin)
-                {
-                    debug!("Error while trying to start aardvark server {}", er);
+            match fs::create_dir(path.as_path()) {
+                Ok(_) => {}
+                // ignore error when path already exists
+                Err(ref e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(e) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("failed to create aardvark-dns directory: {}", e),
+                    )
+                    .into());
                 }
-
-                if let Err(er) = aardvark_interface.commit_netavark_entries(
-                    network_options.container_name,
-                    network_options.container_id,
-                    network_options.networks,
-                    response.clone(),
-                ) {
-                    debug!("Error while applying dns entries {}", er);
-                }
-            } else {
-                debug!("Unable to parse aardvark config path");
             }
+
+            let path_string = match path.into_os_string().into_string() {
+                Ok(path) => path,
+                Err(_) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "failed to convert path to String",
+                    )
+                    .into());
+                }
+            };
+
+            let mut aardvark_interface = Aardvark::new(path_string, rootless, aardvark_bin);
+
+            if let Err(er) = aardvark_interface.commit_netavark_entries(
+                network_options.container_name,
+                network_options.container_id,
+                network_options.networks,
+                response.clone(),
+            ) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Error while applying dns entries: {}", er),
+                )
+                .into());
+            }
+        } else {
+            info!("dns disabled because aardvark-dns path does not exists");
         }
         debug!("{:#?}", response);
         let response_json = serde_json::to_string(&response)?;

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -32,6 +32,7 @@ impl Teardown {
         &self,
         input_file: String,
         config_dir: String,
+        aardvark_bin: String,
         rootless: bool,
     ) -> Result<(), Box<dyn Error>> {
         debug!("{:?}", "Tearing down..");
@@ -45,11 +46,11 @@ impl Teardown {
             }
         };
 
-        if Aardvark::check_aardvark_support() {
+        if Path::new(&aardvark_bin).exists() {
             // stop dns server first before netavark clears the interface
             let path = Path::new(&config_dir).join("aardvark-dns".to_string());
             if let Ok(path_string) = path.into_os_string().into_string() {
-                let mut aardvark_interface = Aardvark::new(path_string, rootless);
+                let mut aardvark_interface = Aardvark::new(path_string, rootless, aardvark_bin);
                 if let Err(er) =
                     aardvark_interface.delete_from_netavark_entries(network_options.clone())
                 {

--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -12,8 +12,6 @@ use std::net::Ipv4Addr;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-const AARDVARK_BINARY: [&str; 1] = ["/usr/libexec/podman/aardvark-dns"];
-
 #[derive(Debug, Clone)]
 pub struct AardvarkEntry {
     pub network_name: String,
@@ -31,21 +29,17 @@ pub struct Aardvark {
     pub config: String,
     // tells if container is rootfull or rootless
     pub rootless: bool,
+    // path to the aardvark-dns binary
+    pub aardvark_bin: String,
 }
 
 impl Aardvark {
-    pub fn new(config: String, rootless: bool) -> Self {
-        Aardvark { config, rootless }
-    }
-
-    pub fn check_aardvark_support() -> bool {
-        for key in AARDVARK_BINARY {
-            if Path::new(key).exists() {
-                return true;
-            }
+    pub fn new(config: String, rootless: bool, aardvark_bin: String) -> Self {
+        Aardvark {
+            config,
+            rootless,
+            aardvark_bin,
         }
-        log::debug!("No aardvark support found");
-        false
     }
 
     // On success retuns aardvark server's pid or returns -1;
@@ -81,27 +75,7 @@ impl Aardvark {
         false
     }
 
-    pub fn start_aardvark_server_if_not_running(&mut self, aardvark_bin: &str) -> Result<()> {
-        let aardvark_pid = self.get_aardvark_pid();
-        if aardvark_pid != -1 {
-            // check if pid is running
-            match signal::kill(Pid::from_raw(aardvark_pid), Signal::SIGWINCH) {
-                Ok(_) => {
-                    log::debug!("Found aardvark server running");
-                    // process is running do nothing
-                    return Ok(());
-                }
-                _ => {
-                    log::debug!("No aardvark server found of pid {}", aardvark_pid);
-                }
-            }
-        }
-
-        if !Path::new(&self.config).exists() {
-            // silently try to create empty config dir if its not there
-            let _ = fs::create_dir(&self.config);
-        }
-
+    pub fn start_aardvark_server(&self) -> Result<()> {
         log::debug!("Spawning aardvark server");
 
         let mut aardvark_args = vec![];
@@ -116,13 +90,15 @@ impl Aardvark {
         }
 
         aardvark_args.extend(vec![
-            aardvark_bin,
+            self.aardvark_bin.as_str(),
             "--config",
             &self.config,
             "-p",
             "53",
             "run",
         ]);
+
+        log::debug!("start aardvark-dns: {:?}", aardvark_args);
 
         Command::new(&aardvark_args[0])
             .args(&aardvark_args[1..])
@@ -133,16 +109,29 @@ impl Aardvark {
         Ok(())
     }
 
-    pub fn notify(&mut self) -> Result<()> {
+    pub fn notify(&mut self, start: bool) -> Result<()> {
         let aardvark_pid = self.get_aardvark_pid();
         if aardvark_pid != -1 {
-            signal::kill(Pid::from_raw(aardvark_pid), Signal::SIGHUP)?;
-        } else {
+            match signal::kill(Pid::from_raw(aardvark_pid), Signal::SIGHUP) {
+                Ok(_) => return Ok(()),
+                Err(err) => {
+                    // ESRCH == process does not exists
+                    if err != nix::errno::Errno::ESRCH {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("failed to send SIGHUP to aardvark: {}", err),
+                        ));
+                    }
+                }
+            }
+        }
+        if !start {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                "Invalid pid to notify",
+                "aardvark pid not found",
             ));
         }
+        self.start_aardvark_server()?;
 
         Ok(())
     }
@@ -222,7 +211,7 @@ impl Aardvark {
             netavark_res,
         );
         self.commit_entries(entries)?;
-        self.notify()?;
+        self.notify(true)?;
         Ok(())
     }
 
@@ -343,7 +332,7 @@ impl Aardvark {
             }
         }
         if modified {
-            self.notify()?;
+            self.notify(false)?;
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
         .unwrap_or_else(|| String::from("/usr/libexec/podman/aardvark-dns"));
     let result = match opts.subcmd {
         SubCommand::Setup(setup) => setup.exec(file, config, aardvark_bin, rootless),
-        SubCommand::Teardown(teardown) => teardown.exec(file, config, rootless),
+        SubCommand::Teardown(teardown) => teardown.exec(file, config, aardvark_bin, rootless),
         SubCommand::Version(version) => version.exec(),
     };
 


### PR DESCRIPTION
This saves startup time since aardvark does not have to read the same
config twice. Also improve the error handling. We should not ignore errors
such as EPERM, etc...

Signed-off-by: Paul Holzinger <pholzing@redhat.com>
Signed-off-by: Brent Baude <bbaude@redhat.com>