### PR TITLE
do not remove NETAVARK_FORWARD rule on teardown 

### DIFF
--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -232,7 +232,7 @@ pub fn get_network_chains(
                 NETAVARK_FORWARD
             ),
             position: Some(1),
-            td_policy: Some(TeardownPolicy::OnComplete),
+            td_policy: Some(TeardownPolicy::Never),
         });
         chains.push(forward_chain);
     }


### PR DESCRIPTION
When we have two containers on different networks running and stop one
of them we still need the NETAVARK_FORWARD rule in the FORWARD chain.

If this rule is removed the containers lose connections if the default
FORWARD policy is DROP.

test: add iptables rule check

Add tests to check the exact iptables rules.