### PR TITLE
Add host_ip and container_ip version matching to iptables `get_port_forwarding_chains`

### DIFF
--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -345,6 +345,21 @@ pub fn get_port_forwarding_chains<'a>(
     }
 
     for i in pfwd.port_mappings.clone() {
+        if let Ok(ip) = i.host_ip.parse::<IpAddr>() {
+            match ip {
+                IpAddr::V4(_) => {
+                    if is_ipv6 {
+                        continue;
+                    }
+                }
+                IpAddr::V6(_) => {
+                    if !is_ipv6 {
+                        continue;
+                    }
+                }
+            }
+        }
+
         // hostport dnat
         let is_range = i.range > 1;
         let mut host_port = i.host_port.to_string();

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -218,9 +218,20 @@ fw_driver=iptables
     test_port_fw hostip="172.16.0.1"
 }
 
+@test "$fw_driver - port forwarding with hostip ipv4 dual stack- tcp" {
+    add_dummy_interface_on_host dummy0 "172.16.0.1/24"
+    run_in_host_netns ip addr
+    test_port_fw ip=dual hostip="172.16.0.1"
+}
+
 @test "$fw_driver - port range forwarding with hostip ipv6 - tcp" {
     add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
     test_port_fw ip=6 hostip="fd65:8371:648b:0c06::1"
+}
+
+@test "$fw_driver - port range forwarding with hostip ipv6 dual stack - tcp" {
+    add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
+    test_port_fw ip=dual hostip="fd65:8371:648b:0c06::1"
 }
 
 @test "$fw_driver - port range forwarding with hostip ipv4 - udp" {

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -212,9 +212,20 @@ function teardown() {
     test_port_fw hostip="172.16.0.1"
 }
 
+@test "$fw_driver - port forwarding with hostip ipv4 dual stack- tcp" {
+    add_dummy_interface_on_host dummy0 "172.16.0.1/24"
+    run_in_host_netns ip addr
+    test_port_fw ip=dual hostip="172.16.0.1"
+}
+
 @test "$fw_driver - port range forwarding with hostip ipv6 - tcp" {
     add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
     test_port_fw ip=6 hostip="fd65:8371:648b:0c06::1"
+}
+
+@test "$fw_driver - port range forwarding with hostip ipv6 dual stack - tcp" {
+    add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
+    test_port_fw ip=dual hostip="fd65:8371:648b:0c06::1"
 }
 
 @test "$fw_driver - port range forwarding with hostip ipv4 - udp" {


### PR DESCRIPTION
In my (limited) testing, this fixes the issue described in #232. I'm not very familiar with netavark or iptables but I hope I didn't miss anything. If there are issues, I'd be happy to improve the solution with input on what's lacking.

I think the test file `ipv6-bridge.json` could be changed to show the behavior from #232 but I'm not sure how to exactly.

I skimmed the firewalld.rs and I think the issue is present there too. I think I can't test the firewalld implementation since my system is still using firewalld 1.0.1 and the bats tests emit `(skipped: TODO: Firewalld driver swapped with iptables until firewalld 1.1.0)`.