### PR TITLE
core,macvlan: add `gateway` from spec as default route to `macvlan` interface

### DIFF
--- a/test/300-macvlan.bats
+++ b/test/300-macvlan.bats
@@ -28,6 +28,11 @@ function setup() {
     run_in_container_netns ip addr show eth0
     assert "$output" "=~" "$ipaddr" "IP address matches container address"
     assert_json "$result" ".podman.interfaces.eth0.subnets[0].ipnet" "==" "$ipaddr" "Result contains correct IP address"
+
+    # check gateway assignment
+    run_in_container_netns ip r
+    assert "$output" "=~" "default via 10.88.0.1" "gateway must be there in default route"
+    assert_json "$result" ".podman.interfaces.eth0.subnets[0].gateway" == "10.88.0.1" "Result contains gateway address"
 }
 
 @test "macvlan setup with mtu" {


### PR DESCRIPTION
Gateway must be added as default route to `macvlan` interface.

Since gateway is already there in netavark config following config just
makes sure that we parse and add it to interface's default route instead
of adding no route at all.

Closes: https://github.com/containers/netavark/issues/234