### PR TITLE
use local cargo dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,0 @@
-# Use vendor for everything
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ target/
 targets/
 *.swp
 netavark.1
-vendor/winapi*gnu*/lib/*.a
-vendor/**/*.dll
+vendor/
 .idea/*

--- a/DISTRO_PACKAGE.md
+++ b/DISTRO_PACKAGE.md
@@ -42,6 +42,19 @@ a tarball. You can download them with the following:
 
 `https://github.com/containers/netavark/releases/download/v{version}/netavark-v{version}.tar.gz`
 
+And then create a cargo config file to point it to the vendor dir.
+```
+tar xvf %{SOURCE}
+mkdir -p .cargo
+cat >.cargo/config << EOF
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
+```
+
 The Fedora packaging sources for Netavark are available at the [Netavark
 dist-git](https://src.fedoraproject.org/rpms/netavark).
 

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -19,7 +19,6 @@ _run_noarg() {
 _run_build() {
     # Assume we're on a fast VM, compile everything needed by the
     # rest of CI since subsequent tasks may have limited resources.
-	make vendor
     make all debug=1
     make build_unit  # reuses some debug binaries
     make all  # optimized/non-debug binaries
@@ -36,7 +35,6 @@ EOF
 }
 
 _run_validate() {
-	make vendor
     make validate
 }
 
@@ -48,7 +46,6 @@ _run_verify_vendor() {
 }
 
 _run_unit() {
-	cargo vendor
     make unit
 }
 


### PR DESCRIPTION
We should not try to build with deps from the vendor directory locally.
This will force me to run make vendor manually if I pull in new deps.

When distros want to build with bundeld deps they should a) download
the linked vendor tarball which we should provide for the releases and
b) create the cargo config since to let cargo use the vendor dir.
```
tar xvf %{SOURCE1}
mkdir -p .cargo

cat >.cargo/config << EOF
[source.crates-io]
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"
EOF
```

see https://src.fedoraproject.org/rpms/rust-coreos-installer/blob/rawhide/f/rust-coreos-installer.spec#_86

Signed-off-by: Paul Holzinger <pholzing@redhat.com>