### PR TITLE
test: use regex to validate version

### DIFF
--- a/test/001-basic.bats
+++ b/test/001-basic.bats
@@ -7,11 +7,11 @@ load helpers
 
 @test "netavark version" {
     run_netavark --version
-    assert "netavark 1.0.1-dev" "expected version"
+    assert "$output" =~ "netavark 1\.[0-9]+\.[0-9]+(-rc|-dev)?" "expected version"
 
     run_netavark version
     json="$output"
-    assert_json "$json" ".version" == "1.0.1-dev" "correct version"
+    assert_json "$json" ".version" =~ "^1\.[0-9]+\.[0-9]+(-rc[0-9]|-dev)?" "correct version"
     assert_json "$json" ".commit" =~ "[0-9a-f]{40}" "shows commit sha"
     assert_json "$json" ".build_time" =~ "20.*" "show build date"
     assert_json "$json" ".target" =~ ".*" "contains target string"


### PR DESCRIPTION
Use a regex in the tests to validate the version.
It will cover all 1... versions.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>