### PR TITLE
macvlan: support `--internal` `macvlan` network with no default gateway in routes

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -398,35 +398,38 @@ impl Core {
         // prepare a vector of static aps with appropriate cidr
         for (idx, subnet) in network.subnets.iter().flatten().enumerate() {
             let subnet_mask_cidr = subnet.subnet.prefix_len();
-            if let Some(gw) = subnet.gateway {
-                let gw_net = match gw {
-                    IpAddr::V4(gw4) => match ipnet::Ipv4Net::new(gw4, subnet_mask_cidr) {
-                        Ok(dest) => ipnet::IpNet::from(dest),
-                        Err(err) => {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::Other,
-                                format!(
-                                    "failed to parse address {}/{}: {}",
-                                    gw4, subnet_mask_cidr, err
-                                ),
-                            ))
-                        }
-                    },
-                    IpAddr::V6(gw6) => match ipnet::Ipv6Net::new(gw6, subnet_mask_cidr) {
-                        Ok(dest) => ipnet::IpNet::from(dest),
-                        Err(err) => {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::Other,
-                                format!(
-                                    "failed to parse address {}/{}: {}",
-                                    gw6, subnet_mask_cidr, err
-                                ),
-                            ))
-                        }
-                    },
-                };
+            // Only add gateway to route if macvlan is not marked as an internal network
+            if !network.internal {
+                if let Some(gw) = subnet.gateway {
+                    let gw_net = match gw {
+                        IpAddr::V4(gw4) => match ipnet::Ipv4Net::new(gw4, subnet_mask_cidr) {
+                            Ok(dest) => ipnet::IpNet::from(dest),
+                            Err(err) => {
+                                return Err(std::io::Error::new(
+                                    std::io::ErrorKind::Other,
+                                    format!(
+                                        "failed to parse address gateway address while configuring macvlan {}/{}: {}",
+                                        gw4, subnet_mask_cidr, err
+                                    ),
+                                ))
+                            }
+                        },
+                        IpAddr::V6(gw6) => match ipnet::Ipv6Net::new(gw6, subnet_mask_cidr) {
+                            Ok(dest) => ipnet::IpNet::from(dest),
+                            Err(err) => {
+                                return Err(std::io::Error::new(
+                                    std::io::ErrorKind::Other,
+                                    format!(
+                                        "failed to parse address gateway address while configuring macvlan {}/{}: {}",
+                                        gw6, subnet_mask_cidr, err
+                                    ),
+                                ))
+                            }
+                        },
+                    };
 
-                gw_ipaddr_vector.push(gw_net)
+                    gw_ipaddr_vector.push(gw_net)
+                }
             }
 
             // Build up response information

--- a/test/300-macvlan.bats
+++ b/test/300-macvlan.bats
@@ -35,6 +35,28 @@ function setup() {
     assert_json "$result" ".podman.interfaces.eth0.subnets[0].gateway" == "10.88.0.1" "Result contains gateway address"
 }
 
+@test "macvlan setup internal" {
+    run_netavark --file ${TESTSDIR}/testfiles/macvlan-internal.json setup $(get_container_netns_path)
+    result="$output"
+
+    mac=$(jq -r '.podman.interfaces.eth0.mac_address' <<< "$result" )
+    # check that interface exists
+    run_in_container_netns ip -j --details link show eth0
+    link_info="$output"
+    assert_json "$link_info" ".[].address" "=="  "$mac" "MAC matches container mac"
+    assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
+    assert_json "$link_info" ".[].linkinfo.info_kind" "==" "macvlan" "Container interface is a macvlan device"
+
+    ipaddr="10.88.0.2/16"
+    run_in_container_netns ip addr show eth0
+    assert "$output" "=~" "$ipaddr" "IP address matches container address"
+    assert_json "$result" ".podman.interfaces.eth0.subnets[0].ipnet" "==" "$ipaddr" "Result contains correct IP address"
+
+    # internal macvlan must not contain
+    run_in_container_netns ip r
+    assert "$output" !~ 'default' "macvlan must not contain default gateway in route at all"
+}
+
 @test "macvlan setup with mtu" {
     run_netavark --file ${TESTSDIR}/testfiles/macvlan-mtu.json setup $(get_container_netns_path)
     result="$output"

--- a/test/testfiles/macvlan-internal.json
+++ b/test/testfiles/macvlan-internal.json
@@ -1,0 +1,32 @@
+{
+    "container_id": "someID",
+    "container_name": "someName",
+    "networks": {
+       "podman": {
+          "static_ips": [
+             "10.88.0.2"
+          ],
+          "interface_name": "eth0"
+       }
+    },
+    "network_info": {
+       "podman": {
+          "name": "podman",
+          "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+          "driver": "macvlan",
+          "network_interface": "dummy0",
+          "subnets": [
+             {
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
+             }
+          ],
+          "ipv6_enabled": false,
+          "internal": true,
+          "dns_enabled": false,
+          "ipam_options": {
+             "driver": "host-local"
+          }
+       }
+    }
+ }


### PR DESCRIPTION
Higher level container managers like `podman` can choose to create `macvlan` networks
with no default gateway by setting `--internal` as `true` in netavark
spec.

This can allow other tools and users to create macvlan networks without
default gateway routes but container manager like `podman` must allow
`macvlan` with `--internal` flag.

Netavark Implementation for: https://github.com/containers/podman/issues/13319