### PR TITLE
netavark.spec.rpkg: remove unnecessary conditional

### DIFF
--- a/netavark.spec.rpkg
+++ b/netavark.spec.rpkg
@@ -46,11 +46,7 @@ BuildRequires: git-core
 BuildRequires: golang-github-cpuguy83-md2man
 Recommends: aardvark-dns
 Provides: container-network-stack
-
 ExclusiveArch:  %{rust_arches}
-%if %{__cargo_skip_build}
-BuildArch:      noarch
-%endif
 
 %global _description %{expand:
 OCI network stack.}


### PR DESCRIPTION
The __cargo_skip_build isn't really useful to us. Netavark will always
be archful so this conditional is best removed.

This will also fix a build issue on rhel 8 envs.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@baude @flouthoc @Luap99 @mheon PTAL, trivial change to fix rhel8 auto builds on the fedora `rhcontainerbot/podman-next` copr.

EDIT: Description update.