### PR TITLE
Add more distribution rust builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -166,6 +166,28 @@ fedora36_build_task:
     script:
         - cargo build
 
+ubuntu20_build_task:
+    alias: ubuntu20_build
+    depends_on:
+      - "build"
+    container:
+        cpu: 2
+        memory: 2
+        image: quay.io/libpod/ubuntu20rust
+    script:
+        - cargo build
+
+centos9_build_task:
+    alias: centos9_build
+    depends_on:
+      - "build"
+    container:
+        cpu: 2
+        memory: 2
+        image: quay.io/libpod/centos9rust
+    script:
+        - cargo build
+
 success_task:
   name: "Total success"
   alias: success
@@ -178,6 +200,8 @@ success_task:
     - "integration"
     - "meta"
     - "fedora36_build"
+    - "ubuntu20_build"
+    - "centos9_build"
   env:
     CIRRUS_SHELL: "/bin/sh"
   clone_script: *noop


### PR DESCRIPTION
Because the rust toolchains can differ immensely depending on the
distribution and because we pull the latest rust toolchain in the rest
of the netavark CI, we need to perform test builds by distributions.
Fedora 35 already exists.  Adding CentOS9 and Ubuntu 20.04.4 LTS.

Signed-off-by: Brent Baude <bbaude@redhat.com>