### PR TITLE
aardvark: only use systemd-run when systemd is available

### DIFF
--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -13,6 +13,9 @@ use std::net::Ipv4Addr;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+const SYSTEMD_CHECK_PATH: &str = "/run/systemd/system";
+const SYSTEMD_RUN: &str = "systemd-run";
+
 #[derive(Debug, Clone)]
 pub struct AardvarkEntry {
     pub network_name: String,
@@ -77,10 +80,10 @@ impl Aardvark {
         log::debug!("Spawning aardvark server");
 
         let mut aardvark_args = vec![];
-        let systemd_run = "systemd-run";
-        if Aardvark::is_executable_in_path(systemd_run) {
+        // only use systemd when it is booted, see sd_booted(3)
+        if Path::new(SYSTEMD_CHECK_PATH).exists() && Aardvark::is_executable_in_path(SYSTEMD_RUN) {
             // TODO: This could be replaced by systemd-api.
-            aardvark_args = vec![systemd_run, "-q", "--scope"];
+            aardvark_args = vec![SYSTEMD_RUN, "-q", "--scope"];
 
             if self.rootless {
                 aardvark_args.push("--user");


### PR DESCRIPTION
According to sd_booted(3) checking if /run/systemd/system exists is good
enough to see if systemd is booted.
While this check is not perfect it will at least allow us to use it
inside a container where systemd binaries are installed but the
container is run without systemd, see
https://github.com/containers/podman/issues/13533

Another option would be to use the systemd dbus API. I gave it a try but
couldn't figure out the exact format we have to send and also had
trouble connecting to the rootless session.

For now this should help to get aardvark working inside a container.