### PR TITLE
bridge/macvlan: use IpNet::new() to create subnet

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -93,33 +93,18 @@ impl Core {
         for (idx, subnet) in network.subnets.iter().flatten().enumerate() {
             let subnet_mask_cidr = subnet.subnet.prefix_len();
             if let Some(gw) = subnet.gateway {
-                let gw_net = match gw {
-                    IpAddr::V4(gw4) => match ipnet::Ipv4Net::new(gw4, subnet_mask_cidr) {
-                        Ok(dest) => ipnet::IpNet::from(dest),
-                        Err(err) => {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::Other,
-                                format!(
-                                    "failed to parse address {}/{}: {}",
-                                    gw4, subnet_mask_cidr, err
-                                ),
-                            ))
-                        }
-                    },
-                    IpAddr::V6(gw6) => match ipnet::Ipv6Net::new(gw6, subnet_mask_cidr) {
-                        Ok(dest) => ipnet::IpNet::from(dest),
-                        Err(err) => {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::Other,
-                                format!(
-                                    "failed to parse address {}/{}: {}",
-                                    gw6, subnet_mask_cidr, err
-                                ),
-                            ))
-                        }
-                    },
+                let gw_net = match ipnet::IpNet::new(gw, subnet_mask_cidr) {
+                    Ok(dest) => dest,
+                    Err(err) => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!(
+                                "failed to parse address {}/{}: {}",
+                                gw, subnet_mask_cidr, err
+                            ),
+                        ))
+                    }
                 };
-
                 gw_ipaddr_vector.push(gw_net)
             }
 
@@ -394,33 +379,18 @@ impl Core {
             // Only add gateway to route if macvlan is not marked as an internal network
             if !network.internal {
                 if let Some(gw) = subnet.gateway {
-                    let gw_net = match gw {
-                        IpAddr::V4(gw4) => match ipnet::Ipv4Net::new(gw4, subnet_mask_cidr) {
-                            Ok(dest) => ipnet::IpNet::from(dest),
-                            Err(err) => {
-                                return Err(std::io::Error::new(
-                                    std::io::ErrorKind::Other,
-                                    format!(
-                                        "failed to parse address gateway address while configuring macvlan {}/{}: {}",
-                                        gw4, subnet_mask_cidr, err
-                                    ),
-                                ))
-                            }
-                        },
-                        IpAddr::V6(gw6) => match ipnet::Ipv6Net::new(gw6, subnet_mask_cidr) {
-                            Ok(dest) => ipnet::IpNet::from(dest),
-                            Err(err) => {
-                                return Err(std::io::Error::new(
-                                    std::io::ErrorKind::Other,
-                                    format!(
-                                        "failed to parse address gateway address while configuring macvlan {}/{}: {}",
-                                        gw6, subnet_mask_cidr, err
-                                    ),
-                                ))
-                            }
-                        },
+                    let gw_net = match ipnet::IpNet::new(gw, subnet_mask_cidr) {
+                        Ok(dest) => dest,
+                        Err(err) => {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                format!(
+                                    "failed to parse address {}/{}: {}",
+                                    gw, subnet_mask_cidr, err
+                                ),
+                            ))
+                        }
                     };
-
                     gw_ipaddr_vector.push(gw_net)
                 }
             }


### PR DESCRIPTION
Simplify the logic a bit by using IpNet:new() which works for ipv4 and
ipv6 instead of having to use a match.