### PR TITLE
add ipam driver none support

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -10,3 +10,8 @@ pub const MACVLAN_MODE_VEPA: u32 = 2;
 pub const MACVLAN_MODE_BRIDGE: u32 = 4;
 pub const MACVLAN_MODE_PASSTHRU: u32 = 8;
 pub const MACVLAN_MODE_SOURCE: u32 = 16;
+
+// IPAM drivers
+pub const IPAM_HOSTLOCAL: &str = "host-local";
+pub const IPAM_DHCP: &str = "dhcp";
+pub const IPAM_NONE: &str = "none";

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -54,3 +54,14 @@ pub struct PortForwardConfig {
     // Must be set if the v6 address is set.
     pub subnet_v6: Option<Subnet>,
 }
+
+/// IPAMAddresses is used to pass ipam information around
+pub struct IPAMAddresses {
+    // ip addresses for netlink
+    pub container_addresses: Vec<ipnet::IpNet>,
+    pub gateway_addresses: Vec<ipnet::IpNet>,
+    pub ipv6_enabled: bool,
+    // result for podman
+    pub net_addresses: Vec<types::NetAddress>,
+    pub nameservers: Vec<IpAddr>,
+}

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -41,6 +41,11 @@ pub struct Network {
     #[serde(rename = "options")]
     pub options: Option<HashMap<String, String>>,
 
+    /// IPAM options is a set of key-value options that have been applied to
+    /// the Network.
+    #[serde(rename = "ipam_options")]
+    pub ipam_options: Option<HashMap<String, String>>,
+
     /// Subnets to use for this network.
     #[serde(rename = "subnets")]
     pub subnets: Option<Vec<Subnet>>,


### PR DESCRIPTION
Allow creating interfaces only with no ip addresses assigned.
Also combine some duplicated code for bridge/macvlan.

Ref https://github.com/containers/common/pull/967
