### PR TITLE
test/helpers.bash: assert handle corner cases correctly

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -222,6 +222,11 @@ function assert() {
         if [ "$actual_string" = "$expect_string" ]; then
             return
         fi
+    elif [[ $operator == '!=' ]]; then
+        # Same special case as above
+        if [ "$actual_string" != "$expect_string" ]; then
+            return
+        fi
     else
         if eval "[[ $not \$actual_string $actual_op \$expect_string ]]"; then
             return


### PR DESCRIPTION
Right now `assert t:[1] != t:[1]` passes. This is obviously incorrect
and some test might not be working correctly because of this. We have to
special case this like the "==" case.

I discovered this in buildah, since we use the same logic here we should
fix it to prevent unexpected bugs.