### PR TITLE
isolate podman networks

### DIFF
--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -16,7 +16,7 @@ use std::process::{Command, Stdio};
 const SYSTEMD_CHECK_PATH: &str = "/run/systemd/system";
 const SYSTEMD_RUN: &str = "systemd-run";
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct AardvarkEntry {
     pub network_name: String,
     pub network_gateway_v4: String,

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -17,6 +17,8 @@ pub struct SetupNetwork {
     pub net: types::Network,
     // hash id for the network
     pub network_hash_name: String,
+    // isolation determines whether the network can communicate with others outside of its interface
+    pub isolation: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -98,7 +98,7 @@ function teardown() {
     run_in_host_netns sh -c "echo 0 > /proc/sys/net/ipv6/conf/default/accept_dad"
     #run_in_container_netns sh -c "echo 0 > /proc/sys/net/ipv6/conf/default/accept_dad"
 
-    #run_in_host_netns sh -c "echo 0 > /proc/sys/net/ipv6/conf/default/accept_ra"
+    # run_in_host_netns sh -c "echo 0 > /proc/sys/net/ipv6/conf/default/accept_ra"
 
     run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge.json setup $(get_container_netns_path)
     result="$output"

--- a/test/testfiles/connectbridge.json
+++ b/test/testfiles/connectbridge.json
@@ -1,0 +1,32 @@
+{
+    "container_id": "01f0b94d5f4c",
+    "container_name": "isolatedcontainer",
+    "networks": {
+        "podman1": {
+            "interface_name": "eth1",
+            "static_ips": [
+                "10.88.1.3"
+            ]
+        }
+    },
+    "network_info": {
+        "podman1": {
+            "dns_enabled": true,
+            "driver": "bridge",
+            "id": "f3ac3c903b76f20e8a122b1eb2ba393ab2519ba516626be5b490b66dc96b54b7",
+            "internal": false,
+            "ipv6_enabled": false,
+            "name": "podman1",
+            "network_interface": "podman1",
+            "subnets": [
+                {
+                    "gateway": "10.88.1.2",
+                    "subnet": "10.88.1.0/22"
+                }
+            ],
+            "options": {
+                "isolate": "true"
+             }
+        }
+    }
+}


### PR DESCRIPTION
add support for a new option "isolate", a boolean that determines whether or not a network
can send/recieve data outside of its bridge. This is done by creating a new chain "NETAVARK_ISOLATION" that drops external outgoing connections

resolves #154

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>