### PR TITLE
Cirrus: Gather arm and aarch64 netavark binaries

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,6 +74,26 @@ build_task:
   upload_caches: [ "cargo", "targets", "bin" ]
 
 
+build_cross_task:
+  alias: "build_cross"
+  cargo_cache:
+    <<: *cargo_cache
+    # Don't confuse cache architectures, bad things will happen.
+    fingerprint_key: "cargo_v2_${DEST_BRANCH}_arm64"
+  targets_cache:
+    <<: *targets_cache
+    fingerprint_key: "targets_v2_${CIRRUS_TAG}${DEST_BRANCH}${CIRRUS_PR}_arm64" # Cache only within same tag, branch, or PR (branch will be 'pull/#')
+  bin_cache:
+    <<: *bin_cache
+    fingerprint_key: "bin_v2_${CIRRUS_TAG}${DEST_BRANCH}${CIRRUS_PR}_arm64" # Cache only within same tag, branch, or PR (branch will be 'pull/#')
+  setup_script: *setup
+  main_script: *main
+  # Upload cross-compiled binary for collection by success task
+  # https://cirrus-ci.org/guide/writing-tasks/#artifacts-instruction
+  binary_artifacts:
+    path: ./bin/netavark*
+
+
 validate_task:
   alias: "validate"
   depends_on:
@@ -105,16 +125,6 @@ verify_vendor_task:
 
 unit_task:
   alias: "unit"
-  depends_on:
-    - "build"
-  cargo_cache: *ro_cargo_cache
-  targets_cache: *ro_targets_cache
-  bin_cache: *ro_bin_cache
-  setup_script: *setup
-  main_script: *main
-
-build_cross_task:
-  alias: "build_cross"
   depends_on:
     - "build"
   cargo_cache: *ro_cargo_cache
@@ -198,6 +208,10 @@ success_task:
   bin_cache: *ro_bin_cache
   # The paths used for uploaded artifacts are relative here and in Cirrus
   script:
+    # Cross-compiled binary artifact is required by other CI systems
+    - curl --fail --location -O --url https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/build_cross/binary.zip
+    - unzip binary.zip
+    - rm -f binary.zip
     - mv bin/* ./
     - rm -rf bin
   # Upload tested binary for consumption downstream

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,7 +51,7 @@ build_task:
     # all PRs & branches will share caches with other PRs and branches
     # for a given $DEST_BRANCH and vX value.  Adjust vX if cache schema
     # changes.
-    fingerprint_key: "cargo_v1_${DEST_BRANCH}"
+    fingerprint_key: "cargo_v2_${DEST_BRANCH}_amd64"
     # Required to be set explicitly since fingerprint_key is also set
     reupload_on_changes: true
   targets_cache: &targets_cache
@@ -60,14 +60,14 @@ build_task:
     # contexts.  For example, two PRs that happen to coincidentally change
     # and use cache.  Adjust vX if cache schema changes.
     folder: "$CARGO_TARGET_DIR"
-    fingerprint_key: "targets_v1_${CIRRUS_BUILD_ID}" # Cache only within same build
+    fingerprint_key: "targets_v2_${CIRRUS_TAG}${DEST_BRANCH}${CIRRUS_PR}_amd64" # Cache only within same tag, branch, or PR (branch will be 'pull/#')
     reupload_on_changes: true
   bin_cache: &bin_cache
     # This simply prevents rebuilding bin/netavark for every subsequent task.
     folder: "$CIRRUS_WORKING_DIR/bin"
     # Avoid binary pollution by scoping this to only this specific build.
     # Adjust vX if cache schema changes.
-    fingerprint_key: "bin_v1_${CIRRUS_BUILD_ID}" # Cache only within same build
+    fingerprint_key: "bin_v2_${CIRRUS_TAG}${DEST_BRANCH}${CIRRUS_PR}_amd64" # Cache only within same tag, branch, or PR (branch will be 'pull/#')
     reupload_on_changes: true
   setup_script: &setup "$SCRIPT_BASE/setup.sh"
   main_script: &main "$SCRIPT_BASE/runner.sh $CIRRUS_TASK_NAME"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,8 +16,8 @@ env:
     CARGO_TARGET_DIR: "$CIRRUS_WORKING_DIR/targets"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
-    FEDORA_NAME: "fedora-35"
-    IMAGE_SUFFIX: "c6118659411148800"
+    FEDORA_NAME: "fedora-36"
+    IMAGE_SUFFIX: "c6457378097856512"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
 
 
@@ -155,17 +155,6 @@ meta_task:
     clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR  # source not needed
     script: /usr/local/bin/entrypoint.sh
 
-fedora36_build_task:
-    alias: fedora36_build
-    depends_on:
-      - "build"
-    container:
-        cpu: 2
-        memory: 2
-        image: quay.io/libpod/fedora36rust
-    script:
-        - cargo build
-
 ubuntu20_build_task:
     alias: ubuntu20_build
     depends_on:
@@ -176,6 +165,7 @@ ubuntu20_build_task:
         image: quay.io/libpod/ubuntu20rust
     script:
         - cargo build
+
 
 centos9_build_task:
     alias: centos9_build
@@ -188,6 +178,7 @@ centos9_build_task:
     script:
         - cargo build
 
+
 success_task:
   name: "Total success"
   alias: success
@@ -199,7 +190,6 @@ success_task:
     - "unit"
     - "integration"
     - "meta"
-    - "fedora36_build"
     - "ubuntu20_build"
     - "centos9_build"
   env:

--- a/Makefile
+++ b/Makefile
@@ -76,13 +76,17 @@ build_unit: $(CARGO_TARGET_DIR)
 	cargo test --no-run
 
 # Test build cross-architecture
+# Ref: https://github.com/cross-rs/cross
 .PHONY: build_cross
-build_cross: $(CARGO_TARGET_DIR)
+build_cross: build_cross.aarch64-unknown-linux-gnu build_cross.arm-unknown-linux-gnueabi
+
+.PHONY: build_cross.%
+build_cross.%: bin $(CARGO_TARGET_DIR)
 	cargo install cross
-	rustup target add aarch64-unknown-linux-gnu
-	rustup target add arm-unknown-linux-gnueabi
-	cross build --target aarch64-unknown-linux-gnu
-	cross build --target arm-unknown-linux-gnueabi
+	rustup target add $*
+	cross build --target $* $(release)
+	cp $(CARGO_TARGET_DIR)/$*/$(profile)/netavark \
+		bin/netavark.$(*)$(if $(debug),.debug,)
 
 .PHONY: unit
 unit: $(CARGO_TARGET_DIR)

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -41,6 +41,7 @@ _run_validate() {
 }
 
 _run_build_cross() {
+    make build_cross debug=1
     make build_cross
 }
 


### PR DESCRIPTION
In order to test `aardvark-dns` (and maybe elsewhere) a recent binary
build of netavark from the CI system is needed.  Previously this was
always an `x86_64` binary along with a `.debug` version.  Add support for
archiving both `arm` (32 bit) and `aarch64` binaries.  Name them with
the architecture-target as a suffix so they may be distinguished from
the (necked) `netavark` binary.

e.g. `bin/netavark.aarch64-unknown-linux-gnu`

*note:* A VM image update was also required

Signed-off-by: Chris Evich <cevich@redhat.com>