### PR TITLE
dns: start aardvark-dns on a different port

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -111,6 +111,9 @@ impl Setup {
                         network,
                         &self.network_namespace_path,
                     )?;
+                    // get DNS server IPs
+                    let dns_server_ips: Vec<IpAddr> =
+                        status_block.dns_server_ips.clone().unwrap_or_default();
                     response.insert(net_name.to_owned(), status_block);
                     if network.internal {
                         match &network.network_interface {
@@ -200,7 +203,8 @@ impl Setup {
                                 subnet_v4: net_v4,
                                 container_ip_v6: addr_v6,
                                 subnet_v6: net_v6,
-                                dns_port: if network.dns_enabled { dns_port } else { 53 },
+                                dns_port,
+                                dns_server_ips,
                             };
                             // Need to enable sysctl localnet so that traffic can pass
                             // through localhost to containers

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -142,21 +142,14 @@ impl Setup {
                         isolation: isolation_config,
                     };
                     firewall_driver.setup_network(sn)?;
-                    let port_bindings = network_options.port_mappings.clone();
-                    match port_bindings {
+                    match per_network_opts.static_ips.as_ref() {
                         None => {}
-                        Some(i) => {
-                            let container_ips =
-                                per_network_opts.static_ips.as_ref().ok_or_else(|| {
-                                    std::io::Error::new(
-                                        std::io::ErrorKind::Other,
-                                        "no container ip provided",
-                                    )
-                                })?;
+                        Some(container_ips) => {
+                            let port_bindings = network_options.port_mappings.clone();
                             let networks = network.subnets.as_ref().ok_or_else(|| {
                                 std::io::Error::new(
                                     std::io::ErrorKind::Other,
-                                    "no network address provided",
+                                    "IP assigned but no network address provided",
                                 )
                             })?;
                             let mut has_ipv4 = false;
@@ -186,7 +179,7 @@ impl Setup {
                             let spf = PortForwardConfig {
                                 net: network.clone(),
                                 container_id: network_options.container_id.clone(),
-                                port_mappings: i.clone(),
+                                port_mappings: port_bindings.unwrap_or_default(),
                                 network_name: (*net_name).clone(),
                                 network_hash_name: id_network_hash.clone(),
                                 container_ip_v4: addr_v4,

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -101,11 +101,14 @@ impl Teardown {
                             )
                         })?;
                     //Remove container interfaces
-                    network::core::Core::remove_interface_per_podman_network(
+                    let status_block = network::core::Core::remove_interface_per_podman_network(
                         per_network_opts,
                         network,
                         &self.network_namespace_path,
                     )?;
+                    // get DNS server IPs
+                    let dns_server_ips: Vec<IpAddr> =
+                        status_block.dns_server_ips.unwrap_or_default();
                     // Teardown basic firewall port forwarding
 
                     let id_network_hash = network::core_utils::CoreUtils::create_network_hash(
@@ -159,7 +162,8 @@ impl Teardown {
                                     subnet_v4: net_v4,
                                     container_ip_v6: addr_v6,
                                     subnet_v6: net_v6,
-                                    dns_port: if network.dns_enabled { dns_port } else { 53 },
+                                    dns_port,
+                                    dns_server_ips,
                                 };
                                 let td = TeardownPortForward {
                                     config: spf,

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -99,21 +99,14 @@ impl Teardown {
                     );
 
                     if !network.internal {
-                        let port_bindings = network_options.port_mappings.clone();
-                        match port_bindings {
+                        match per_network_opts.static_ips.as_ref() {
                             None => {}
-                            Some(i) => {
-                                let container_ips =
-                                    per_network_opts.static_ips.as_ref().ok_or_else(|| {
-                                        std::io::Error::new(
-                                            std::io::ErrorKind::Other,
-                                            "no container ip provided",
-                                        )
-                                    })?;
+                            Some(container_ips) => {
+                                let port_bindings = network_options.port_mappings.clone();
                                 let networks = network.subnets.as_ref().ok_or_else(|| {
                                     std::io::Error::new(
                                         std::io::ErrorKind::Other,
-                                        "no network address provided",
+                                        "IP assigned but no network address provided",
                                     )
                                 })?;
 
@@ -144,7 +137,7 @@ impl Teardown {
                                 let spf = PortForwardConfig {
                                     net: network.clone(),
                                     container_id: network_options.container_id.clone(),
-                                    port_mappings: i.clone(),
+                                    port_mappings: port_bindings.unwrap_or_default(),
                                     network_name: (*net_name).clone(),
                                     network_hash_name: id_network_hash.clone(),
                                     container_ip_v4: addr_v4,

--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -296,27 +296,22 @@ impl Aardvark {
     pub fn delete_entry(&mut self, container_id: String, network_name: String) -> Result<()> {
         let path = Path::new(&self.config).join(network_name);
         let file_content = fs::read_to_string(&path)?;
-        let lines: Vec<&str> = file_content.split('\n').collect();
+        let lines: Vec<&str> = file_content.split_terminator('\n').collect();
 
-        let mut idx = 1;
+        let mut idx = 0;
         let mut file = File::create(&path)?;
 
-        for line in &lines {
+        for line in lines {
             if line.contains(&container_id) {
-                if lines.len() <= 3 {
-                    // delete the file and return
-                    // since there is nothing in the network
-                    fs::remove_file(&path)?;
-                    return Ok(());
-                }
-                idx += 1;
                 continue;
             }
             file.write_all(line.as_bytes())?;
-            if idx < lines.len() {
-                file.write_all(b"\n")?;
-            }
+            file.write_all(b"\n")?;
             idx += 1;
+        }
+        // nothing left in file (only header), remove it
+        if idx <= 1 {
+            fs::remove_file(&path)?
         }
         Ok(())
     }

--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -34,14 +34,17 @@ pub struct Aardvark {
     pub rootless: bool,
     // path to the aardvark-dns binary
     pub aardvark_bin: String,
+    // port to bind to
+    pub port: String,
 }
 
 impl Aardvark {
-    pub fn new(config: String, rootless: bool, aardvark_bin: String) -> Self {
+    pub fn new(config: String, rootless: bool, aardvark_bin: String, port: u16) -> Self {
         Aardvark {
             config,
             rootless,
             aardvark_bin,
+            port: port.to_string(),
         }
     }
 
@@ -94,7 +97,7 @@ impl Aardvark {
             "--config",
             &self.config,
             "-p",
-            "53",
+            &self.port,
             "run",
         ]);
 

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -212,10 +212,13 @@ impl firewall::FirewallDriver for IptablesDriver {
                 chain.remove_rules(tear.complete_teardown)?;
             }
             for chain in &chains {
+                if !tear.complete_teardown || !chain.create {
+                    continue;
+                }
                 match &chain.td_policy {
                     None => {}
                     Some(policy) => {
-                        if tear.complete_teardown && *policy == TeardownPolicy::OnComplete {
+                        if *policy == TeardownPolicy::OnComplete {
                             chain.remove()?;
                         }
                     }
@@ -242,10 +245,13 @@ impl firewall::FirewallDriver for IptablesDriver {
                 chain.remove_rules(tear.complete_teardown)?;
             }
             for chain in &chains {
+                if !tear.complete_teardown || !chain.create {
+                    continue;
+                }
                 match &chain.td_policy {
                     None => {}
                     Some(policy) => {
-                        if tear.complete_teardown && *policy == TeardownPolicy::OnComplete {
+                        if *policy == TeardownPolicy::OnComplete {
                             chain.remove()?;
                         }
                     }

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -415,16 +415,19 @@ pub fn get_port_forwarding_chains<'a>(
 
     // Create redirection for aardvark-dns on non-standard port
     if pfwd.dns_port != 53 {
-        if let Some(gateway) = network_address.gateway {
-            let mut gateway_ip_value = gateway.to_string();
+        for dns_ip in &pfwd.dns_server_ips {
+            if is_ipv6 != dns_ip.is_ipv6() {
+                continue;
+            }
+            let mut ip_value = dns_ip.to_string();
             if is_ipv6 {
-                gateway_ip_value = format!("[{}]", gateway_ip_value)
+                ip_value = format!("[{}]", ip_value)
             }
             netavark_hostport_dn_chain.create = true;
             netavark_hostport_dn_chain.build_rule(VarkRule::new(
                 format!(
                     "-j {} -d {} -p {} --dport {} --to-destination {}:{}",
-                    DNAT, gateway, "udp", 53, gateway_ip_value, pfwd.dns_port
+                    DNAT, dns_ip, "udp", 53, ip_value, pfwd.dns_port
                 ),
                 Some(TeardownPolicy::OnComplete),
             ));

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -340,14 +340,15 @@ pub fn get_port_forwarding_chains<'a>(
     );
 
     // NETAVARK_HOSTPORT_DNAT
-    // Determination to create the chain is done only
-    // if there are port mappings
+    // We need to create that chain for prerouting/output chain rules
+    // using it, even if there are no port mappings.
     let mut netavark_hostport_dn_chain = VarkChain::new(
         conn,
         NAT.to_string(),
         NETAVARK_HOSTPORT_DNAT.to_string(),
         None,
     );
+    netavark_hostport_dn_chain.create = true;
 
     // Setup one-off rules that have nothing to do with ports
     // PREROUTING
@@ -409,7 +410,6 @@ pub fn get_port_forwarding_chains<'a>(
 
     //  Determine if we need to create chains
     if !pfwd.port_mappings.is_empty() {
-        netavark_hostport_dn_chain.create = true;
         netavark_hashed_dn_chain.create = true;
     }
 

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -55,6 +55,9 @@ pub struct PortForwardConfig {
     // subnet associated with the ipv6 address.
     // Must be set if the v6 address is set.
     pub subnet_v6: Option<Subnet>,
+    // port used by DNS that should create forwarding rules
+    // forwarding is not setup if this is 53.
+    pub dns_port: u16,
 }
 
 /// IPAMAddresses is used to pass ipam information around

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -58,6 +58,8 @@ pub struct PortForwardConfig {
     // port used by DNS that should create forwarding rules
     // forwarding is not setup if this is 53.
     pub dns_port: u16,
+    // dns servers IPs where forwarding rule to port 53 from dns_port are necessary
+    pub dns_server_ips: Vec<IpAddr>,
 }
 
 /// IPAMAddresses is used to pass ipam information around

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -66,7 +66,8 @@ fw_driver=iptables
 
     # check iptables POSTROUTING chain
     run_in_host_netns iptables -S POSTROUTING -t nat
-    assert "${lines[1]}" =~ "-A POSTROUTING -s 10.88.0.0/16 -j NETAVARK-1D8721804F16F" "POSTROUTING container rule"
+    assert "${lines[1]}" =~ "-A POSTROUTING -j NETAVARK-HOSTPORT-MASQ" "POSTROUTING HOSTPORT-MASQ rule"
+    assert "${lines[2]}" =~ "-A POSTROUTING -s 10.88.0.0/16 -j NETAVARK-1D8721804F16F" "POSTROUTING container rule"
 
     # check iptables NETAVARK-1D8721804F16F chain
     run_in_host_netns iptables -S NETAVARK-1D8721804F16F -t nat

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -150,36 +150,63 @@ fw_driver=iptables
 }
 
 @test "$fw_driver - dual stack dns with alt port" {
-    dns_port=$(random_port)
-    NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json setup $(get_container_netns_path)
+    # get a random port directly to avoid low ports e.g. 53 would not create iptables
+    dns_port=$((RANDOM+10000))
+
+    # hack to make aardvark-dns run when really root or when running as user with
+    # podman unshare --rootless-netns; since netavark runs aardvark with systemd-run
+    # it needs to know if it should use systemd user instance or not.
+    # iptables are still setup identically.
+    rootless=false
+    if [[ ! -e "/run/dbus/system_bus_socket" ]]; then
+        rootless=true
+    fi
+
+    mkdir -p "$NETAVARK_TMPDIR/config"
+
+    NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
+        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
+        setup $(get_container_netns_path)
+
+    # check iptables
     run_in_host_netns iptables -t nat -S NETAVARK-HOSTPORT-DNAT
     assert "${lines[1]}" == "-A NETAVARK-HOSTPORT-DNAT -d 10.89.3.1/32 -p udp -m udp --dport 53 -j DNAT --to-destination 10.89.3.1:$dns_port" "ipv4 dns forward rule"
     run_in_host_netns ip6tables -t nat -S NETAVARK-HOSTPORT-DNAT
     assert "${lines[1]}" == "-A NETAVARK-HOSTPORT-DNAT -d fd10:88:a::1/128 -p udp -m udp --dport 53 -j DNAT --to-destination [fd10:88:a::1]:$dns_port" "ipv6 dns forward rule"
 
-    # test redirection actually works -- we can't use run_nc_test
-    # we _also_ cannot use run_in_host_ns for this command as it echoes
-    # the command back, and we only want nc reply...
-    nsenter -n -t $HOST_NS_PID timeout --foreground -v --kill=10 5 \
-        nc -4 --udp -l -p "$dns_port" &>"$NETAVARK_TMPDIR/nc-out" </dev/null &
-    data=$(random_string)
-    run_in_container_netns nc -4 --udp 10.89.3.1 53 <<<"$data"
-    got=$(cat "$NETAVARK_TMPDIR/nc-out")
-    assert "$got" == "$data" "ncat received data"
+    # check aardvark config and running
+    run_helper cat "$NETAVARK_TMPDIR/config/aardvark-dns/podman1"
+    assert "${lines[0]}" =~ "10.89.3.1,fd10:88:a::1" "aardvark set to listen to all IPs"
+    assert "${lines[1]}" =~ "[0-9a-f]* 10.89.3.2  somename" "aardvark config's container ipv4"
+    assert "${lines[2]}" =~ "[0-9a-f]*  fd10:88:a::2 somename" "aardvark config's container ipv6"
+    assert "${#lines[@]}" = 3 "too many liness in aardvark config"
 
-    # same for ipv6
-    nsenter -n -t $HOST_NS_PID timeout --foreground -v --kill=10 5 \
-        nc -6 --udp -l -p "$dns_port" &>"$NETAVARK_TMPDIR/nc-out" </dev/null &
-    data=$(random_string)
-    run_in_container_netns nc -6 --udp fd10:88:a::1 53 <<<"$data"
-    got=$(cat "$NETAVARK_TMPDIR/nc-out")
-    assert "$got" == "$data" "ncat received data"
+    aardvark_pid=$(cat "$NETAVARK_TMPDIR/config/aardvark-dns/aardvark.pid")
+    assert "$ardvark_pid" =~ "[0-9]*" "aardvark pid not found"
+    run_helper ps "$aardvark_pid"
+    assert "${lines[1]}" =~ ".*aardvark-dns --config $NETAVARK_TMPDIR/config/aardvark-dns -p $dns_port run" "aardvark not running or bad options"
 
-    NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json teardown $(get_container_netns_path)
+    # test redirection actually works
+    run_in_container_netns dig +short "somename.dns.podman" @10.89.3.1
+    assert "${lines[0]}" =~ "10.89.3.2" "ipv4 dns resolution works 1/2"
+    assert "${lines[1]}" =~ "fd10:88:a::2" "ipv4 dns resolution works 2/2"
+
+    run_in_container_netns dig +short "somename.dns.podman" @fd10:88:a::1
+    assert "${lines[0]}" =~ "10.89.3.2" "ipv6 dns resolution works"
+
+    NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
+        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
+        teardown $(get_container_netns_path)
+
+    # check iptables got removed
     run_in_host_netns iptables -t nat -S NETAVARK-HOSTPORT-DNAT
     assert "${#lines[@]}" = 1 "too many v4 NETAVARK_HOSTPORT-DNAT rules after teardown"
     run_in_host_netns ip6tables -t nat -S NETAVARK-HOSTPORT-DNAT
     assert "${#lines[@]}" = 1 "too many v6 NETAVARK_HOSTPORT-DNAT rules after teardown"
+
+    # check aardvark config got cleared, process killed
+    expected_rc=2 run_helper ls "$NETAVARK_TMPDIR/config/aardvark-dns/podman1"
+    expected_rc=1 run_helper ps "$aardvark_pid"
 }
 
 @test "$fw_driver - check error message from netns thread" {

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -65,36 +65,36 @@ fw_driver=iptables
     run_in_host_netns ping -c 1 10.88.0.2
 
     # check iptables POSTROUTING chain
-    run_in_host_netns iptables -nvL POSTROUTING -t nat
-    assert "${lines[2]}" =~ "\s+[0-9]\s+[0-9]+\s+NETAVARK-1D8721804F16F  all  --  \*      \*       10\.88\.0\.0\/16         0\.0\.0\.0\/0\s+" "POSTROUTING rule"
+    run_in_host_netns iptables -S POSTROUTING -t nat
+    assert "${lines[1]}" =~ "-A POSTROUTING -s 10.88.0.0/16 -j NETAVARK-1D8721804F16F" "POSTROUTING container rule"
 
     # check iptables NETAVARK-1D8721804F16F chain
-    run_in_host_netns iptables -nvL NETAVARK-1D8721804F16F -t nat
-    assert "${lines[2]}" =~ "\s+[0-9]\s+[0-9]+\s+ACCEPT     all  --  \*      \*       0\.0\.0\.0\/0            10\.88\.0\.0\/16\s+" "NETAVARK-1D8721804F16F ACCEPT rule"
-    assert "${lines[3]}" == "    0     0 MASQUERADE  all  --  *      *       0.0.0.0/0           !224.0.0.0/4         " "NETAVARK-1D8721804F16F MASQUERADE rule"
+    run_in_host_netns iptables -S NETAVARK-1D8721804F16F -t nat
+    assert "${lines[1]}" =~ "-A NETAVARK-1D8721804F16F -d 10.88.0.0/16 -j ACCEPT" "NETAVARK-1D8721804F16F ACCEPT rule"
+    assert "${lines[2]}" == "-A NETAVARK-1D8721804F16F ! -d 224.0.0.0/4 -j MASQUERADE" "NETAVARK-1D8721804F16F MASQUERADE rule"
 
     # check FORWARD rules
-    run_in_host_netns iptables -nvL FORWARD
-    assert "${lines[2]}" == "    0     0 NETAVARK_FORWARD  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* netavark firewall plugin rules */" "FORWARD rule"
-    run_in_host_netns iptables -nvL NETAVARK_FORWARD
-    assert "${lines[2]}" == "    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            10.88.0.0/16         ctstate RELATED,ESTABLISHED" "NETAVARK_FORWARD rule 1"
-    assert "${lines[3]}" == "    0     0 ACCEPT     all  --  *      *       10.88.0.0/16         0.0.0.0/0           " "NETAVARK_FORWARD rule 2"
+    run_in_host_netns iptables -S FORWARD
+    assert "${lines[1]}" == "-A FORWARD -m comment --comment \"netavark firewall plugin rules\" -j NETAVARK_FORWARD" "FORWARD rule"
+    run_in_host_netns iptables -S NETAVARK_FORWARD
+    assert "${lines[1]}" == "-A NETAVARK_FORWARD -d 10.88.0.0/16 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT" "NETAVARK_FORWARD rule 1"
+    assert "${lines[2]}" == "-A NETAVARK_FORWARD -s 10.88.0.0/16 -j ACCEPT" "NETAVARK_FORWARD rule 2"
 
     run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json teardown $(get_container_netns_path)
 
     # now check that iptables rules are gone
-    run_in_host_netns iptables -nvL
+    run_in_host_netns iptables -S
 
     # check FORWARD rules
-    run_in_host_netns iptables -nvL FORWARD
-    assert "${lines[2]}" == "    0     0 NETAVARK_FORWARD  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* netavark firewall plugin rules */" "FORWARD rule"
-    run_in_host_netns iptables -nvL NETAVARK_FORWARD
+    run_in_host_netns iptables -S FORWARD
+    assert "${lines[1]}" == "-A FORWARD -m comment --comment \"netavark firewall plugin rules\" -j NETAVARK_FORWARD" "FORWARD rule"
     # rule 1 should be DROP for any existing networks
-    assert "${lines[2]}" == "" "NETAVARK_FORWARD rule 1 is empty"
-    assert "${lines[3]}" == "" "NETAVARK_FORWARD rule 2 is empty"
+    run_in_host_netns iptables -S NETAVARK_FORWARD
+    assert "${lines[1]}" == "" "NETAVARK_FORWARD rule 1 is empty"
+    assert "${lines[2]}" == "" "NETAVARK_FORWARD rule 2 is empty"
 
     # check POSTROUTING nat rules
-    run_in_host_netns iptables -nvL POSTROUTING -t nat
+    run_in_host_netns iptables -S POSTROUTING -t nat
     assert "${lines[2]}" == "" "POSTROUTING rule is empty"
 
     # NETAVARK-1D8721804F16F chain should not exists

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -134,6 +134,39 @@ function teardown() {
     run_in_host_netns ping6 -c 1 fd10:88:a::2
 }
 
+@test "$fw_driver - dual stack dns with alt port" {
+    dns_port=$(random_port)
+    NETAVARK_FW=firewalld NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json setup $(get_container_netns_path)
+
+    # firewall-cmd --list-rich-rules does not guarantee order, use sort
+    run_in_host_netns sh -c 'firewall-cmd --policy netavark_portfwd --list-rich-rules | sort'
+    assert "${lines[0]}" =~ "rule family=\"ipv4\" destination address=\"10.89.3.1\" forward-port port=\"53\" protocol=\"udp\" to-port=\"$dns_port\" to-addr=\"10.89.3.1\"" "ipv4 dns redirection"
+    assert "${lines[1]}" =~ "rule family=\"ipv6\" destination address=\"fd10:88:a::1\" forward-port port=\"53\" protocol=\"udp\" to-port=\"$dns_port\" to-addr=\"fd10:88:a::1\"" "ipv6 dns redirection"
+    assert "${#lines[@]}" = 2 "too many rich rules"
+
+    # test redirection actually works -- we can't use run_nc_test
+    # we _also_ cannot use run_in_host_ns for this command as it echoes
+    # the command back, and we only want nc reply...
+    nsenter -n -t $HOST_NS_PID timeout --foreground -v --kill=10 5 \
+        nc -4 --udp -l -p "$dns_port" &>"$NETAVARK_TMPDIR/nc-out" </dev/null &
+    data=$(random_string)
+    run_in_container_netns nc -4 --udp 10.89.3.1 53 <<<"$data"
+    got=$(cat "$NETAVARK_TMPDIR/nc-out")
+    assert "$got" == "$data" "ncat received data"
+
+    # same for ipv6
+    nsenter -n -t $HOST_NS_PID timeout --foreground -v --kill=10 5 \
+        nc -6 --udp -l -p "$dns_port" &>"$NETAVARK_TMPDIR/nc-out" </dev/null &
+    data=$(random_string)
+    run_in_container_netns nc -6 --udp fd10:88:a::1 53 <<<"$data"
+    got=$(cat "$NETAVARK_TMPDIR/nc-out")
+    assert "$got" == "$data" "ncat received data"
+
+    NETAVARK_FW=firewalld NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json teardown $(get_container_netns_path)
+    run_in_host_netns firewall-cmd --policy netavark_portfwd --list-rich-rules
+    assert "${#lines[@]}" = 0 "rich rules did not get removed on teardown"
+}
+
 @test "$fw_driver - check error message from netns thread" {
     # create interface in netns to force error
     run_in_container_netns ip link add eth0 type dummy

--- a/test/testfiles/dualstack-bridge.json
+++ b/test/testfiles/dualstack-bridge.json
@@ -1,0 +1,37 @@
+{
+    "container_id": "f031bf33eecba75d0d84952337b1ceef6a239eb8e94b48aee0993d0791345325",
+    "container_name": "somename",
+    "networks": {
+        "podman1": {
+            "static_ips": [
+                "10.89.3.2",
+                "fd10:88:a::2"
+            ],
+            "interface_name": "eth0"
+        }
+    },
+    "network_info": {
+        "podman1": {
+            "name": "podman1",
+            "id": "ec79dd0cad82083c8ac5cc23e9542e4ddea813dff60d68258d36e84f6393b63b",
+            "driver": "bridge",
+            "network_interface": "podman1",
+            "subnets": [
+                {
+                    "subnet": "10.89.3.0/24",
+                    "gateway": "10.89.3.1"
+                },
+                {
+                    "subnet": "fd10:88:a::/64",
+                    "gateway": "fd10:88:a::1"
+                }
+            ],
+            "ipv6_enabled": true,
+            "internal": false,
+            "dns_enabled": true,
+            "ipam_options": {
+                "driver": "host-local"
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've taken a stab at a proof of concept first -- as said in the issue about port 53 shouldn't be used (link below) it seems simple enough to use DNAT for this.

This WIP version has at least two problems:
 - I've hardcoded port 1153 as alternative port, we should either use an ephemeral port (problem: we can't know if it's free unless we try to bind to it, so we'd need some retry...) or simpler just make it configurable at network level as a driver-specific option. I'd favor the later.
 - I'm not actually checking if dns settings are enabled to create the forward rule, that should obviously be checked.

Is there anything else I missed?

Fixes: https://github.com/containers/aardvark-dns/issues/13