### PR TITLE
core,lint: omit the unused `let` binding

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -127,7 +127,7 @@ impl Core {
             gw_ipaddr_clone.push(*gw_ip)
         }
         //call configure bridge
-        let _ = match core_utils::CoreUtils::configure_bridge_async(
+        match core_utils::CoreUtils::configure_bridge_async(
             br_name,
             gw_ipaddr,
             mtu_config,
@@ -142,7 +142,7 @@ impl Core {
             }
         };
 
-        let _ = match core_utils::CoreUtils::configure_veth_async(
+        match core_utils::CoreUtils::configure_veth_async(
             host_veth_name,
             container_veth_name,
             br_name,
@@ -341,7 +341,7 @@ impl Core {
         netns_ipaddr: Vec<ipnet::IpNet>,
         netns: &str,
     ) -> Result<String, std::io::Error> {
-        let _ = match core_utils::CoreUtils::configure_macvlan_async(
+        match core_utils::CoreUtils::configure_macvlan_async(
             master_ifname,
             container_macvlan,
             macvlan_mode,


### PR DESCRIPTION
After the recent cargo update validate fails because of using `let`
binding on unit value further we are not interested in using this value
so drop it.

See: https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value

Fixes issue in: https://github.com/containers/netavark/pull/322
Fixes broken CI on current main branch: https://cirrus-ci.com/build/4539848676605952