### PR TITLE
misc fixes

### DIFF
--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -296,27 +296,22 @@ impl Aardvark {
     pub fn delete_entry(&mut self, container_id: String, network_name: String) -> Result<()> {
         let path = Path::new(&self.config).join(network_name);
         let file_content = fs::read_to_string(&path)?;
-        let lines: Vec<&str> = file_content.split('\n').collect();
+        let lines: Vec<&str> = file_content.split_terminator('\n').collect();
 
-        let mut idx = 1;
+        let mut idx = 0;
         let mut file = File::create(&path)?;
 
-        for line in &lines {
+        for line in lines {
             if line.contains(&container_id) {
-                if lines.len() <= 3 {
-                    // delete the file and return
-                    // since there is nothing in the network
-                    fs::remove_file(&path)?;
-                    return Ok(());
-                }
-                idx += 1;
                 continue;
             }
             file.write_all(line.as_bytes())?;
-            if idx < lines.len() {
-                file.write_all(b"\n")?;
-            }
+            file.write_all(b"\n")?;
             idx += 1;
+        }
+        // nothing left in file (only header), remove it
+        if idx <= 1 {
+            fs::remove_file(&path)?
         }
         Ok(())
     }

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -212,10 +212,13 @@ impl firewall::FirewallDriver for IptablesDriver {
                 chain.remove_rules(tear.complete_teardown)?;
             }
             for chain in &chains {
+                if !tear.complete_teardown || !chain.create {
+                    continue;
+                }
                 match &chain.td_policy {
                     None => {}
                     Some(policy) => {
-                        if tear.complete_teardown && *policy == TeardownPolicy::OnComplete {
+                        if *policy == TeardownPolicy::OnComplete {
                             chain.remove()?;
                         }
                     }
@@ -242,10 +245,13 @@ impl firewall::FirewallDriver for IptablesDriver {
                 chain.remove_rules(tear.complete_teardown)?;
             }
             for chain in &chains {
+                if !tear.complete_teardown || !chain.create {
+                    continue;
+                }
                 match &chain.td_policy {
                     None => {}
                     Some(policy) => {
-                        if tear.complete_teardown && *policy == TeardownPolicy::OnComplete {
+                        if *policy == TeardownPolicy::OnComplete {
                             chain.remove()?;
                         }
                     }

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -340,14 +340,15 @@ pub fn get_port_forwarding_chains<'a>(
     );
 
     // NETAVARK_HOSTPORT_DNAT
-    // Determination to create the chain is done only
-    // if there are port mappings
+    // We need to create that chain for prerouting/output chain rules
+    // using it, even if there are no port mappings.
     let mut netavark_hostport_dn_chain = VarkChain::new(
         conn,
         NAT.to_string(),
         NETAVARK_HOSTPORT_DNAT.to_string(),
         None,
     );
+    netavark_hostport_dn_chain.create = true;
 
     // Setup one-off rules that have nothing to do with ports
     // PREROUTING
@@ -409,7 +410,6 @@ pub fn get_port_forwarding_chains<'a>(
 
     //  Determine if we need to create chains
     if !pfwd.port_mappings.is_empty() {
-        netavark_hostport_dn_chain.create = true;
         netavark_hashed_dn_chain.create = true;
     }
 


### PR DESCRIPTION
While working on #323 I found a few issues, I had intended to just push them together but I found two more today so might as well fix separately.

Individual commit messages have better descriptions, but to recap:
 - the chain.create logic in iptables was never correct, we cannot skip creation of the dn chain as it's referred to in unchecked path. That only really matters with next PR as we start doing it all the time but it's also probably possible to pass an empty vec as opposed to None and trigger this today.
 - we were trying to delete too many chains, causing chain does not exist errors in teardown when they aren't created in setup
 - the logic to cleanup `/run/containers/networks/aardvark-dns/<network>` files was a bit broken, in particular when multiple lines belonged to a container and that was the last to shut down (which happens on dualstack network) we wouldn't correctly identify the new file as empty and didn't delete it. That caused aardvark to not shutdown when all configs are gone. This isn't really a problem normally but when playing with changing ports we need aardvark to be stopped.
 - the way we're handling subnets means we would only ever listen to one of the IPs configured for a container in /etc/resolv.conf.
This part is still not 100% coherent, resolv.conf content comes from ipam config whatever that is and we use gateway addresses for listening IPs here, but it's a start: at least with this aardvark listens to both ipv4 and ipv6 when both are set.

We don't actually need the distinction of gateway v4 or v6 as we just treat it as a string so I simplified that a bit as well and removed unneeded `mut` flags when I saw them. Hopefully that won't make a difference.