### PR TITLE
rework isolate option to match CNI

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -63,7 +63,7 @@ function get_container_netns_path() {
     local which="0"
     if [[ $# -eq 1 ]]; then
         which=$1
-    fi 
+    fi
     echo /proc/"${CONTAINER_NS_PIDS[$which]}"/ns/net
 }
 
@@ -84,7 +84,8 @@ function run_netavark() {
 #
 function run_in_container_netns() {
     local i="0"
-    if [[ $1 -eq "1" ]]; then
+    isnum='^[0-9]+$'
+    if [[ $1 =~ $isnum ]]; then
         i=$1
         shift 1
     fi
@@ -552,7 +553,7 @@ function run_nc_test() {
 
     nsenter -n -t "${CONTAINER_NS_PIDS[$container_ns]}" timeout --foreground -v --kill=10 5 \
         nc $nc_common_args -l -p $container_port &>"$NETAVARK_TMPDIR/nc-out" <$stdin &
-    
+
     data=$(random_string)
     run_in_host_netns nc $nc_common_args $connect_ip $host_port <<<"$data"
 

--- a/test/testfiles/isolate1.json
+++ b/test/testfiles/isolate1.json
@@ -1,28 +1,33 @@
 {
-    "container_id": "01f0b94d5f4c",
-    "container_name": "isolatedcontainer",
+    "container_id": "01f0b94d5f4c1",
+    "container_name": "isolatedcontainer1",
     "networks": {
-        "podman1": {
+        "isolate1": {
             "interface_name": "eth1",
             "static_ips": [
-                "10.89.0.2"
+                "10.89.0.2",
+                "fd90::2"
             ]
         }
     },
     "network_info": {
-        "podman1": {
+        "isolate1": {
             "dns_enabled": false,
             "driver": "bridge",
             "id": "f3ac3c903b76f20e8a122b1eb2ba393ab2519ba516626be5b490b66dc96b54b7",
             "internal": false,
             "ipv6_enabled": false,
-            "name": "podman1",
-            "network_interface": "podman1",
+            "name": "isolate1",
+            "network_interface": "isolate1",
             "subnets": [
                 {
                     "gateway": "10.89.0.1",
                     "subnet": "10.89.0.0/24"
-                }
+                },
+                {
+                    "subnet": "fd90::/64",
+                    "gateway": "fd90::1"
+               }
             ],
             "options": {
                 "isolate": "true"

--- a/test/testfiles/isolate2.json
+++ b/test/testfiles/isolate2.json
@@ -1,0 +1,37 @@
+{
+    "container_id": "01f0b94d5f4c1",
+    "container_name": "isolatedcontainer1",
+    "networks": {
+        "isolate2": {
+            "interface_name": "eth2",
+            "static_ips": [
+                "10.89.1.2",
+                "fd99::2"
+            ]
+        }
+    },
+    "network_info": {
+        "isolate2": {
+            "dns_enabled": false,
+            "driver": "bridge",
+            "id": "f3ac3c903b76f20e8a122b1eb2ba393ab2519ba516626be5b490b66dc96b54b7",
+            "internal": false,
+            "ipv6_enabled": false,
+            "name": "isolate2",
+            "network_interface": "isolate2",
+            "subnets": [
+                {
+                    "gateway": "10.89.1.1",
+                    "subnet": "10.89.1.0/24"
+                },
+                {
+                    "subnet": "fd99::/64",
+                    "gateway": "fd99::1"
+               }
+            ],
+            "options": {
+                "isolate": "true"
+             }
+        }
+    }
+}


### PR DESCRIPTION
The isolate option doe snot work as expected. It currently prevents all
traffic does is not on the same network. Instead it should only block
traffic between two isolated networks, never external connections.

Also it did not work for ipv6 at all.

Fixes #331
