### PR TITLE
Support read only /proc

### DIFF
--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -1349,13 +1349,6 @@ impl CoreUtils {
         response.to_string()
     }
 
-    // get a sysctl value by the value's namespace
-    pub fn lookup_sysctl_value(ns_value: &str) -> Result<String, SysctlError> {
-        debug!("Getting sysctl value for {}", ns_value);
-        let ctl = sysctl::Ctl::new(ns_value)?;
-        ctl.value_string()
-    }
-
     /// Set a sysctl value by value's namespace.
     pub fn apply_sysctl_value(
         ns_value: impl AsRef<str>,
@@ -1365,6 +1358,14 @@ impl CoreUtils {
         let val = val.as_ref();
         debug!("Setting sysctl value for {} to {}", ns_value, val);
         let ctl = sysctl::Ctl::new(ns_value)?;
+        match ctl.value_string() {
+            Ok(result) => {
+                if result == val {
+                    return Ok(result);
+                }
+            }
+            Err(e) => return Err(e),
+        }
         ctl.set_value_string(val)
     }
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -55,7 +55,7 @@ function teardown() {
 function create_netns() {
     # create a new netns and mountns and run a sleep process to keep it alive
     # we have to redirect stdout/err to /dev/null otherwise bats will hang
-    unshare -n sleep inf &>/dev/null &
+    unshare -nm sleep inf &>/dev/null &
     echo $!
 }
 
@@ -89,7 +89,7 @@ function run_in_container_netns() {
         i=$1
         shift 1
     fi
-    run_helper nsenter -n -t "${CONTAINER_NS_PIDS[$i]}" "$@"
+    run_helper nsenter -n -m -w -t "${CONTAINER_NS_PIDS[$i]}" "$@"
 
 }
 
@@ -97,7 +97,7 @@ function run_in_container_netns() {
 #   run_in_host_netns  #  Run args in host netns
 ################
 function run_in_host_netns() {
-    run_helper nsenter -n -t $HOST_NS_PID "$@"
+    run_helper nsenter -n -m -w -t $HOST_NS_PID "$@"
 }
 
 #### Functions below are taken from podman and buildah and adapted to netavark.

--- a/test/testfiles/simplebridge.json
+++ b/test/testfiles/simplebridge.json
@@ -11,11 +11,11 @@
     },
     "network_info": {
         "podman": {
-            "dns_enabled": true,
+            "dns_enabled": false,
             "driver": "bridge",
             "id": "53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
             "internal": false,
-            "ipv6_enabled": true,
+            "ipv6_enabled": false,
             "name": "podman",
             "network_interface": "podman0",
             "subnets": [


### PR DESCRIPTION
When we set a syctl we should not error when they are already set to the
correct value. This allows us to work on a read only /proc when the user
already configured the correct sysctls.

CNI supports this as well.

Fixes #330