### PR TITLE
Add rust container images

### DIFF
--- a/contrib/container_images/Dockerfile.CentOS9
+++ b/contrib/container_images/Dockerfile.CentOS9
@@ -1,0 +1,2 @@
+FROM quay.io/centos/centos:stream9
+RUN dnf -y install cargo && dnf -y clean all

--- a/contrib/container_images/Dockerfile.UbuntuLatest
+++ b/contrib/container_images/Dockerfile.UbuntuLatest
@@ -1,0 +1,2 @@
+FROM docker.io/library/ubuntu:latest
+RUN apt-get update && apt-get -y install cargo

--- a/contrib/container_images/Dockerfile.f36
+++ b/contrib/container_images/Dockerfile.f36
@@ -1,0 +1,2 @@
+FROM registry.fedoraproject.org/fedora:36
+RUN dnf -y install cargo && dnf -y clean all


### PR DESCRIPTION
Add the build files for the rust container images to
contrib/container_images.  Build triggers will need to be done in quay
once this PR is commited.  From there, new container images for the rust
builds will be generated at each push to containers/netavark.

Signed-off-by: Brent Baude <bbaude@redhat.com>