### PR TITLE
Cirrus: Use CI VM images from aardvark

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ env:
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
     FEDORA_NAME: "fedora-35"
-    IMAGE_SUFFIX: "c4560539387953152"
+    IMAGE_SUFFIX: "c4801636756357120"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
 
 


### PR DESCRIPTION
The `c4560539387953152` images were pruned due to a monitoring SNAFU
(fix is in the works).  Luckily the same/similar image is used by
aardvark-dns and is still alive.  Bring that image over here to get
branch-CI working again.

Signed-off-by: Chris Evich <cevich@redhat.com>