### PR TITLE
Use latest aardvark-dns binary

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,8 +17,10 @@ env:
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
     FEDORA_NAME: "fedora-36"
-    IMAGE_SUFFIX: "c6457378097856512"
+    IMAGE_SUFFIX: "c5353795591864320"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
+    AARDVARK_DNS_BRANCH: "main"
+    AARDVARK_DNS_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_DNS_BRANCH}"
 
 
 gcp_credentials: ENCRYPTED[d6efdb7d6d4c61e3831df2193ca6348bb02f26cd931695f69d41930b1965f7dab72a838ca0902f6ed8cde66c7deddae2]

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -24,18 +24,20 @@ dnf -y install make automake gcc gcc-c++ kernel-devel
 show_env_vars
 
 if [[ "$CIRRUS_TASK_NAME" == "build_cross" ]]; then
-	# Setup short-name for rustembedded/cross
-	# TODO: We can move this to quay.io if we reach rate-limits, hopefully that's not gonna happen for netavark
-	echo '  "rustembedded/cross" = "docker.io/rustembedded/cross"'  >> /etc/containers/registries.conf.d/000-shortnames.conf
+    # TODO: Remove this when we're building natively, but remember to still
+    # collect the artifact in success_task for downstream CI use.
+    dnf reinstall -y netavark aardvark-dns
+    # Setup short-name for rustembedded/cross
+    # TODO: We can move this to quay.io if we reach rate-limits, hopefully that's not gonna happen for netavark
+    echo '  "rustembedded/cross" = "docker.io/rustembedded/cross"'  >> /etc/containers/registries.conf.d/000-shortnames.conf
+else
+    req_env_vars AARDVARK_DNS_URL
+
+    set -x  # show what's happening
+    curl --fail --location -o /tmp/aardvark-dns.zip "$AARDVARK_DNS_URL"
+    mkdir -p /usr/libexec/podman
+    cd /usr/libexec/podman
+    rm -f aardvark-dns*
+    unzip -o /tmp/aardvark-dns.zip
+    chmod a+x /usr/libexec/podman/aardvark-dns
 fi
-
-req_env_vars AARDVARK_DNS_URL
-
-set -x  # show what's happening
-curl --fail --location -o /tmp/aardvark-dns.zip "$AARDVARK_DNS_URL"
-mkdir -p /usr/libexec/podman
-cd /usr/libexec/podman
-rm -f aardvark-dns*
-unzip -o /tmp/aardvark-dns.zip
-chmod a+x /usr/libexec/podman/aardvark-dns
-

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -28,3 +28,14 @@ if [[ "$CIRRUS_TASK_NAME" == "build_cross" ]]; then
 	# TODO: We can move this to quay.io if we reach rate-limits, hopefully that's not gonna happen for netavark
 	echo '  "rustembedded/cross" = "docker.io/rustembedded/cross"'  >> /etc/containers/registries.conf.d/000-shortnames.conf
 fi
+
+req_env_vars AARDVARK_DNS_URL
+
+set -x  # show what's happening
+curl --fail --location -o /tmp/aardvark-dns.zip "$AARDVARK_DNS_URL"
+mkdir -p /usr/libexec/podman
+cd /usr/libexec/podman
+rm -f aardvark-dns*
+unzip -o /tmp/aardvark-dns.zip
+chmod a+x /usr/libexec/podman/aardvark-dns
+


### PR DESCRIPTION
Instead of using a packaged version of aardvark-dns, we grabbed the
latest main branch zip copy and use it instead.

Signed-off-by: Brent Baude <bbaude@redhat.com>