### PR TITLE
update netlink crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea4302b9759a7a88242299225ea3688e63c85ea136371bb6cf94fd674efaab"
+checksum = "f5dee5ed749373c298237fe694eb0a51887f4cc1a27370c8464bac4382348f1a"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
+checksum = "46f1cfa18f8cebe685373a2697915d7e0db3b4554918bba118385e0f71f258a7"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,14 +32,14 @@ serde_json = "1.0.82"
 sysctl = "0.4.4"
 url = "2.1.0"
 zbus = "2.2.0"
-rtnetlink = "0.10.1"
+rtnetlink = "0.11.0"
 futures = "0.3.21"
 nix = "0.24.1"
 rand = "0.8.5"
 tokio = { version = "1.20.0", features = ["full"] }
 zvariant = "3.4.1"
 sha2 = "0.10.1"
-netlink-packet-route = "0.12"
+netlink-packet-route = "0.13"
 
 [build-dependencies]
 chrono = "0.4.7"


### PR DESCRIPTION
This includes an import fix for kernel v5.19, without this it is
impossible to delete interfaces.

Fixes #345
