### PR TITLE
Fix Makefile for docs and main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build: bin $(CARGO_TARGET_DIR)
 .PHONY: clean
 clean:
 	rm -rf bin
-	if [[ "$(CARGO_TARGET_DIR)" == "targets" ]]; then rm -rf targets; fi
+	if [ "$(CARGO_TARGET_DIR)" = "targets" ]; then rm -rf targets; fi
 	$(MAKE) -C docs clean
 
 .PHONY: docs
@@ -103,7 +103,7 @@ vendor-rm-windows:
 .PHONY: vendor-tarball
 vendor-tarball: build vendor
 	VERSION=$(shell bin/netavark --version | cut -f2 -d" ") && \
-	[[ $$VERSION == *-dev ]] && echo "version ends with -dev" && exit 1; \
+	case $$VERSION in *-dev) echo "version ends with -dev" && exit 1;; esac; \
 	tar cvf netavark-$$VERSION-vendor.tar.gz vendor/ && \
 	gzip -c bin/netavark > netavark.gz && \
 	sha256sum netavark.gz netavark-$$VERSION-vendor.tar.gz > sha256sum

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
 PREFIX ?= /usr/local
 DATADIR ?= ${PREFIX}/share
 MANDIR ?= $(DATADIR)/man
-MANDOWN ?= $(shell command -v mandown)
+MANDOWN ?= $(shell export PATH; command -v mandown)
 
 docs: $(patsubst %.md,%,$(wildcard *.md))
 


### PR DESCRIPTION
The Makefile in the docs directory was unable to find the `mandown` binary despite it being in the PATH. Exporting it fixes it.

Also `[[ ... ]]` does not work with `sh`, which `make` uses by default. Using `[ ... ]` works fine.