### PR TITLE
Cirrus: cache x86_64 binary for other repos

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -287,7 +287,7 @@ success_task:
   env:
     CIRRUS_SHELL: "/bin/sh"
   clone_script: *noop
-  bin_cache: *ro_bin_cache_aarch64
+  bin_cache: *ro_bin_cache
   # The paths used for uploaded artifacts are relative here and in Cirrus
   script:
     # Cross-compiled binary artifact is required by other CI systems


### PR DESCRIPTION
Fixes: https://cirrus-ci.com/task/5065866822811648

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@cevich @Luap99 PTAL