### PR TITLE
create network driver interface

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -4,7 +4,7 @@ use crate::error::{NetavarkError, NetavarkResult};
 use crate::firewall;
 use crate::network;
 use crate::network::driver::{get_network_driver, DriverInfo};
-use crate::network::{core_utils, types};
+use crate::network::types;
 use clap::Parser;
 use log::{debug, error, info};
 use std::collections::HashMap;
@@ -12,8 +12,6 @@ use std::env;
 use std::fs::{self, File};
 use std::os::unix::prelude::AsRawFd;
 use std::path::Path;
-
-const IPV4_FORWARD: &str = "net.ipv4.ip_forward";
 
 #[derive(Parser, Debug)]
 pub struct Setup {
@@ -60,14 +58,6 @@ impl Setup {
             Ok(driver) => driver,
             Err(e) => return Err(e),
         };
-
-        // Sysctl setup
-        // set ipv4 forwarding to 1
-        core_utils::CoreUtils::apply_sysctl_value(IPV4_FORWARD, "1")?;
-        // set ipv6 forwarding to 1
-        // if network.ipv6_enabled {
-        //     core_utils::CoreUtils::apply_sysctl_value(IPV6_FORWARD, "1")?;
-        // }
 
         let mut response: HashMap<String, types::StatusBlock> = HashMap::new();
 

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -213,7 +213,7 @@ impl firewall::FirewallDriver for FirewallD {
                     rich_rules = Array::new(sig);
                 }
             }
-            for dns_ip in &setup_portfw.dns_server_ips {
+            for dns_ip in setup_portfw.dns_server_ips {
                 let ip_family = if dns_ip.is_ipv6() { "ipv6" } else { "ipv4" };
                 let rule = format!("rule family=\"{}\" destination address=\"{}\" forward-port port=\"53\" protocol=\"udp\" to-port=\"{}\" to-addr=\"{}\"",
                                    ip_family, dns_ip, setup_portfw.dns_port, dns_ip);
@@ -371,7 +371,7 @@ impl firewall::FirewallDriver for FirewallD {
         }
         if let Some(old_rich_rules) = old_rich_rules_option {
             let mut rules_to_delete: Vec<String> = vec![];
-            for dns_ip in &teardown_pf.config.dns_server_ips {
+            for dns_ip in teardown_pf.config.dns_server_ips {
                 let ip_family = if dns_ip.is_ipv6() { "ipv6" } else { "ipv4" };
                 let rule = format!("rule family=\"{}\" destination address=\"{}\" forward-port port=\"53\" protocol=\"udp\" to-port=\"{}\" to-addr=\"{}\"",
                                    ip_family, dns_ip, teardown_pf.config.dns_port, dns_ip);

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -432,7 +432,7 @@ pub fn get_port_forwarding_chains<'a>(
 
     // Create redirection for aardvark-dns on non-standard port
     if pfwd.dns_port != 53 {
-        for dns_ip in &pfwd.dns_server_ips {
+        for dns_ip in pfwd.dns_server_ips {
             if is_ipv6 != dns_ip.is_ipv6() {
                 continue;
             }

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -1,0 +1,379 @@
+use std::{collections::HashMap, net::IpAddr};
+
+use ipnet::IpNet;
+use log::{debug, error};
+use rand::Rng;
+
+use crate::{
+    dns::aardvark::AardvarkEntry,
+    error::{NetavarkError, NetavarkResult},
+    firewall::iptables::MAX_HASH_SIZE,
+    network::{constants, types},
+};
+
+use super::{
+    constants::{NO_CONTAINER_INTERFACE_ERROR, OPTION_ISOLATE, OPTION_MTU},
+    core::Core,
+    core_utils::{get_ipam_addresses, parse_option, CoreUtils},
+    driver::{self, DriverInfo},
+    internal_types::{
+        IPAMAddresses, PortForwardConfig, SetupNetwork, TearDownNetwork, TeardownPortForward,
+    },
+    types::{StatusBlock, Subnet},
+};
+
+const NO_BRIDGE_NAME_ERROR: &str = "no bridge interface name given";
+
+struct InternalData {
+    /// interface name of the veth pair inside the container netns
+    container_interface_name: String,
+    /// interface name of the bridge for on the host
+    bridge_interface_name: String,
+    /// static mac address
+    mac_address: Option<Vec<u8>>,
+    /// ip addresses
+    ipam: IPAMAddresses,
+    /// mtu for the network interfaces (0 if default)
+    mtu: u32,
+    /// if this network should be isolated from others
+    isolate: bool,
+    // TODO: add vlan
+}
+
+pub struct Bridge<'a> {
+    info: DriverInfo<'a>,
+    data: Option<InternalData>,
+}
+
+impl<'a> Bridge<'a> {
+    pub fn new(info: DriverInfo<'a>) -> Self {
+        Bridge { info, data: None }
+    }
+}
+
+impl driver::NetworkDriver for Bridge<'_> {
+    fn network_name(&self) -> String {
+        self.info.network.name.clone()
+    }
+
+    fn validate(&mut self) -> NetavarkResult<()> {
+        let bridge_name = get_interface_name(self.info.network.network_interface.clone())?;
+        if self.info.per_network_opts.interface_name.is_empty() {
+            return Err(NetavarkError::msg_str(NO_CONTAINER_INTERFACE_ERROR));
+        }
+        let ipam = get_ipam_addresses(self.info.per_network_opts, self.info.network)?;
+
+        let mtu: u32 = parse_option(&self.info.network.options, OPTION_MTU, 0)?;
+        let isolate: bool = parse_option(&self.info.network.options, OPTION_ISOLATE, false)?;
+
+        let static_mac = match &self.info.per_network_opts.static_mac {
+            Some(mac) => Some(CoreUtils::decode_address_from_hex(mac)?),
+            None => None,
+        };
+
+        self.data = Some(InternalData {
+            bridge_interface_name: bridge_name,
+            container_interface_name: self.info.per_network_opts.interface_name.clone(),
+            mac_address: static_mac,
+            ipam,
+            mtu,
+            isolate,
+        });
+        Ok(())
+    }
+
+    fn setup(&self) -> NetavarkResult<(StatusBlock, Option<AardvarkEntry>)> {
+        let data = match &self.data {
+            Some(d) => d,
+            None => {
+                return Err(NetavarkError::msg_str(
+                    "must call validate() before setup()",
+                ))
+            }
+        };
+
+        debug!("Setup network {}", self.info.network.name);
+        debug!(
+            "Container interface name: {} with IP addresses {:?}",
+            data.container_interface_name, data.ipam.container_addresses
+        );
+        debug!(
+            "Bridge name: {} with IP addresses {:?}",
+            data.bridge_interface_name, data.ipam.gateway_addresses
+        );
+
+        // get random name for host veth, TODO let kernel assign name
+        let host_veth_name = format!("veth{:x}", rand::thread_rng().gen::<u32>());
+        let container_veth_mac = match Core::add_bridge_and_veth(
+            &data.bridge_interface_name,
+            &data.ipam.container_addresses,
+            &data.ipam.gateway_addresses,
+            data.mac_address.clone(),
+            &data.container_interface_name,
+            &host_veth_name,
+            self.info.netns_container,
+            data.mtu,
+            data.ipam.ipv6_enabled,
+        ) {
+            Ok(addr) => addr,
+            Err(err) => {
+                return Err(NetavarkError::Message(format!(
+                    "failed to configure bridge and veth interface: {}",
+                    err
+                )))
+            }
+        };
+
+        //  StatusBlock response
+        let mut response = types::StatusBlock {
+            dns_server_ips: Some(Vec::<IpAddr>::new()),
+            dns_search_domains: Some(Vec::<String>::new()),
+            interfaces: Some(HashMap::new()),
+        };
+        // interfaces map, but we only ever expect one, for response
+        let mut interfaces: HashMap<String, types::NetInterface> = HashMap::new();
+
+        let interface = types::NetInterface {
+            mac_address: container_veth_mac,
+            subnets: Option::from(data.ipam.net_addresses.clone()),
+        };
+        // Add interface to interfaces (part of StatusBlock)
+        interfaces.insert(data.container_interface_name.clone(), interface);
+        let _ = response.interfaces.insert(interfaces);
+        if self.info.network.dns_enabled {
+            let _ = response
+                .dns_server_ips
+                .insert(data.ipam.nameservers.clone());
+            // Note: this is being added so podman setup is backward compatible with the design
+            // which we had with dnsname/dnsmasq. I belive this can be fixed in later releases.
+            let _ = response
+                .dns_search_domains
+                .insert(vec![constants::PODMAN_DEFAULT_SEARCH_DOMAIN.to_string()]);
+        }
+
+        // if the network is internal block routing and do not setup firewall rules
+        if self.info.network.internal {
+            CoreUtils::apply_sysctl_value(
+                format!(
+                    "/proc/sys/net/ipv4/conf/{}/forwarding",
+                    data.bridge_interface_name
+                ),
+                "0",
+            )?;
+            if data.ipam.ipv6_enabled {
+                CoreUtils::apply_sysctl_value(
+                    format!(
+                        "/proc/sys/net/ipv6/conf/{}/forwarding",
+                        data.bridge_interface_name
+                    ),
+                    "0",
+                )?;
+            }
+            // return here to skip setting up firewall rules
+            return Ok((response, None));
+        }
+
+        self.setup_firewall(data)?;
+
+        Ok((response, None))
+    }
+
+    fn teardown(&self) -> NetavarkResult<()> {
+        Core::remove_container_interface(
+            &self.info.per_network_opts.interface_name,
+            self.info.netns_container,
+        )?; // handle error and continue
+
+        let complete_teardown =
+            match get_interface_name(self.info.network.network_interface.clone()) {
+                Ok(bridge_name) => {
+                    let complete_teardown =
+                        match CoreUtils::bridge_count_connected_interfaces(&bridge_name) {
+                            Ok(ints) => ints.is_empty(),
+                            Err(e) => {
+                                error!(
+                                    "failed to count veth interface on bridge {}: {}",
+                                    bridge_name, e
+                                );
+                                false
+                            }
+                        };
+
+                    CoreUtils::remove_interface(&bridge_name)?; // handle error and continue
+                    complete_teardown
+                }
+                Err(e) => {
+                    error!(
+                        "failed to get bridge name on network {}: {}",
+                        self.info.network.name, e
+                    );
+                    false
+                }
+            };
+
+        if self.info.network.internal {
+            return Ok(());
+        }
+
+        self.teardown_firewall(complete_teardown)?;
+
+        Ok(())
+    }
+}
+
+fn get_interface_name(name: Option<String>) -> NetavarkResult<String> {
+    let name = match name {
+        None => return Err(NetavarkError::msg_str(NO_BRIDGE_NAME_ERROR)),
+        Some(n) => {
+            if n.is_empty() {
+                return Err(NetavarkError::msg_str(NO_BRIDGE_NAME_ERROR));
+            }
+            n
+        }
+    };
+    Ok(name)
+}
+
+impl<'a> Bridge<'a> {
+    fn get_firewall_conf(
+        &'a self,
+        container_addresses: &Vec<IpNet>,
+        nameservers: &'a Vec<IpAddr>,
+        isolate: bool,
+    ) -> NetavarkResult<(SetupNetwork, PortForwardConfig)> {
+        let id_network_hash =
+            CoreUtils::create_network_hash(&self.info.network.name, MAX_HASH_SIZE);
+        let sn = SetupNetwork {
+            net: self.info.network.clone(),
+            network_hash_name: id_network_hash.clone(),
+            isolation: isolate,
+        };
+
+        let mut has_ipv4 = false;
+        let mut has_ipv6 = false;
+        let mut addr_v4: Option<IpAddr> = None;
+        let mut addr_v6: Option<IpAddr> = None;
+        let mut net_v4: Option<Subnet> = None;
+        let mut net_v6: Option<Subnet> = None;
+        for net in container_addresses {
+            match net {
+                IpNet::V4(v4) => {
+                    if has_ipv4 {
+                        continue;
+                    }
+                    addr_v4 = Some(IpAddr::V4(v4.addr()));
+                    net_v4 = Some(Subnet {
+                        gateway: None,
+                        subnet: IpNet::new(v4.network().into(), v4.prefix_len()).unwrap(),
+                        lease_range: None,
+                    });
+                    has_ipv4 = true;
+                }
+                IpNet::V6(v6) => {
+                    if has_ipv6 {
+                        continue;
+                    }
+
+                    addr_v6 = Some(IpAddr::V6(v6.addr()));
+                    net_v6 = Some(Subnet {
+                        gateway: None,
+                        subnet: IpNet::new(v6.network().into(), v6.prefix_len()).unwrap(),
+                        lease_range: None,
+                    });
+                    has_ipv6 = true;
+                }
+            }
+        }
+        let spf = PortForwardConfig {
+            container_id: self.info.container_id.clone(),
+            port_mappings: self.info.port_mappings.clone().unwrap_or_default(),
+            network_name: self.info.network.name.clone(),
+            network_hash_name: id_network_hash,
+            container_ip_v4: addr_v4,
+            subnet_v4: net_v4,
+            container_ip_v6: addr_v6,
+            subnet_v6: net_v6,
+            dns_port: self.info.dns_port,
+            dns_server_ips: nameservers,
+        };
+        Ok((sn, spf))
+    }
+
+    fn setup_firewall(&self, data: &InternalData) -> NetavarkResult<()> {
+        let (sn, spf) = self.get_firewall_conf(
+            &data.ipam.container_addresses,
+            &data.ipam.nameservers,
+            data.isolate,
+        )?;
+
+        self.info.firewall.setup_network(sn)?;
+
+        if !spf.port_mappings.is_empty() {
+            // Need to enable sysctl localnet so that traffic can pass
+            // through localhost to containers
+
+            CoreUtils::apply_sysctl_value(
+                format!(
+                    "net.ipv4.conf.{}.route_localnet",
+                    data.bridge_interface_name
+                ),
+                "1",
+            )?;
+        }
+
+        self.info.firewall.setup_port_forward(spf)?;
+        Ok(())
+    }
+
+    fn teardown_firewall(&self, complete_teardown: bool) -> NetavarkResult<()> {
+        // we have to allocate the vecoros here in the top level to avoid
+        // "borrow later used" problems
+        let (container_addresses, nameservers);
+
+        let (container_addresses_ref, nameservers_ref, isolate) = match &self.data {
+            Some(d) => (&d.ipam.container_addresses, &d.ipam.nameservers, d.isolate),
+            None => {
+                // options are not yet parsed
+                let isolate = match parse_option(&self.info.network.options, OPTION_ISOLATE, false)
+                {
+                    Ok(i) => i,
+                    Err(e) => {
+                        // just log we still try to do as much as possible for cleanup
+                        error!("failed to parse {} option: {}", OPTION_ISOLATE, e);
+                        false
+                    }
+                };
+
+                (container_addresses, nameservers) =
+                    match get_ipam_addresses(self.info.per_network_opts, self.info.network) {
+                        Ok(i) => (i.container_addresses, i.nameservers),
+                        Err(e) => {
+                            // just log we still try to do as much as possible for cleanup
+                            error!("failed to parse ipam options: {}", e);
+                            (Vec::new(), Vec::new())
+                        }
+                    };
+                (&container_addresses, &nameservers, isolate)
+            }
+        };
+
+        let (sn, spf) =
+            self.get_firewall_conf(container_addresses_ref, nameservers_ref, isolate)?;
+
+        let tn = TearDownNetwork {
+            config: sn,
+            complete_teardown,
+        };
+
+        // FIXME store error and continue
+        self.info.firewall.teardown_network(tn)?;
+
+        let tpf = TeardownPortForward {
+            config: spf,
+            complete_teardown,
+        };
+
+        self.info.firewall.teardown_port_forward(tpf)?;
+        Ok(())
+    }
+}

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -204,7 +204,9 @@ impl driver::NetworkDriver for Bridge<'_> {
                             }
                         };
 
-                    CoreUtils::remove_interface(&bridge_name)?; // handle error and continue
+                    if complete_teardown {
+                        CoreUtils::remove_interface(&bridge_name)?; // handle error and continue
+                    }
                     complete_teardown
                 }
                 Err(e) => {

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -15,3 +15,12 @@ pub const MACVLAN_MODE_SOURCE: u32 = 16;
 pub const IPAM_HOSTLOCAL: &str = "host-local";
 pub const IPAM_DHCP: &str = "dhcp";
 pub const IPAM_NONE: &str = "none";
+
+pub const DRIVER_BRIDGE: &str = "bridge";
+pub const DRIVER_MACVLAN: &str = "macvlan";
+
+pub const OPTION_ISOLATE: &str = "isolate";
+pub const OPTION_MTU: &str = "mtu";
+pub const OPTION_MODE: &str = "mode";
+
+pub const NO_CONTAINER_INTERFACE_ERROR: &str = "no container interface name given";

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -1,129 +1,31 @@
-use crate::network::{constants, core_utils, types};
+use crate::network::core_utils;
 use ipnet;
 use log::debug;
 use log::warn;
 use nix::sched;
-use rand::Rng;
-use std::collections::HashMap;
-use std::fs::File;
 use std::io::Error;
-use std::net::IpAddr;
+
 use std::os::unix::prelude::*;
 use std::thread;
 
-pub struct Core {
-    pub networkns: String,
-}
+pub struct Core {}
 
 impl Core {
-    pub fn bridge_per_podman_network(
-        per_network_opts: &types::PerNetworkOptions,
-        network: &types::Network,
-        netns: &str,
-    ) -> Result<types::StatusBlock, std::io::Error> {
-        //  StatusBlock response
-        let mut response = types::StatusBlock {
-            dns_server_ips: Some(Vec::<IpAddr>::new()),
-            dns_search_domains: Some(Vec::<String>::new()),
-            interfaces: Some(HashMap::new()),
-        };
-        // get bridge name
-        let bridge_name = match network.network_interface.clone() {
-            None => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "no bridge provided".to_string(),
-                ))
-            }
-            Some(i) => i,
-        };
-        // interfaces map, but we only ever expect one, for response
-        let mut interfaces: HashMap<String, types::NetInterface> = HashMap::new();
-
-        // mtu to configure
-        let mtu_config = match network.options.as_ref().and_then(|map| map.get("mtu")) {
-            Some(mtu) => match mtu.parse() {
-                Ok(mtu) => mtu,
-                Err(err) => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("unable to parse mtu: {}", err),
-                    ))
-                }
-            },
-            // default mtu is 0 (the kernel will pick one)
-            None => 0,
-        };
-
-        let container_veth_name: String = per_network_opts.interface_name.to_owned();
-        let static_mac = match &per_network_opts.static_mac {
-            Some(mac) => mac,
-            None => "",
-        };
-
-        let ipam = core_utils::get_ipam_addresses(per_network_opts, network)?;
-
-        debug!("Container veth name: {:?}", container_veth_name);
-        debug!("Brige name: {:?}", bridge_name);
-        debug!("IP address for veth vector: {:?}", ipam.container_addresses);
-        debug!("Gateway ip address vector: {:?}", ipam.gateway_addresses);
-
-        // get random name for host veth
-        let host_veth_name = format!("veth{:x}", rand::thread_rng().gen::<u32>());
-
-        let container_veth_mac = match Core::add_bridge_and_veth(
-            &bridge_name,
-            ipam.container_addresses,
-            ipam.gateway_addresses,
-            static_mac,
-            &container_veth_name,
-            &host_veth_name,
-            netns,
-            mtu_config,
-            ipam.ipv6_enabled,
-        ) {
-            Ok(addr) => addr,
-            Err(err) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("failed to configure bridge and veth interface: {}", err),
-                ))
-            }
-        };
-        debug!("Container veth mac: {:?}", container_veth_mac);
-        let interface = types::NetInterface {
-            mac_address: container_veth_mac,
-            subnets: Option::from(ipam.net_addresses),
-        };
-        // Add interface to interfaces (part of StatusBlock)
-        interfaces.insert(container_veth_name, interface);
-        let _ = response.interfaces.insert(interfaces);
-        if network.dns_enabled {
-            let _ = response.dns_server_ips.insert(ipam.nameservers);
-            // Note: this is being added so podman setup is backward compatible with the design
-            // which we had with dnsname/dnsmasq. I belive this can be fixed in later releases.
-            let _ = response
-                .dns_search_domains
-                .insert(vec![constants::PODMAN_DEFAULT_SEARCH_DOMAIN.to_string()]);
-        }
-        Ok(response)
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub fn add_bridge_and_veth(
         br_name: &str,
-        netns_ipaddr: Vec<ipnet::IpNet>,
-        gw_ipaddr: Vec<ipnet::IpNet>,
-        static_mac: &str,
+        netns_ipaddr: &Vec<ipnet::IpNet>,
+        gw_ipaddr: &Vec<ipnet::IpNet>,
+        static_mac: Option<Vec<u8>>,
         container_veth_name: &str,
         host_veth_name: &str,
-        netns: &str,
+        netns_fd: RawFd,
         mtu_config: u32,
         ipv6_enabled: bool,
     ) -> Result<String, std::io::Error> {
         //copy subnet masks and gateway ips since we are going to use it later
         let mut gw_ipaddr_clone = Vec::new();
-        for gw_ip in &gw_ipaddr {
+        for gw_ip in gw_ipaddr {
             gw_ipaddr_clone.push(*gw_ip)
         }
         //call configure bridge
@@ -146,7 +48,7 @@ impl Core {
             host_veth_name,
             container_veth_name,
             br_name,
-            netns,
+            netns_fd,
             mtu_config,
             ipv6_enabled,
         ) {
@@ -169,176 +71,70 @@ impl Core {
         //bridge and veth configured successfully
         //do we want mac ?
         //TODO: we can verify MAC here
-
-        match File::open(&netns) {
-            Ok(netns_file) => {
-                let netns_fd = netns_file.as_raw_fd();
-                //clone values before spwaning thread in new namespace
-                let container_veth_name_clone: String = container_veth_name.to_owned();
-                let static_mac_clone: String = static_mac.to_owned();
-                // So complicated cloning for threads ?
-                // TODO: simplify this later
-                let mut netns_ipaddr_clone = Vec::new();
-                for ip in &netns_ipaddr {
-                    netns_ipaddr_clone.push(*ip)
-                }
-                let handle = thread::spawn(move || -> Result<String, Error> {
-                    if let Err(err) = sched::setns(netns_fd, sched::CloneFlags::CLONE_NEWNET) {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("failed to setns to fd={}: {}", netns_fd, err),
-                        ));
-                    }
-
-                    if let Err(err) = core_utils::CoreUtils::configure_netns_interface_async(
-                        &container_veth_name_clone,
-                        netns_ipaddr_clone,
-                        gw_ipaddr_clone,
-                        &static_mac_clone,
-                    ) {
-                        return Err(err);
-                    }
-                    debug!(
-                        "Configured static up address for {}",
-                        container_veth_name_clone
-                    );
-
-                    if let Err(er) = core_utils::CoreUtils::turn_up_interface("lo") {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("failed while turning up `lo` in container namespace {}", er),
-                        ));
-                    }
-
-                    //return MAC address to status block could use this
-                    match core_utils::CoreUtils::get_interface_address(&container_veth_name_clone) {
-                        Ok(addr) => Ok(addr),
-                        Err(err) => Err(err),
-                    }
-                });
-                match handle.join() {
-                    Ok(interface_address) => interface_address,
-                    Err(err) => {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("failed to join: {:?}", err),
-                        ))
-                    }
-                }
+        //clone values before spwaning thread in new namespace
+        let container_veth_name_clone: String = container_veth_name.to_owned();
+        let static_mac_clone = static_mac;
+        // So complicated cloning for threads ?
+        // TODO: simplify this later
+        let mut netns_ipaddr_clone = Vec::new();
+        for ip in netns_ipaddr {
+            netns_ipaddr_clone.push(*ip)
+        }
+        let handle = thread::spawn(move || -> Result<String, Error> {
+            if let Err(err) = sched::setns(netns_fd, sched::CloneFlags::CLONE_NEWNET) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("failed to setns to fd={}: {}", netns_fd, err),
+                ));
             }
+
+            if let Err(err) = core_utils::CoreUtils::configure_netns_interface_async(
+                &container_veth_name_clone,
+                netns_ipaddr_clone,
+                &gw_ipaddr_clone,
+                static_mac_clone,
+            ) {
+                return Err(err);
+            }
+            debug!(
+                "Configured static up address for {}",
+                container_veth_name_clone
+            );
+
+            if let Err(er) = core_utils::CoreUtils::turn_up_interface("lo") {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("failed while turning up `lo` in container namespace {}", er),
+                ));
+            }
+
+            //return MAC address to status block could use this
+            match core_utils::CoreUtils::get_interface_address(&container_veth_name_clone) {
+                Ok(addr) => Ok(addr),
+                Err(err) => Err(err),
+            }
+        });
+        match handle.join() {
+            Ok(interface_address) => interface_address,
             Err(err) => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("failed to open the netns file: {}", err),
+                    format!("failed to join: {:?}", err),
                 ))
             }
         }
     }
 
-    pub fn macvlan_per_podman_network(
-        per_network_opts: &types::PerNetworkOptions,
-        network: &types::Network,
-        netns: &str,
-    ) -> Result<types::StatusBlock, std::io::Error> {
-        //  StatusBlock response
-        let mut response = types::StatusBlock {
-            dns_server_ips: Some(Vec::<IpAddr>::new()),
-            dns_search_domains: Some(Vec::<String>::new()),
-            interfaces: Some(HashMap::new()),
-        };
-
-        // parse mode option
-        let macvlan_mode = match network.options.as_ref().and_then(|map| map.get("mode")) {
-            Some(mode) => match core_utils::CoreUtils::get_macvlan_mode_from_string(mode) {
-                Ok(mode) => mode,
-                Err(err) => {
-                    return Err(err);
-                }
-            },
-            // default MACVLAN_MODE is bridge
-            None => constants::MACVLAN_MODE_BRIDGE,
-        };
-
-        // mtu to configure
-        let mtu_config = match network.options.as_ref().and_then(|map| map.get("mtu")) {
-            Some(mtu) => match mtu.parse() {
-                Ok(mtu) => mtu,
-                Err(err) => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("unable to parse mtu: {}", err),
-                    ))
-                }
-            },
-            // default mtu is 0 (the kernel will pick one)
-            None => 0,
-        };
-
-        // get master interface name
-        let master_ifname = match network.network_interface.as_deref() {
-            None | Some("") => {
-                if let Ok(ifname) = core_utils::CoreUtils::get_default_route_interface() {
-                    ifname
-                } else {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "unable to find any valid master interface for macvlan",
-                    ));
-                }
-            }
-            Some(interface) => interface.to_string(),
-        };
-
-        // interfaces map, but we only ever expect one, for response
-        let mut interfaces: HashMap<String, types::NetInterface> = HashMap::new();
-        let container_macvlan_name: String = per_network_opts.interface_name.to_owned();
-        let mut ipam = core_utils::get_ipam_addresses(per_network_opts, network)?;
-        // Remove gateways when marked as internal network
-        if network.internal {
-            ipam.gateway_addresses = Vec::new();
-        }
-
-        debug!("Container macvlan name: {:?}", container_macvlan_name);
-        debug!("Master interface name: {:?}", master_ifname);
-        debug!("IP address for macvlan: {:?}", ipam.container_addresses);
-
-        // create macvlan
-        let container_macvlan_mac = match Core::add_macvlan(
-            &master_ifname,
-            &container_macvlan_name,
-            ipam.gateway_addresses,
-            macvlan_mode,
-            mtu_config,
-            ipam.container_addresses,
-            netns,
-        ) {
-            Ok(addr) => addr,
-            Err(err) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("failed configure macvlan: {}", err),
-                ))
-            }
-        };
-        debug!("Container macvlan mac: {:?}", container_macvlan_mac);
-        let interface = types::NetInterface {
-            mac_address: container_macvlan_mac,
-            subnets: Option::from(ipam.net_addresses),
-        };
-        // Add interface to interfaces (part of StatusBlock)
-        interfaces.insert(container_macvlan_name, interface);
-        let _ = response.interfaces.insert(interfaces);
-        Ok(response)
-    }
-
+    #[allow(clippy::too_many_arguments)]
     pub fn add_macvlan(
         master_ifname: &str,
         container_macvlan: &str,
-        gw_ipaddr: Vec<ipnet::IpNet>,
+        gw_ipaddr: &[ipnet::IpNet],
         macvlan_mode: u32,
         mtu: u32,
-        netns_ipaddr: Vec<ipnet::IpNet>,
-        netns: &str,
+        netns_ipaddr: &[ipnet::IpNet],
+        static_mac: Option<Vec<u8>>,
+        netns: RawFd,
     ) -> Result<String, std::io::Error> {
         match core_utils::CoreUtils::configure_macvlan_async(
             master_ifname,
@@ -363,144 +159,82 @@ impl Core {
             }
         };
 
-        match File::open(&netns) {
-            Ok(netns_file) => {
-                let netns_fd = netns_file.as_raw_fd();
-                //clone values before spwaning thread in new namespace
-                let container_macvlan_clone: String = container_macvlan.to_owned();
-                // So complicated cloning for threads ?
-                // TODO: simplify this later
-                let mut netns_ipaddr_clone = Vec::new();
-                for ip in &netns_ipaddr {
-                    netns_ipaddr_clone.push(*ip)
-                }
-                let handle = thread::spawn(move || -> Result<String, Error> {
-                    if let Err(err) = sched::setns(netns_fd, sched::CloneFlags::CLONE_NEWNET) {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("failed to setns to fd={}: {}", netns_fd, err),
-                        ));
-                    }
-
-                    if let Err(err) = core_utils::CoreUtils::configure_netns_interface_async(
-                        &container_macvlan_clone,
-                        netns_ipaddr_clone,
-                        gw_ipaddr,
-                        "", // do we want static mac support for macvlan ? probably later.
-                    ) {
-                        return Err(err);
-                    }
-                    debug!(
-                        "Configured static up address for {}",
-                        container_macvlan_clone
-                    );
-
-                    if let Err(er) = core_utils::CoreUtils::turn_up_interface("lo") {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("failed while turning up `lo` in container namespace {}", er),
-                        ));
-                    }
-
-                    //return MAC address to status block could use this
-                    match core_utils::CoreUtils::get_interface_address(&container_macvlan_clone) {
-                        Ok(addr) => Ok(addr),
-                        Err(err) => Err(err),
-                    }
-                });
-                match handle.join() {
-                    Ok(interface_address) => interface_address,
-                    Err(err) => {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("failed to join: {:?}", err),
-                        ))
-                    }
-                }
+        //clone values before spwaning thread in new namespace
+        let container_macvlan_clone: String = container_macvlan.to_owned();
+        // So complicated cloning for threads ?
+        // TODO: simplify this later
+        let netns_ipaddr_clone = netns_ipaddr.to_vec();
+        let gw_addrs_clone = gw_ipaddr.to_vec();
+        let handle = thread::spawn(move || -> Result<String, Error> {
+            if let Err(err) = sched::setns(netns, sched::CloneFlags::CLONE_NEWNET) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("failed to setns to fd={}: {}", netns, err),
+                ));
             }
+
+            if let Err(err) = core_utils::CoreUtils::configure_netns_interface_async(
+                &container_macvlan_clone,
+                netns_ipaddr_clone,
+                &gw_addrs_clone,
+                static_mac,
+            ) {
+                return Err(err);
+            }
+            debug!(
+                "Configured static up address for {}",
+                container_macvlan_clone
+            );
+
+            if let Err(er) = core_utils::CoreUtils::turn_up_interface("lo") {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("failed while turning up `lo` in container namespace {}", er),
+                ));
+            }
+
+            //return MAC address to status block could use this
+            match core_utils::CoreUtils::get_interface_address(&container_macvlan_clone) {
+                Ok(addr) => Ok(addr),
+                Err(err) => Err(err),
+            }
+        });
+        match handle.join() {
+            Ok(interface_address) => interface_address,
             Err(err) => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("failed to open the netns file: {}", err),
+                    format!("failed to join: {:?}", err),
                 ))
             }
         }
     }
 
-    pub fn remove_interface_per_podman_network(
-        per_network_opts: &types::PerNetworkOptions,
-        network: &types::Network,
-        netns: &str,
-    ) -> Result<types::StatusBlock, std::io::Error> {
-        //  StatusBlock response
-        let mut response = types::StatusBlock {
-            dns_server_ips: Some(Vec::<IpAddr>::new()),
-            dns_search_domains: Some(Vec::<String>::new()),
-            interfaces: Some(HashMap::new()),
-        };
-        let container_veth_name: String = per_network_opts.interface_name.to_owned();
-        debug!(
-            "Container veth name being removed: {:?}",
-            container_veth_name
-        );
+    pub fn remove_container_interface(ifname: &str, netns: RawFd) -> Result<(), std::io::Error> {
+        let container_veth: String = ifname.to_owned();
+        let handle = thread::spawn(move || -> Result<(), Error> {
+            if let Err(err) = sched::setns(netns, sched::CloneFlags::CLONE_NEWNET) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "failed to setns on container network namespace fd={}: {}",
+                        netns, err
+                    ),
+                ));
+            }
 
-        if let Err(err) = Core::remove_container_veth(&container_veth_name, netns) {
+            if let Err(err) = core_utils::CoreUtils::remove_interface(&container_veth) {
+                return Err(err);
+            }
+
+            Ok(())
+        });
+        if let Err(err) = handle.join() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                format!("unable to remove container veth: {}", err),
+                format!("unable to join thread: {:?}", err),
             ));
         }
-
-        debug!("Container veth removed: {:?}", container_veth_name);
-
-        let ipam = core_utils::get_ipam_addresses(per_network_opts, network)?;
-        if network.dns_enabled {
-            let _ = response.dns_server_ips.insert(ipam.nameservers);
-            // Note: this is being added so podman setup is backward compatible with the design
-            // which we had with dnsname/dnsmasq. I belive this can be fixed in later releases.
-            let _ = response
-                .dns_search_domains
-                .insert(vec![constants::PODMAN_DEFAULT_SEARCH_DOMAIN.to_string()]);
-        }
-        Ok(response)
-    }
-
-    fn remove_container_veth(ifname: &str, netns: &str) -> Result<(), std::io::Error> {
-        match File::open(netns) {
-            Ok(file) => {
-                let netns_fd = file.as_raw_fd();
-                let container_veth: String = ifname.to_owned();
-                let handle = thread::spawn(move || -> Result<(), Error> {
-                    if let Err(err) = sched::setns(netns_fd, sched::CloneFlags::CLONE_NEWNET) {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!(
-                                "failed to setns on container network namespace fd={}: {}",
-                                netns_fd, err
-                            ),
-                        ));
-                    }
-
-                    if let Err(err) = core_utils::CoreUtils::remove_interface(&container_veth) {
-                        return Err(err);
-                    }
-
-                    Ok(())
-                });
-                if let Err(err) = handle.join() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("unable to join thread: {:?}", err),
-                    ));
-                }
-            }
-            Err(err) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("failed to open network namespace: {}", err),
-                ))
-            }
-        };
 
         Ok(())
     }

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -1,0 +1,48 @@
+use crate::{
+    dns::aardvark::AardvarkEntry,
+    error::{NetavarkError, NetavarkResult},
+    firewall::FirewallDriver,
+};
+
+use super::{
+    bridge::Bridge,
+    constants,
+    macvlan::MacVlan,
+    types::{Network, PerNetworkOptions, PortMapping, StatusBlock},
+};
+use std::os::unix::io::RawFd;
+
+pub struct DriverInfo<'a> {
+    pub firewall: &'a dyn FirewallDriver,
+    pub container_id: &'a String,
+    //pub netns_host: RawFd,
+    pub netns_container: RawFd,
+    pub network: &'a Network,
+    pub per_network_opts: &'a PerNetworkOptions,
+    pub port_mappings: &'a Option<Vec<PortMapping>>,
+    pub dns_port: u16,
+}
+
+pub trait NetworkDriver {
+    /// validate the driver options
+    fn validate(&mut self) -> NetavarkResult<()>;
+    /// setup the network interfaces/firewall rules for this driver
+    fn setup(&self) -> NetavarkResult<(StatusBlock, Option<AardvarkEntry>)>;
+    /// teardown the network interfaces/firewall rules for this driver
+    fn teardown(&self) -> NetavarkResult<()>;
+
+    /// return the network name
+    fn network_name(&self) -> String;
+}
+
+pub fn get_network_driver(info: DriverInfo) -> NetavarkResult<Box<dyn NetworkDriver + '_>> {
+    match info.network.driver.as_str() {
+        constants::DRIVER_BRIDGE => Ok(Box::new(Bridge::new(info))),
+        constants::DRIVER_MACVLAN => Ok(Box::new(MacVlan::new(info))),
+
+        _ => Err(NetavarkError::Message(format!(
+            "unknown network driver {}",
+            info.network.driver
+        ))),
+    }
+}

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -4,8 +4,8 @@ use std::net::IpAddr;
 
 //  Teardown contains options for tearing down behind a container
 #[derive(Clone, Debug)]
-pub struct TeardownPortForward {
-    pub config: PortForwardConfig,
+pub struct TeardownPortForward<'a> {
+    pub config: PortForwardConfig<'a>,
     // remove network related information
     pub complete_teardown: bool,
 }
@@ -28,9 +28,7 @@ pub struct TearDownNetwork {
 }
 
 #[derive(Clone, Debug)]
-pub struct PortForwardConfig {
-    //  network object
-    pub net: types::Network,
+pub struct PortForwardConfig<'a> {
     // id of container
     pub container_id: String,
     // port mappings
@@ -59,7 +57,7 @@ pub struct PortForwardConfig {
     // forwarding is not setup if this is 53.
     pub dns_port: u16,
     // dns servers IPs where forwarding rule to port 53 from dns_port are necessary
-    pub dns_server_ips: Vec<IpAddr>,
+    pub dns_server_ips: &'a Vec<IpAddr>,
 }
 
 /// IPAMAddresses is used to pass ipam information around

--- a/src/network/macvlan.rs
+++ b/src/network/macvlan.rs
@@ -1,0 +1,156 @@
+use std::{collections::HashMap, net::IpAddr};
+
+use log::debug;
+
+use crate::{
+    dns::aardvark::AardvarkEntry,
+    error::{NetavarkError, NetavarkResult},
+    network::core::Core,
+};
+
+use super::{
+    constants::{NO_CONTAINER_INTERFACE_ERROR, OPTION_MODE, OPTION_MTU},
+    core_utils::{get_ipam_addresses, parse_option, CoreUtils},
+    driver::{self, DriverInfo},
+    internal_types::IPAMAddresses,
+    types::{NetInterface, StatusBlock},
+};
+
+struct InternalData {
+    /// interface name of on the host
+    host_interface_name: String,
+    /// static mac address
+    mac_address: Option<Vec<u8>>,
+    /// ip addresses
+    ipam: IPAMAddresses,
+    /// mtu for the network interfaces (0 if default)
+    mtu: u32,
+    /// macvlan mode
+    macvlan_mode: u32,
+    // TODO: add vlan
+}
+
+pub struct MacVlan<'a> {
+    info: DriverInfo<'a>,
+    data: Option<InternalData>,
+}
+
+impl<'a> MacVlan<'a> {
+    pub fn new(info: DriverInfo<'a>) -> Self {
+        MacVlan { info, data: None }
+    }
+}
+
+impl driver::NetworkDriver for MacVlan<'_> {
+    fn network_name(&self) -> String {
+        self.info.network.name.clone()
+    }
+
+    fn validate(&mut self) -> NetavarkResult<()> {
+        if self.info.per_network_opts.interface_name.is_empty() {
+            return Err(NetavarkError::msg_str(NO_CONTAINER_INTERFACE_ERROR));
+        }
+
+        let master_ifname = match self.info.network.network_interface.as_deref() {
+            None | Some("") => match CoreUtils::get_default_route_interface() {
+                Ok(ifname) => ifname,
+                Err(e) => {
+                    return Err(NetavarkError::wrap_str(
+                        "unable to find any valid master interface for macvlan",
+                        e.into(),
+                    ));
+                }
+            },
+            Some(interface) => interface.to_string(),
+        };
+
+        let mode = parse_option(&self.info.network.options, OPTION_MODE, String::default())?;
+        let macvlan_mode = CoreUtils::get_macvlan_mode_from_string(&mode)?;
+
+        let mut ipam = get_ipam_addresses(self.info.per_network_opts, self.info.network)?;
+
+        let mtu = parse_option(&self.info.network.options, OPTION_MTU, 0)?;
+
+        let static_mac = match &self.info.per_network_opts.static_mac {
+            Some(mac) => Some(CoreUtils::decode_address_from_hex(mac)?),
+            None => None,
+        };
+
+        // Remove gateways when marked as internal network
+        if self.info.network.internal {
+            ipam.gateway_addresses = Vec::new();
+        }
+
+        self.data = Some(InternalData {
+            host_interface_name: master_ifname,
+            mac_address: static_mac,
+            ipam,
+            macvlan_mode,
+            mtu,
+        });
+        Ok(())
+    }
+
+    fn setup(&self) -> Result<(StatusBlock, Option<AardvarkEntry>), NetavarkError> {
+        let data = match &self.data {
+            Some(d) => d,
+            None => {
+                return Err(NetavarkError::msg_str(
+                    "must call validate() before setup()",
+                ))
+            }
+        };
+
+        debug!("Setup network {}", self.info.network.name);
+        debug!(
+            "Container interface name: {} with IP addresses {:?}",
+            self.info.per_network_opts.interface_name, data.ipam.container_addresses
+        );
+
+        // create macvlan
+        let container_macvlan_mac = match Core::add_macvlan(
+            &data.host_interface_name,
+            &self.info.per_network_opts.interface_name,
+            &data.ipam.gateway_addresses,
+            data.macvlan_mode,
+            data.mtu,
+            &data.ipam.container_addresses,
+            data.mac_address.clone(),
+            self.info.netns_container,
+        ) {
+            Ok(addr) => addr,
+            Err(err) => {
+                return Err(NetavarkError::wrap_str(
+                    "failed configure macvlan",
+                    err.into(),
+                ))
+            }
+        };
+
+        //  StatusBlock response
+        let mut response = StatusBlock {
+            dns_server_ips: Some(Vec::<IpAddr>::new()),
+            dns_search_domains: Some(Vec::<String>::new()),
+            interfaces: Some(HashMap::new()),
+        };
+
+        // interfaces map, but we only ever expect one, for response
+        let mut interfaces: HashMap<String, NetInterface> = HashMap::new();
+        let interface = NetInterface {
+            mac_address: container_macvlan_mac,
+            subnets: Option::from(data.ipam.net_addresses.clone()),
+        };
+        // Add interface to interfaces (part of StatusBlock)
+        interfaces.insert(self.info.per_network_opts.interface_name.clone(), interface);
+        let _ = response.interfaces.insert(interfaces);
+        Ok((response, None))
+    }
+
+    fn teardown(&self) -> NetavarkResult<()> {
+        Core::remove_container_interface(
+            &self.info.per_network_opts.interface_name,
+            self.info.netns_container,
+        )?; // handle error and continue
+        Ok(())
+    }
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -2,10 +2,13 @@ pub mod types;
 pub mod validation;
 use anyhow::Result;
 use std::fs::File;
+pub mod bridge;
 pub mod constants;
 pub mod core;
 pub mod core_utils;
+pub mod driver;
 pub mod internal_types;
+pub mod macvlan;
 
 impl types::NetworkOptions {
     pub fn load(path: &str) -> Result<types::NetworkOptions> {

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -461,3 +461,55 @@ EOF
     expected_rc=1 run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json setup $(get_container_netns_path)
     assert_json ".error" "Sysctl error: IO Error: Read-only file system (os error 30)" "Sysctl error because fs is read only"
 }
+
+
+@test "$fw_driver - bridge static mac" {
+   mac="aa:bb:cc:dd:ee:ff"
+
+           read -r -d '\0' config <<EOF
+{
+   "container_id": "someID",
+   "container_name": "someName",
+   "networks": {
+      "podman": {
+         "static_ips": [
+            "10.88.0.2"
+         ],
+         "static_mac": "$mac",
+         "interface_name": "eth0"
+      }
+   },
+   "network_info": {
+      "podman": {
+         "name": "podman",
+         "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+         "driver": "bridge",
+         "network_interface": "podman1",
+         "subnets": [
+            {
+               "subnet": "10.88.0.0/16",
+               "gateway": "10.88.0.1"
+            }
+         ],
+         "ipv6_enabled": false,
+         "internal": false,
+         "dns_enabled": false,
+         "ipam_options": {
+            "driver": "host-local"
+         }
+      }
+   }
+}\0
+EOF
+
+   run_netavark setup $(get_container_netns_path) <<<"$config"
+   result="$output"
+
+
+   assert_json "$result" ".podman.interfaces.eth0.mac_address" == "$mac" "MAC matches input mac"
+   # check that interface exists
+   run_in_container_netns ip -j link show eth0
+   link_info="$output"
+   assert_json "$link_info" ".[].address" "=="  "$mac" "MAC matches container mac"
+   assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
+}

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -214,7 +214,7 @@ fw_driver=iptables
     run_in_container_netns ip link add eth0 type dummy
 
     expected_rc=1 run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json setup $(get_container_netns_path)
-    assert_json ".error" "IO error: failed to configure bridge and veth interface: failed while configuring network interface: from network namespace: interface eth0 already exists on container namespace" "interface exists on netns"
+    assert_json ".error" "failed to configure bridge and veth interface: failed while configuring network interface: from network namespace: interface eth0 already exists on container namespace" "interface exists on netns"
 }
 
 @test "$fw_driver - port forwarding ipv4 - tcp" {

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -513,3 +513,61 @@ EOF
    assert_json "$link_info" ".[].address" "=="  "$mac" "MAC matches container mac"
    assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
 }
+
+
+@test "$fw_driver - bridge teardown" {
+    create_container_ns
+    configs=()
+    for i in 1 2; do
+        read -r -d '\0' config <<EOF
+{
+   "container_id": "someID$i",
+   "container_name": "someName$i",
+   "networks": {
+      "podman": {
+         "static_ips": [
+            "10.88.0.$i"
+         ],
+         "interface_name": "eth0"
+      }
+   },
+   "network_info": {
+      "podman": {
+         "name": "podman",
+         "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+         "driver": "bridge",
+         "network_interface": "podman1",
+         "subnets": [
+            {
+               "subnet": "10.88.0.0/16",
+               "gateway": "10.88.0.1"
+            }
+         ],
+         "ipv6_enabled": false,
+         "internal": false,
+         "dns_enabled": false,
+         "ipam_options": {
+            "driver": "host-local"
+         }
+      }
+   }
+}\0
+EOF
+
+        configs+=("$config")
+    done
+
+    run_netavark setup $(get_container_netns_path) <<<"${configs[0]}"
+    run_netavark setup $(get_container_netns_path 1) <<<"${configs[1]}"
+
+    run_netavark teardown $(get_container_netns_path) <<<"${configs[0]}"
+    # bridge should still exist
+    run_in_host_netns ip link show podman1
+
+    run_netavark teardown $(get_container_netns_path 1) <<<"${configs[1]}"
+    # bridge should be removed
+    expected_rc=1 run_in_host_netns ip link show podman1
+
+    run_in_host_netns ip -o link
+    assert "${#lines[@]}" == 1 "only loopback adapter"
+}

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -200,7 +200,7 @@ function teardown() {
     run_in_container_netns ip link add eth0 type dummy
 
     expected_rc=1 run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json setup $(get_container_netns_path)
-    assert_json ".error" "IO error: failed to configure bridge and veth interface: failed while configuring network interface: from network namespace: interface eth0 already exists on container namespace" "interface exists on netns"
+    assert_json ".error" "failed to configure bridge and veth interface: failed while configuring network interface: from network namespace: interface eth0 already exists on container namespace" "interface exists on netns"
 }
 
 @test "$fw_driver - port forwarding ipv4 - tcp" {

--- a/test/testfiles/internal.json
+++ b/test/testfiles/internal.json
@@ -11,11 +11,11 @@
     },
     "network_info": {
         "podman": {
-            "dns_enabled": true,
+            "dns_enabled": false,
             "driver": "bridge",
             "id": "53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
             "internal": true,
-            "ipv6_enabled": true,
+            "ipv6_enabled": false,
             "name": "podman",
             "network_interface": "podman0",
             "subnets": [


### PR DESCRIPTION
I am sorry, I know that this is almost impossible to review properly but I couldn't
figure out how to split this out in smaller pieces.

We should abstract the internal driver logic behind a interface. This
makes to code easier to maintain since each driver is isolated.

Also this will allow us much better error handling, in case of errors it
is important to still clean up as much as possible, i.e. when we setup
two networks and the second one fails we should teardown the first as
well.


setup routing sysctl only once
It is enough to only setup the sysctl once.

add test for static mac address