### PR TITLE
firewall types: remove unnecessary clones

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -165,3 +165,9 @@ impl From<serde_json::Error> for NetavarkError {
         NetavarkError::Serde(err)
     }
 }
+
+impl From<ipnet::PrefixLenError> for NetavarkError {
+    fn from(e: ipnet::PrefixLenError) -> Self {
+        NetavarkError::Message(format!("{}", e))
+    }
+}

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -169,20 +169,26 @@ impl firewall::FirewallDriver for FirewallD {
         // prevention - if two ports end up mapped to different containers,
         // that is not detected, and firewalld will allow it to happen.
         // Only one of them will win and be active, though.
-        for port in setup_portfw.port_mappings {
-            if !port.host_ip.is_empty() {
-                port_forwarding_rules.append(Value::new(make_port_tuple(&port, &port.host_ip)))?;
-            } else {
-                if let Some(v4) = setup_portfw.container_ip_v4 {
-                    port_forwarding_rules
-                        .append(Value::new(make_port_tuple(&port, &v4.to_string())))?;
-                }
-                if let Some(v6) = setup_portfw.container_ip_v6 {
-                    port_forwarding_rules
-                        .append(Value::new(make_port_tuple(&port, &v6.to_string())))?;
+        match setup_portfw.port_mappings {
+            Some(ports) => {
+                for port in ports {
+                    if !port.host_ip.is_empty() {
+                        port_forwarding_rules
+                            .append(Value::new(make_port_tuple(port, &port.host_ip)))?;
+                    } else {
+                        if let Some(v4) = setup_portfw.container_ip_v4 {
+                            port_forwarding_rules
+                                .append(Value::new(make_port_tuple(port, &v4.to_string())))?;
+                        }
+                        if let Some(v6) = setup_portfw.container_ip_v6 {
+                            port_forwarding_rules
+                                .append(Value::new(make_port_tuple(port, &v6.to_string())))?;
+                        }
+                    }
                 }
             }
-        }
+            None => {}
+        };
 
         // dns port forwarding requires rich rules as we also want to match destination ip
         // only bother if configured dns port isn't 53

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -135,7 +135,7 @@ impl firewall::FirewallDriver for IptablesDriver {
 
     fn setup_port_forward(&self, setup_portfw: PortForwardConfig) -> NetavarkResult<()> {
         if let Some(v4) = setup_portfw.container_ip_v4 {
-            let subnet_v4 = match setup_portfw.subnet_v4.clone() {
+            let subnet_v4 = match setup_portfw.subnet_v4 {
                 Some(s) => s,
                 None => {
                     return Err(std::io::Error::new(
@@ -150,7 +150,7 @@ impl firewall::FirewallDriver for IptablesDriver {
             create_network_chains(chains)?;
         }
         if let Some(v6) = setup_portfw.container_ip_v6 {
-            let subnet_v6 = match setup_portfw.subnet_v6.clone() {
+            let subnet_v6 = match setup_portfw.subnet_v6 {
                 Some(s) => s,
                 None => {
                     return Err(std::io::Error::new(
@@ -169,7 +169,7 @@ impl firewall::FirewallDriver for IptablesDriver {
 
     fn teardown_port_forward(&self, tear: TeardownPortForward) -> NetavarkResult<()> {
         if let Some(v4) = tear.config.container_ip_v4 {
-            let subnet_v4 = match tear.config.subnet_v4.clone() {
+            let subnet_v4 = match tear.config.subnet_v4 {
                 Some(s) => s,
                 None => {
                     return Err(std::io::Error::new(
@@ -202,12 +202,12 @@ impl firewall::FirewallDriver for IptablesDriver {
         }
 
         if let Some(v6) = tear.config.container_ip_v6 {
-            let subnet_v6 = match tear.config.subnet_v6.clone() {
+            let subnet_v6 = match tear.config.subnet_v6 {
                 Some(s) => s,
                 None => {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::Other,
-                        "ipv6 address but provided but no v4 subnet provided",
+                        "ipv6 address but provided but no v6 subnet provided",
                     )
                     .into())
                 }

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -4,7 +4,6 @@ use crate::firewall::varktables::helpers::{
 };
 use crate::firewall::varktables::types::TeardownPolicy::{Never, OnComplete};
 use crate::network::internal_types::PortForwardConfig;
-use crate::network::types::Subnet;
 use ipnet::IpNet;
 use iptables::IPTables;
 use log::debug;
@@ -330,7 +329,7 @@ pub fn get_port_forwarding_chains<'a>(
     conn: &'a IPTables,
     pfwd: &PortForwardConfig,
     container_ip: &IpAddr,
-    network_address: &Subnet,
+    network_address: &IpNet,
     is_ipv6: bool,
 ) -> Vec<VarkChain<'a>> {
     let mut localhost_ip = "127.0.0.1";
@@ -486,7 +485,7 @@ pub fn get_port_forwarding_chains<'a>(
 
         let mut dn_setmark_rule_localhost = format!(
             "-j {} -s {} -p {} --dport {}",
-            NETAVARK_HOSTPORT_SETMARK, network_address.subnet, i.protocol, &host_port
+            NETAVARK_HOSTPORT_SETMARK, network_address, i.protocol, &host_port
         );
 
         let mut dn_setmark_rule_subnet = format!(

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -285,7 +285,7 @@ impl<'a> Bridge<'a> {
         }
         let spf = PortForwardConfig {
             container_id: self.info.container_id.clone(),
-            port_mappings: self.info.port_mappings.clone().unwrap_or_default(),
+            port_mappings: self.info.port_mappings,
             network_name: self.info.network.name.clone(),
             network_hash_name: id_network_hash,
             container_ip_v4: addr_v4,
@@ -307,7 +307,7 @@ impl<'a> Bridge<'a> {
 
         self.info.firewall.setup_network(sn)?;
 
-        if !spf.port_mappings.is_empty() {
+        if spf.port_mappings.is_some() {
             // Need to enable sysctl localnet so that traffic can pass
             // through localhost to containers
 

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -19,7 +19,7 @@ use super::{
     internal_types::{
         IPAMAddresses, PortForwardConfig, SetupNetwork, TearDownNetwork, TeardownPortForward,
     },
-    types::{StatusBlock, Subnet},
+    types::StatusBlock,
 };
 
 const NO_BRIDGE_NAME_ERROR: &str = "no bridge interface name given";
@@ -260,8 +260,8 @@ impl<'a> Bridge<'a> {
         let mut has_ipv6 = false;
         let mut addr_v4: Option<IpAddr> = None;
         let mut addr_v6: Option<IpAddr> = None;
-        let mut net_v4: Option<Subnet> = None;
-        let mut net_v6: Option<Subnet> = None;
+        let mut net_v4: Option<IpNet> = None;
+        let mut net_v6: Option<IpNet> = None;
         for net in container_addresses {
             match net {
                 IpNet::V4(v4) => {
@@ -269,11 +269,7 @@ impl<'a> Bridge<'a> {
                         continue;
                     }
                     addr_v4 = Some(IpAddr::V4(v4.addr()));
-                    net_v4 = Some(Subnet {
-                        gateway: None,
-                        subnet: IpNet::new(v4.network().into(), v4.prefix_len()).unwrap(),
-                        lease_range: None,
-                    });
+                    net_v4 = Some(IpNet::new(v4.network().into(), v4.prefix_len())?);
                     has_ipv4 = true;
                 }
                 IpNet::V6(v6) => {
@@ -282,11 +278,7 @@ impl<'a> Bridge<'a> {
                     }
 
                     addr_v6 = Some(IpAddr::V6(v6.addr()));
-                    net_v6 = Some(Subnet {
-                        gateway: None,
-                        subnet: IpNet::new(v6.network().into(), v6.prefix_len()).unwrap(),
-                        lease_range: None,
-                    });
+                    net_v6 = Some(IpNet::new(v6.network().into(), v6.prefix_len())?);
                     has_ipv6 = true;
                 }
             }

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -1,5 +1,4 @@
 use crate::network::types;
-use crate::network::types::Subnet;
 use std::net::IpAddr;
 
 //  Teardown contains options for tearing down behind a container
@@ -44,7 +43,7 @@ pub struct PortForwardConfig<'a> {
     pub container_ip_v4: Option<IpAddr>,
     // subnet associated with the IPv4 address.
     // Must be set if v4 address is set.
-    pub subnet_v4: Option<Subnet>,
+    pub subnet_v4: Option<ipnet::IpNet>,
     // ipv6 address of the container.
     // If multiple v6 addresses are present, use the first one for this.
     // At least one of container_ip_v6 and container_ip_v6 must be set. Both can
@@ -52,7 +51,7 @@ pub struct PortForwardConfig<'a> {
     pub container_ip_v6: Option<IpAddr>,
     // subnet associated with the ipv6 address.
     // Must be set if the v6 address is set.
-    pub subnet_v6: Option<Subnet>,
+    pub subnet_v6: Option<ipnet::IpNet>,
     // port used by DNS that should create forwarding rules
     // forwarding is not setup if this is 53.
     pub dns_port: u16,

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -2,7 +2,7 @@ use crate::network::types;
 use std::net::IpAddr;
 
 //  Teardown contains options for tearing down behind a container
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct TeardownPortForward<'a> {
     pub config: PortForwardConfig<'a>,
     // remove network related information
@@ -10,7 +10,7 @@ pub struct TeardownPortForward<'a> {
 }
 
 //  SetupNetwork contains options for setting up a container
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct SetupNetwork {
     // network object
     pub net: types::Network,
@@ -20,18 +20,18 @@ pub struct SetupNetwork {
     pub isolation: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct TearDownNetwork {
     pub config: SetupNetwork,
     pub complete_teardown: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PortForwardConfig<'a> {
     // id of container
     pub container_id: String,
     // port mappings
-    pub port_mappings: Vec<types::PortMapping>,
+    pub port_mappings: &'a Option<Vec<types::PortMapping>>,
     // name of network
     pub network_name: String,
     // hash id for the network


### PR DESCRIPTION
Restructure the types so that we do not need to clone the data.

firewall: PortForwardConfig use IpNet instead of Subnet
We are only interested in a single IpNet so no need to keep the full
Subnet info.