### PR TITLE
rework aardvark setup 

### DIFF
--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -91,6 +91,7 @@ impl Teardown {
             let driver = get_network_driver(DriverInfo {
                 firewall: firewall_driver.as_ref(),
                 container_id: &network_options.container_id,
+                container_name: &network_options.container_name,
                 netns_container: ns_fd,
                 network,
                 per_network_opts,

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -15,6 +15,7 @@ use std::os::unix::io::RawFd;
 pub struct DriverInfo<'a> {
     pub firewall: &'a dyn FirewallDriver,
     pub container_id: &'a String,
+    pub container_name: &'a String,
     //pub netns_host: RawFd,
     pub netns_container: RawFd,
     pub network: &'a Network,

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -177,9 +177,8 @@ fw_driver=iptables
     # check aardvark config and running
     run_helper cat "$NETAVARK_TMPDIR/config/aardvark-dns/podman1"
     assert "${lines[0]}" =~ "10.89.3.1,fd10:88:a::1" "aardvark set to listen to all IPs"
-    assert "${lines[1]}" =~ "[0-9a-f]* 10.89.3.2  somename" "aardvark config's container ipv4"
-    assert "${lines[2]}" =~ "[0-9a-f]*  fd10:88:a::2 somename" "aardvark config's container ipv6"
-    assert "${#lines[@]}" = 3 "too many liness in aardvark config"
+    assert "${lines[1]}" =~ "^[0-9a-f]{64} 10.89.3.2 fd10:88:a::2 somename$" "aardvark config's container"
+    assert "${#lines[@]}" = 2 "too many lines in aardvark config"
 
     aardvark_pid=$(cat "$NETAVARK_TMPDIR/config/aardvark-dns/aardvark.pid")
     assert "$ardvark_pid" =~ "[0-9]*" "aardvark pid not found"

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -164,9 +164,8 @@ function teardown() {
     # check aardvark config and running
     run_helper cat "$NETAVARK_TMPDIR/config/aardvark-dns/podman1"
     assert "${lines[0]}" =~ "10.89.3.1,fd10:88:a::1" "aardvark set to listen to all IPs"
-    assert "${lines[1]}" =~ "[0-9a-f]* 10.89.3.2  somename" "aardvark config's container ipv4"
-    assert "${lines[2]}" =~ "[0-9a-f]*  fd10:88:a::2 somename" "aardvark config's container ipv6"
-    assert "${#lines[@]}" = 3 "too many liness in aardvark config"
+    assert "${lines[1]}" =~ "^[0-9a-f]{64} 10.89.3.2 fd10:88:a::2 somename$" "aardvark config's container"
+    assert "${#lines[@]}" = 2 "too many lines in aardvark config"
 
     aardvark_pid=$(cat "$NETAVARK_TMPDIR/config/aardvark-dns/aardvark.pid")
     assert "$ardvark_pid" =~ "[0-9]*" "aardvark pid not found"


### PR DESCRIPTION
Based on #369 

The driver already has all information so the aardvark code should not
have to pass it again. This simplifies the code and creates smaller
aardvark config files since it does not duplicate the contianer id and
names just to set more then one ip.

This does not touch the aardvark teardown logic.

Requires https://github.com/containers/aardvark-dns/pull/183