### PR TITLE
aardvark,commit: acquire fs lock when performing commit to avoid `race` across parallel invocations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +671,7 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "fs2",
  "futures",
  "ipnet",
  "iptables",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1.20.1", features = ["full"] }
 zvariant = "3.4.1"
 sha2 = "0.10.1"
 netlink-packet-route = "0.13"
+fs2 = "0.4.3"
 
 [build-dependencies]
 chrono = "0.4.20"


### PR DESCRIPTION
* We should avoid overriding configs when another instance of aardvark
  is trying to commit configs on the same path.

* On certain system a race exists where more than one aardvark instance
  are started in the frame where one instance has not yet completed
  updating its `aardvark.pid` causing more than one instance to get
  started and eventually causing conflits on the requested ports.

Some conditions are reported on `low power hardware which tries to start
a significant amount of containers` and it looks like the case matches with what is described in the second point.

