### PR TITLE
cleanup: misc lint level fixes to make clippy happy.

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -71,7 +71,7 @@ impl NetavarkError {
 
 impl fmt::Display for NetavarkError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &*self {
+        match self {
             NetavarkError::Message(s) => write!(f, "{}", s),
             NetavarkError::ExitCode(s, _) => write!(f, "{}", s),
             NetavarkError::Chain(s, e) => write!(f, "{}: {}", s, e),
@@ -86,7 +86,7 @@ impl fmt::Display for NetavarkError {
 
 impl PartialEq for NetavarkError {
     fn eq(&self, other: &Self) -> bool {
-        match &*self {
+        match self {
             NetavarkError::Message(s) => {
                 if let NetavarkError::Message(o) = other {
                     return s == o;

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -662,12 +662,12 @@ fn make_port_tuple(port: &PortMapping, addr: &str) -> (String, String, String, S
         // Subtract 1 as these are 1-indexed strings - range of 2 is 1000-1001
         let end_host_range = port.host_port + port.range - 1;
         let end_ctr_range = port.container_port + port.range - 1;
-        return (
+        (
             format!("{}-{}", port.host_port, end_host_range),
             port.protocol.clone(),
             format!("{}-{}", port.container_port, end_ctr_range),
             addr.to_string(),
-        );
+        )
     } else {
         let to_return = (
             format!("{}", port.host_port),

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -34,7 +34,7 @@ const HEXMARK: &str = "0x2000";
 const MULTICAST_NET_V4: &str = "224.0.0.0/4";
 const MULTICAST_NET_V6: &str = "ff00::/8";
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum TeardownPolicy {
     OnComplete,
     Never,

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -116,12 +116,10 @@ impl Core {
         });
         match handle.join() {
             Ok(interface_address) => interface_address,
-            Err(err) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("failed to join: {:?}", err),
-                ))
-            }
+            Err(err) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("failed to join: {:?}", err),
+            )),
         }
     }
 
@@ -201,12 +199,10 @@ impl Core {
         });
         match handle.join() {
             Ok(interface_address) => interface_address,
-            Err(err) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("failed to join: {:?}", err),
-                ))
-            }
+            Err(err) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("failed to join: {:?}", err),
+            )),
         }
     }
 

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -370,25 +370,7 @@ impl CoreUtils {
                     }
                 }
 
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!(
-                        "Unable to resolve physical address for interface {}",
-                        link_name
-                    ),
-                ));
-            }
-            Err(err) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!(
-                        "Unable to resolve physical address for interface {}: {}",
-                        link_name, err
-                    ),
-                ));
-            }
-            Ok(None) => {
-                return Err(std::io::Error::new(
+                Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     format!(
                         "Unable to resolve physical address for interface {}",
@@ -396,6 +378,20 @@ impl CoreUtils {
                     ),
                 ))
             }
+            Err(err) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Unable to resolve physical address for interface {}: {}",
+                    link_name, err
+                ),
+            )),
+            Ok(None) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Unable to resolve physical address for interface {}",
+                    link_name
+                ),
+            )),
         }
     }
     async fn add_ip_address(


### PR DESCRIPTION
Following PR performs various cleanups to ensure latest version of clippy is happy (0.1.63)
**See individual commits for details and reason**

```console
* error: do not dereference and borrow NetavarkError
* firewall: remove unneeded return statement
* firewall,type: Teardownpolicy should also implement Eq when members implement it.
* core, core_utils: remove unneeded return statement
```