### PR TITLE
Add protobuf compiler to container images

### DIFF
--- a/contrib/container_images/Dockerfile.CentOS9
+++ b/contrib/container_images/Dockerfile.CentOS9
@@ -1,2 +1,2 @@
 FROM quay.io/centos/centos:stream9
-RUN dnf -y install cargo && dnf -y clean all
+RUN dnf -y --enablerepo=crb install cargo protobuf-compiler && dnf -y clean all

--- a/contrib/container_images/Dockerfile.UbuntuLatest
+++ b/contrib/container_images/Dockerfile.UbuntuLatest
@@ -1,2 +1,2 @@
 FROM docker.io/library/ubuntu:latest
-RUN apt-get update && apt-get -y install cargo
+RUN apt-get update && apt-get -y install cargo protobuf-compiler libprotobuf-dev

--- a/contrib/container_images/Dockerfile.f36
+++ b/contrib/container_images/Dockerfile.f36
@@ -1,2 +1,2 @@
 FROM registry.fedoraproject.org/fedora:36
-RUN dnf -y install cargo && dnf -y clean all
+RUN dnf -y install cargo protobuf-compiler && dnf -y clean all


### PR DESCRIPTION
For the dhcp proxy which uses the same container images as netavark for
build/test/etc, the protobuf-compiler needs to be added.

Signed-off-by: Brent Baude <bbaude@redhat.com>