### PR TITLE
Packit: initial enablement

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Packit's default fix-spec-file often doesn't fetch version string correctly.
+# This script handles any custom processing of the dist-git spec file and gets used by the
+# fix-spec-file action in .packit.yaml
+
+set -eo pipefail
+
+# Get Version from HEAD
+HEAD_VERSION=$(grep '^version' Cargo.toml | cut -d\" -f2 | sed -e 's/-/~/')
+
+# Generate source tarball from HEAD
+git archive --prefix=netavark-$HEAD_VERSION/ -o netavark-$HEAD_VERSION.tar.gz HEAD
+
+# RPM Spec modifications
+
+# Update Version in spec with Version from Cargo.toml
+sed -i "s/^Version:.*/Version: $HEAD_VERSION/" netavark.spec
+
+# Update Release in spec with Packit's release envvar
+sed -i "s/^Release: %autorelease/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" netavark.spec
+
+# Update Source tarball name in spec
+sed -i "s/^Source:.*.tar.gz/Source: %{name}-$HEAD_VERSION.tar.gz/" netavark.spec
+
+# Update setup macro to use the correct build dir
+sed -i "s/^%setup.*/%autosetup -Sgit -n %{name}-$HEAD_VERSION/" netavark.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,25 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# Build targets can be found at:
+# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
+
+specfile_path: netavark.spec
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    owner: rhcontainerbot
+    project: packit-builds
+    enable_net: true
+    srpm_build_deps:
+      - cargo
+      - make
+      - openssl-devel
+      - rpkg
+    actions:
+      post-upstream-clone:
+        - "rpkg spec --outdir ./"
+      fix-spec-file:
+        - "bash .packit.sh"

--- a/netavark.spec.rpkg
+++ b/netavark.spec.rpkg
@@ -31,7 +31,9 @@ Source: {{{ git_dir_pack }}}
 BuildRequires: make
 BuildRequires: cargo
 BuildRequires: git-core
-BuildRequires: golang-github-cpuguy83-md2man
+BuildRequires: go-md2man
+BuildRequires: protobuf-c
+BuildRequires: protobuf-compiler
 Recommends: aardvark-dns
 Provides: container-network-stack
 %if 0%{?fedora}
@@ -45,8 +47,7 @@ OCI network stack.}
 %description %{_description}
 
 %prep
-#{{{ git_dir_setup_macro }}}
-%autosetup -Sgit -T -b 0 -n %{name}
+{{{ git_dir_setup_macro }}}
 
 %build
 %{__make} CARGO="%{__cargo}" build


### PR DESCRIPTION
This commit will run COPR builds on every PR against all active
releases of CentOS Stream and Fedora, thus allowing buildability checks before the
PR merges.

Builds are done on a custom COPR project:
`rhcontainerbot/packit-builds`.
Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/

The build targets are set in the copr itself, so we don't need to
explicitly mention them in `.packit.yaml`, making upstream configuration
a lot simpler.

The `spec.rpkg` file meant for rpm builds post-pr-merge at
`rhcontainerbot/podman-next` copr gets reused for packit builds, so the
packit jobs are independent of Fedora / CentOS dist-git.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>