### PR TITLE
Makefile: vendor-tarball remove dev version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ vendor-rm-windows:
 .PHONY: vendor-tarball
 vendor-tarball: build vendor
 	VERSION=$(shell bin/netavark --version | cut -f2 -d" ") && \
-	case $$VERSION in *-dev) echo "version ends with -dev" && exit 1;; esac; \
 	tar cvf netavark-v$$VERSION-vendor.tar.gz vendor/ && \
 	gzip -c bin/netavark > netavark.gz && \
 	sha256sum netavark.gz netavark-v$$VERSION-vendor.tar.gz > sha256sum


### PR DESCRIPTION
The vendor tarball generation does not need to check if it's a release
or dev version.

Removal of this check will be especially useful in cases
like #399 where we'll need vendor-tarball generated using HEAD commit
of every PR.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

