### PR TITLE
refactor, clippy: edit syntax as per `clippy` standards

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -88,14 +88,13 @@ impl Core {
                 ));
             }
 
-            if let Err(err) = core_utils::CoreUtils::configure_netns_interface_async(
+            core_utils::CoreUtils::configure_netns_interface_async(
                 &container_veth_name_clone,
                 netns_ipaddr_clone,
                 &gw_ipaddr_clone,
                 static_mac_clone,
-            ) {
-                return Err(err);
-            }
+            )?;
+
             debug!(
                 "Configured static up address for {}",
                 container_veth_name_clone
@@ -171,14 +170,13 @@ impl Core {
                 ));
             }
 
-            if let Err(err) = core_utils::CoreUtils::configure_netns_interface_async(
+            core_utils::CoreUtils::configure_netns_interface_async(
                 &container_macvlan_clone,
                 netns_ipaddr_clone,
                 &gw_addrs_clone,
                 static_mac,
-            ) {
-                return Err(err);
-            }
+            )?;
+
             debug!(
                 "Configured static up address for {}",
                 container_macvlan_clone
@@ -219,9 +217,7 @@ impl Core {
                 ));
             }
 
-            if let Err(err) = core_utils::CoreUtils::remove_interface(&container_veth) {
-                return Err(err);
-            }
+            core_utils::CoreUtils::remove_interface(&container_veth)?;
 
             Ok(())
         });

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -1257,12 +1257,9 @@ impl CoreUtils {
         }
 
         // set static mac here
-        match static_mac {
-            Some(mac) => {
-                CoreUtils::set_link_mac(&handle, ifname, mac).await?;
-            }
-            None => {}
-        };
+        if let Some(mac) = static_mac {
+            CoreUtils::set_link_mac(&handle, ifname, mac).await?;
+        }
 
         // ip netns exec <namespace> ip route add default via <gateway> dev <ifname>
         for gw_ip_add in gw_ip_addrs {

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -517,9 +517,7 @@ impl CoreUtils {
 
         tokio::spawn(connection);
 
-        if let Err(err) = CoreUtils::remove_link(&handle, ifname).await {
-            return Err(err);
-        }
+        CoreUtils::remove_link(&handle, ifname).await?;
 
         Ok(())
     }
@@ -538,9 +536,7 @@ impl CoreUtils {
 
         tokio::spawn(connection);
 
-        if let Err(err) = CoreUtils::set_link_up(&handle, ifname).await {
-            return Err(err);
-        }
+        CoreUtils::set_link_up(&handle, ifname).await?;
 
         Ok(())
     }
@@ -786,11 +782,7 @@ impl CoreUtils {
         // before moving it to network namespace
         // See: https://github.com/containernetworking/plugins/blob/master/plugins/main/macvlan/macvlan.go#L181
         if mtu != 0 {
-            if let Err(err) =
-                CoreUtils::set_link_mtu(&handle, &macvlan_tmp_name.to_owned(), mtu).await
-            {
-                return Err(err);
-            }
+            CoreUtils::set_link_mtu(&handle, &macvlan_tmp_name.to_owned(), mtu).await?;
         }
 
         // change network namespace of macvlan interface
@@ -849,11 +841,7 @@ impl CoreUtils {
                 ));
             }
 
-            if let Err(err) =
-                CoreUtils::rename_macvlan_internal(&macvlan_tmp_ifname, &macvlan_ifname_clone)
-            {
-                return Err(err);
-            }
+            CoreUtils::rename_macvlan_internal(&macvlan_tmp_ifname, &macvlan_ifname_clone)?;
 
             Ok(())
         });
@@ -958,21 +946,15 @@ impl CoreUtils {
             }
         }
         for ip_net in ips.iter() {
-            if let Err(err) = CoreUtils::add_ip_address(&handle, ifname, ip_net).await {
-                return Err(err);
-            }
+            CoreUtils::add_ip_address(&handle, ifname, ip_net).await?;
         }
 
         if mtu != 0 {
-            if let Err(err) = CoreUtils::set_link_mtu(&handle, ifname, mtu).await {
-                return Err(err);
-            }
+            CoreUtils::set_link_mtu(&handle, ifname, mtu).await?;
         }
 
         // make the bridge interface up
-        if let Err(err) = CoreUtils::set_link_up(&handle, ifname).await {
-            return Err(err);
-        }
+        CoreUtils::set_link_up(&handle, ifname).await?;
 
         Ok(())
     }
@@ -1036,12 +1018,8 @@ impl CoreUtils {
 
         // set mtu for container and host veth
         if mtu != 0 {
-            if let Err(err) = CoreUtils::set_link_mtu(&handle, host_veth, mtu).await {
-                return Err(err);
-            }
-            if let Err(err) = CoreUtils::set_link_mtu(&handle, container_veth, mtu).await {
-                return Err(err);
-            }
+            CoreUtils::set_link_mtu(&handle, host_veth, mtu).await?;
+            CoreUtils::set_link_mtu(&handle, container_veth, mtu).await?;
         }
 
         if ipv6_enabled {
@@ -1161,15 +1139,13 @@ impl CoreUtils {
                 ));
             }
 
-            if let Err(err) = CoreUtils::generate_veth_pair_internal(
+            CoreUtils::generate_veth_pair_internal(
                 netavark_pid,
                 &hst_veth,
                 &ctr_veth,
                 mtu,
                 ipv6_enabled,
-            ) {
-                return Err(err);
-            }
+            )?;
 
             Ok(())
         });
@@ -1249,9 +1225,7 @@ impl CoreUtils {
         }
 
         // ip link set <eth> up
-        if let Err(err) = CoreUtils::set_link_up(&handle, host_veth).await {
-            return Err(err);
-        }
+        CoreUtils::set_link_up(&handle, host_veth).await?;
 
         Ok(())
     }
@@ -1275,23 +1249,17 @@ impl CoreUtils {
         };
         tokio::spawn(_connection);
         // ip netns exec ip link set <ifname> up
-        if let Err(err) = CoreUtils::set_link_up(&handle, ifname).await {
-            return Err(err);
-        }
+        CoreUtils::set_link_up(&handle, ifname).await?;
 
         // ip netns exec <namespace> ip addr add <addr>/<mask> dev <ifname>
         for ip_net in ips.into_iter() {
-            if let Err(err) = CoreUtils::add_ip_address(&handle, ifname, &ip_net).await {
-                return Err(err);
-            }
+            CoreUtils::add_ip_address(&handle, ifname, &ip_net).await?;
         }
 
         // set static mac here
         match static_mac {
             Some(mac) => {
-                if let Err(err) = CoreUtils::set_link_mac(&handle, ifname, mac).await {
-                    return Err(err);
-                }
+                CoreUtils::set_link_mac(&handle, ifname, mac).await?;
             }
             None => {}
         };
@@ -1301,9 +1269,7 @@ impl CoreUtils {
             match gw_ip_add.addr() {
                 IpAddr::V4(gateway) => match ipnet::Ipv4Net::new(Ipv4Addr::new(0, 0, 0, 0), 0) {
                     Ok(dest) => {
-                        if let Err(err) = CoreUtils::add_route_v4(&handle, &dest, &gateway).await {
-                            return Err(err);
-                        }
+                        CoreUtils::add_route_v4(&handle, &dest, &gateway).await?;
                     }
                     Err(err) => {
                         return Err(std::io::Error::new(
@@ -1315,11 +1281,7 @@ impl CoreUtils {
                 IpAddr::V6(gateway) => {
                     match ipnet::Ipv6Net::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), 0) {
                         Ok(dest) => {
-                            if let Err(err) =
-                                CoreUtils::add_route_v6(&handle, &dest, &gateway).await
-                            {
-                                return Err(err);
-                            }
+                            CoreUtils::add_route_v6(&handle, &dest, &gateway).await?;
                         }
                         Err(err) => {
                             return Err(std::io::Error::new(


### PR DESCRIPTION
Makes CI validation green again by applying following changes

* clippy: edit expressions that could be replaced by the question mark operator.
* clippy: use if let instead of single match

Ref: https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
Ref: https://rust-lang.github.io/rust-clippy/master/index.html#single_match