### PR TITLE
tests: dig request both `A` and `AAAA` record for specific cases

### DIFF
--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -186,9 +186,9 @@ fw_driver=iptables
     assert "${lines[1]}" =~ ".*aardvark-dns --config $NETAVARK_TMPDIR/config/aardvark-dns -p $dns_port run" "aardvark not running or bad options"
 
     # test redirection actually works
-    run_in_container_netns dig +short "somename.dns.podman" @10.89.3.1
+    run_in_container_netns dig +short "somename.dns.podman" @10.89.3.1 A "somename.dns.podman" @10.89.3.1 AAAA
     assert "${lines[0]}" =~ "10.89.3.2" "ipv4 dns resolution works 1/2"
-    assert "${lines[1]}" =~ "fd10:88:a::2" "ipv4 dns resolution works 2/2"
+    assert "${lines[1]}" =~ "fd10:88:a::2" "ipv6 dns resolution works 2/2"
 
     run_in_container_netns dig +short "somename.dns.podman" @fd10:88:a::1
     assert "${lines[0]}" =~ "10.89.3.2" "ipv6 dns resolution works"

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -173,9 +173,9 @@ function teardown() {
     assert "${lines[1]}" =~ ".*aardvark-dns --config $NETAVARK_TMPDIR/config/aardvark-dns -p $dns_port run" "aardvark not running or bad options"
 
     # test redirection actually works
-    run_in_container_netns dig +short "somename.dns.podman" @10.89.3.1
+    run_in_container_netns dig +short "somename.dns.podman" @10.89.3.1 A "somename.dns.podman" @10.89.3.1 AAAA
     assert "${lines[0]}" =~ "10.89.3.2" "ipv4 dns resolution works 1/2"
-    assert "${lines[1]}" =~ "fd10:88:a::2" "ipv4 dns resolution works 2/2"
+    assert "${lines[1]}" =~ "fd10:88:a::2" "ipv6 dns resolution works 2/2"
 
     run_in_container_netns dig +short "somename.dns.podman" @fd10:88:a::1
     assert "${lines[0]}" =~ "10.89.3.2" "ipv6 dns resolution works"


### PR DESCRIPTION
Retrofit test cases like

* iptables - dual stack dns with alt port
* firewalld - dual stack dns with alt port

have a case where output expects both `A` and `AAAA` record however dig defaults to `A` if nothing is specified hence explicitly request both `A` and `AAAA` records where needed.

Following behaviour is expected after: https://github.com/containers/aardvark-dns/pull/205
Should help with issues seen in: https://github.com/containers/netavark/pull/418