### PR TITLE
Cirrus: Use images w/ fixed-in-time rust + clippy

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ env:
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
     FEDORA_NAME: "fedora-36"
-    IMAGE_SUFFIX: "c5823947156488192"
+    IMAGE_SUFFIX: "c6535313974624256"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
     AARDVARK_DNS_BRANCH: "main"
     AARDVARK_DNS_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_DNS_BRANCH}"

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -79,14 +79,6 @@ msg "************************************************************"
 msg "Toolchain details"
 msg "************************************************************"
 
-# FIXME (@lsm5): rustup commands should be moved to c/automation_images repo
-# https://github.com/containers/automation_images/issues/150
-rustup install stable
-rustup default stable
-if [[ $(uname -m) == "aarch64" ]]; then
-    rustup target add aarch64-unknown-linux-gnu
-fi
-
 rustc --version
 cargo --version
 

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -23,13 +23,16 @@ show_env_vars
 
 req_env_vars AARDVARK_DNS_URL
 
-set -x  # show what's happening
-curl --fail --location -o /tmp/aardvark-dns.zip "$AARDVARK_DNS_URL"
+showrun curl --fail --location -o /tmp/aardvark-dns.zip "$AARDVARK_DNS_URL"
 mkdir -p /usr/libexec/podman
 cd /usr/libexec/podman
 rm -f aardvark-dns*
-unzip -o /tmp/aardvark-dns.zip
+showrun unzip -o /tmp/aardvark-dns.zip
 if [[ $(uname -m) != "x86_64" ]]; then
-    mv aardvark-dns.$(uname -m)-unknown-linux-gnu aardvark-dns
+    showrun mv aardvark-dns.$(uname -m)-unknown-linux-gnu aardvark-dns
 fi
-chmod a+x /usr/libexec/podman/aardvark-dns
+showrun chmod a+x /usr/libexec/podman/aardvark-dns
+
+# Warning, this isn't the end.  An exit-handler is installed to finalize
+# setup of env. vars.  This is required for runner.sh to operate properly.
+# See complete_setup() in lib.sh for details.


### PR DESCRIPTION
In order to prioritize stable CI for upstream development, use VM images with pre-installed rust toolchain and clippy linter.  This prevents these components from changing unexpectedly, especially on new release branches.

Ref: https://github.com/containers/automation_images/pull/214

Signed-off-by: Chris Evich <cevich@redhat.com>