### PR TITLE
Do not use ipv6 autoconf

### DIFF
--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -1248,6 +1248,30 @@ impl CoreUtils {
             }
         };
         tokio::spawn(_connection);
+
+        // make sure autoconf is off, we want manaully config only
+        if let Err(err) = CoreUtils::apply_sysctl_value(
+            format!("/proc/sys/net/ipv6/conf/{}/autoconf", ifname),
+            "0",
+        ) {
+            match err {
+                SysctlError::NotFound(_) => {
+                    // if the sysctl is not found we likely run on a system without ipv6
+                    // just ignore that case
+                }
+
+                // if we have a read only /proc we ignore it as well
+                SysctlError::IoError(ref e) if e.raw_os_error() == Some(libc::EROFS) => {}
+
+                _ => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("failed to set autoconf sysctl: {}", err),
+                    ));
+                }
+            }
+        };
+
         // ip netns exec ip link set <ifname> up
         CoreUtils::set_link_up(&handle, ifname).await?;
 

--- a/test/300-macvlan.bats
+++ b/test/300-macvlan.bats
@@ -33,6 +33,9 @@ function setup() {
     run_in_container_netns ip r
     assert "$output" "=~" "default via 10.88.0.1" "gateway must be there in default route"
     assert_json "$result" ".podman.interfaces.eth0.subnets[0].gateway" == "10.88.0.1" "Result contains gateway address"
+
+    run_in_container_netns cat /proc/sys/net/ipv6/conf/eth0/autoconf
+    assert "0" "autoconf is disabled"
 }
 
 @test "macvlan setup internal" {


### PR DESCRIPTION
When we run container netavark (or in the future the dhcp proxy) should set ip addresses. The ipv6 auto configuration is not wanted in almost all cases so we just disable it for now.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2126243

I was able to reproduce this and can confirm that this fixes the issue for me. I don't think we can test it in CI.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>