### PR TITLE
README.md: remove latest release section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ $ make test
 ```
 Also see [./test](./test/README.md) for more information.
 
-## Latest release
-[v1.0.0](https://github.com/containers/netavark/releases/latest)
-
 ## Communications
 
 For general questions and discussion, please use Podman's


### PR DESCRIPTION
Netavark follows github releases which is already listed on homepage. 
* Remove section which needs additional maintenance.
* Follow parity with other projects in github.com/containers such as podman.

Closes: https://github.com/containers/netavark/issues/440
