### PR TITLE
error: NetavarkError use Into<String> Trait

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -38,7 +38,7 @@ impl Setup {
         match network::validation::ns_checks(&self.network_namespace_path) {
             Ok(_) => (),
             Err(e) => {
-                return Err(NetavarkError::wrap_str("invalid namespace path", e));
+                return Err(NetavarkError::wrap("invalid namespace path", e));
             }
         }
         debug!("{:?}", "Setting up...");

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -7,18 +7,23 @@ pub type NetavarkResult<T> = Result<T, NetavarkError>;
 #[macro_export]
 macro_rules! wrap {
     ($result:expr, $msg:expr) => {
-        $result.map_err(|err| NetavarkError::wrap_str($msg, err.into()))
+        $result.map_err(|err| NetavarkError::wrap($msg, err.into()))
     };
 }
 
 pub trait ErrorWrap<T> {
     /// wrap NetavarkResult error into a NetavarkError and add the given msg
-    fn wrap(self, msg: &str) -> NetavarkResult<T>;
+    fn wrap<S>(self, msg: S) -> NetavarkResult<T>
+    where
+        S: Into<String>;
 }
 
 impl<T> ErrorWrap<T> for NetavarkResult<T> {
-    fn wrap(self, msg: &str) -> NetavarkResult<T> {
-        self.map_err(|err| NetavarkError::wrap_str(msg, err))
+    fn wrap<S>(self, msg: S) -> NetavarkResult<T>
+    where
+        S: Into<String>,
+    {
+        self.map_err(|err| NetavarkError::wrap(msg, err))
     }
 }
 
@@ -51,19 +56,18 @@ struct JsonError {
 }
 
 impl NetavarkError {
-    // TODO: There has to be a better way of doing this
-    pub fn msg_str(string: &str) -> NetavarkError {
-        NetavarkError::Message(string.to_string())
+    pub fn msg<S>(msg: S) -> NetavarkError
+    where
+        S: Into<String>,
+    {
+        NetavarkError::Message(msg.into())
     }
 
-    // TODO: There has to be a better way of doing this
-    pub fn wrap(string: String, chained: NetavarkError) -> NetavarkError {
-        NetavarkError::Chain(string, Box::new(chained))
-    }
-
-    // TODO: There has to be a better way of doing this
-    pub fn wrap_str(string: &str, chained: NetavarkError) -> NetavarkError {
-        NetavarkError::Chain(string.to_string(), Box::new(chained))
+    pub fn wrap<S>(msg: S, chained: NetavarkError) -> NetavarkError
+    where
+        S: Into<String>,
+    {
+        NetavarkError::Chain(msg.into(), Box::new(chained))
     }
 
     // Print the error in a standardized JSON format recognized by callers of

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -141,7 +141,7 @@ impl firewall::FirewallDriver for FirewallD {
             Some(a) => match a {
                 Value::Array(arr) => port_forwarding_rules = arr.clone(),
                 _ => {
-                    return Err(NetavarkError::msg_str(
+                    return Err(NetavarkError::msg(
                         "forward-port in firewalld policy object has a bad type",
                     ))
                 }
@@ -152,7 +152,7 @@ impl firewall::FirewallDriver for FirewallD {
                 let sig = match Signature::try_from("(ssss)") {
                     Ok(s) => s,
                     Err(e) => {
-                        return Err(NetavarkError::wrap_str(
+                        return Err(NetavarkError::wrap(
                             "Error creating signature for new DBus array",
                             e.into(),
                         ))
@@ -199,7 +199,7 @@ impl firewall::FirewallDriver for FirewallD {
                 Some(a) => match a {
                     Value::Array(arr) => rich_rules = arr.clone(),
                     _ => {
-                        return Err(NetavarkError::msg_str(
+                        return Err(NetavarkError::msg(
                             "forward-port in firewalld policy object has a bad type",
                         ))
                     }
@@ -210,7 +210,7 @@ impl firewall::FirewallDriver for FirewallD {
                     let sig = match Signature::try_from("s") {
                         Ok(s) => s,
                         Err(e) => {
-                            return Err(NetavarkError::wrap_str(
+                            return Err(NetavarkError::wrap(
                                 "Error creating signature for new DBus array",
                                 e.into(),
                             ))
@@ -291,7 +291,7 @@ impl firewall::FirewallDriver for FirewallD {
                 Some(a) => match a {
                     Value::Array(arr) => Some(arr.clone()),
                     _ => {
-                        return Err(NetavarkError::msg_str(
+                        return Err(NetavarkError::msg(
                             "forward-port in firewalld policy object has a bad type",
                         ))
                     }
@@ -307,7 +307,7 @@ impl firewall::FirewallDriver for FirewallD {
             let sig = match Signature::try_from("(ssss)") {
                 Ok(s) => s,
                 Err(e) => {
-                    return Err(NetavarkError::wrap_str(
+                    return Err(NetavarkError::wrap(
                         "Error creating signature for new dbus array",
                         e.into(),
                     ))
@@ -332,13 +332,13 @@ impl firewall::FirewallDriver for FirewallD {
                     Value::Structure(s) => {
                         let fields = s.clone().into_fields();
                         if fields.len() != 4 {
-                            return Err(NetavarkError::msg_str(
+                            return Err(NetavarkError::msg(
                                 "Port forwarding rule that was not a 4-tuple encountered",
                             ));
                         }
                         let port_ip = match fields[3].clone() {
                             Value::Str(s) => s.as_str().to_string(),
-                            _ => return Err(NetavarkError::msg_str("Port forwarding tuples must contain only strings, encountered a non-string object")),
+                            _ => return Err(NetavarkError::msg("Port forwarding tuples must contain only strings, encountered a non-string object")),
                         };
                         debug!("IP string from firewalld is {}", port_ip);
                         if port_ip != ipv4 && port_ip != ipv6 {
@@ -346,7 +346,7 @@ impl firewall::FirewallDriver for FirewallD {
                         }
                     }
                     _ => {
-                        return Err(NetavarkError::msg_str(
+                        return Err(NetavarkError::msg(
                             "Port forwarding rule that was not a structure encountered",
                         ))
                     }
@@ -368,7 +368,7 @@ impl firewall::FirewallDriver for FirewallD {
                 match a {
                     Value::Array(arr) => old_rich_rules_option = Some(arr.clone()),
                     _ => {
-                        return Err(NetavarkError::msg_str(
+                        return Err(NetavarkError::msg(
                             "forward-port in firewalld policy object has a bad type",
                         ))
                     }
@@ -386,7 +386,7 @@ impl firewall::FirewallDriver for FirewallD {
             let sig = match Signature::try_from("s") {
                 Ok(s) => s,
                 Err(e) => {
-                    return Err(NetavarkError::wrap_str(
+                    return Err(NetavarkError::wrap(
                         "Error creating signature for new DBus array",
                         e.into(),
                     ))
@@ -401,7 +401,7 @@ impl firewall::FirewallDriver for FirewallD {
                         }
                     }
                     _ => {
-                        return Err(NetavarkError::msg_str(
+                        return Err(NetavarkError::msg(
                             "Rich rule that was not a string encountered",
                         ))
                     }
@@ -464,7 +464,7 @@ fn create_zone_if_not_exist(conn: &Connection, zone_name: &str) -> NetavarkResul
     let zones: Vec<&str> = match zones_msg.body() {
         Ok(b) => b,
         Err(e) => {
-            return Err(NetavarkError::wrap_str(
+            return Err(NetavarkError::wrap(
                 "Error decoding DBus message for active zones",
                 e.into(),
             ))
@@ -488,7 +488,7 @@ fn create_zone_if_not_exist(conn: &Connection, zone_name: &str) -> NetavarkResul
     let zones_perm: Vec<&str> = match perm_zones_msg.body() {
         Ok(b) => b,
         Err(e) => {
-            return Err(NetavarkError::wrap_str(
+            return Err(NetavarkError::wrap(
                 "Error decoding DBus message for permanent zones",
                 e.into(),
             ))
@@ -535,7 +535,7 @@ pub fn add_source_subnets_to_zone(
         let zone_string: String = match subnet_zone.body() {
             Ok(s) => s,
             Err(e) => {
-                return Err(NetavarkError::wrap_str(
+                return Err(NetavarkError::wrap(
                     "Error decoding DBus message for zone of subnet",
                     e.into(),
                 ))
@@ -587,7 +587,7 @@ fn add_policy_if_not_exist(
     let policies: Vec<&str> = match policies_msg.body() {
         Ok(v) => v,
         Err(e) => {
-            return Err(NetavarkError::wrap_str(
+            return Err(NetavarkError::wrap(
                 "Error decoding policy list response",
                 e.into(),
             ))
@@ -611,7 +611,7 @@ fn add_policy_if_not_exist(
     let perm_policies: Vec<&str> = match perm_policies_msg.body() {
         Ok(v) => v,
         Err(e) => {
-            return Err(NetavarkError::wrap_str(
+            return Err(NetavarkError::wrap(
                 "Error decoding permanent policy list response",
                 e.into(),
             ))

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -43,7 +43,7 @@ fn get_firewall_impl() -> NetavarkResult<FirewallImpl> {
                 let conn = match block_on(Connection::system()) {
                     Ok(c) => c,
                     Err(e) => {
-                        return Err(NetavarkError::wrap_str(
+                        return Err(NetavarkError::wrap(
                             "Error retrieving dbus connection for requested firewall backend",
                             e.into(),
                         ))
@@ -98,7 +98,7 @@ pub fn get_supported_firewall_driver() -> NetavarkResult<Box<dyn FirewallDriver>
             }
             FirewallImpl::Nftables => {
                 info!("Using nftables firewall driver");
-                Err(NetavarkError::msg_str(
+                Err(NetavarkError::msg(
                     "nftables support presently not available",
                 ))
             }

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -63,7 +63,7 @@ impl driver::NetworkDriver for Bridge<'_> {
     fn validate(&mut self) -> NetavarkResult<()> {
         let bridge_name = get_interface_name(self.info.network.network_interface.clone())?;
         if self.info.per_network_opts.interface_name.is_empty() {
-            return Err(NetavarkError::msg_str(NO_CONTAINER_INTERFACE_ERROR));
+            return Err(NetavarkError::msg(NO_CONTAINER_INTERFACE_ERROR));
         }
         let ipam = get_ipam_addresses(self.info.per_network_opts, self.info.network)?;
 
@@ -92,11 +92,7 @@ impl driver::NetworkDriver for Bridge<'_> {
     ) -> NetavarkResult<(StatusBlock, Option<AardvarkEntry>)> {
         let data = match &self.data {
             Some(d) => d,
-            None => {
-                return Err(NetavarkError::msg_str(
-                    "must call validate() before setup()",
-                ))
-            }
+            None => return Err(NetavarkError::msg("must call validate() before setup()")),
         };
 
         debug!("Setup network {}", self.info.network.name);
@@ -242,10 +238,10 @@ impl driver::NetworkDriver for Bridge<'_> {
 
 fn get_interface_name(name: Option<String>) -> NetavarkResult<String> {
     let name = match name {
-        None => return Err(NetavarkError::msg_str(NO_BRIDGE_NAME_ERROR)),
+        None => return Err(NetavarkError::msg(NO_BRIDGE_NAME_ERROR)),
         Some(n) => {
             if n.is_empty() {
-                return Err(NetavarkError::msg_str(NO_BRIDGE_NAME_ERROR));
+                return Err(NetavarkError::msg(NO_BRIDGE_NAME_ERROR));
             }
             n
         }
@@ -527,7 +523,7 @@ fn create_veth_pair(
             ),
             err,
         ),
-        _ => NetavarkError::wrap_str("create veth pair", err),
+        _ => NetavarkError::wrap("create veth pair", err),
     })?;
 
     let veth = netns

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -245,7 +245,7 @@ impl CoreUtils {
 pub fn join_netns(fd: RawFd) -> NetavarkResult<()> {
     match sched::setns(fd, sched::CloneFlags::CLONE_NEWNET) {
         Ok(_) => Ok(()),
-        Err(e) => Err(NetavarkError::wrap_str(
+        Err(e) => Err(NetavarkError::wrap(
             "setns",
             NetavarkError::Io(io::Error::from(e)),
         )),
@@ -358,7 +358,7 @@ pub fn disable_ipv6_autoconf(if_name: &str) -> NetavarkResult<()> {
             SysctlError::IoError(ref e) if e.raw_os_error() == Some(libc::EROFS) => {}
 
             _ => {
-                return Err(NetavarkError::wrap_str(
+                return Err(NetavarkError::wrap(
                     "failed to set autoconf sysctl",
                     NetavarkError::Sysctl(err),
                 ));

--- a/src/network/macvlan.rs
+++ b/src/network/macvlan.rs
@@ -51,7 +51,7 @@ impl driver::NetworkDriver for MacVlan<'_> {
 
     fn validate(&mut self) -> NetavarkResult<()> {
         if self.info.per_network_opts.interface_name.is_empty() {
-            return Err(NetavarkError::msg_str(NO_CONTAINER_INTERFACE_ERROR));
+            return Err(NetavarkError::msg(NO_CONTAINER_INTERFACE_ERROR));
         }
 
         let mode = parse_option(&self.info.network.options, OPTION_MODE, String::default())?;
@@ -92,11 +92,7 @@ impl driver::NetworkDriver for MacVlan<'_> {
     ) -> Result<(StatusBlock, Option<AardvarkEntry>), NetavarkError> {
         let data = match &self.data {
             Some(d) => d,
-            None => {
-                return Err(NetavarkError::msg_str(
-                    "must call validate() before setup()",
-                ))
-            }
+            None => return Err(NetavarkError::msg("must call validate() before setup()")),
         };
 
         debug!("Setup network {}", self.info.network.name);
@@ -196,8 +192,8 @@ fn setup(
         }
     }
 
-    Err(NetavarkError::Message(
-        "failed to get the mac address from the container veth interface".to_string(),
+    Err(NetavarkError::msg(
+        "failed to get the mac address from the container veth interface",
     ))
 }
 
@@ -232,7 +228,5 @@ fn get_default_route_interface(host: &mut netlink::Socket) -> NetavarkResult<Str
             }
         }
     }
-    Err(NetavarkError::Message(
-        "failed to get default route interface".to_string(),
-    ))
+    Err(NetavarkError::msg("failed to get default route interface"))
 }

--- a/src/network/netlink.rs
+++ b/src/network/netlink.rs
@@ -78,7 +78,7 @@ impl Socket {
 
         let mut result = self.make_netlink_request(RtnlMessage::GetLink(msg), 0)?;
         if result.len() != 1 {
-            return Err(NetavarkError::msg_str("unexpected netlink result"));
+            return Err(NetavarkError::msg("unexpected netlink result"));
         }
         match result.remove(0) {
             RtnlMessage::NewLink(m) => Ok(m),
@@ -97,7 +97,7 @@ impl Socket {
             NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE,
         )?;
         if !result.is_empty() {
-            return Err(NetavarkError::msg_str("unexpected netlink result"));
+            return Err(NetavarkError::msg("unexpected netlink result"));
         }
 
         Ok(())
@@ -113,7 +113,7 @@ impl Socket {
 
         let result = self.make_netlink_request(RtnlMessage::DelLink(msg), NLM_F_ACK)?;
         if !result.is_empty() {
-            return Err(NetavarkError::msg_str("unexpected netlink result 1243"));
+            return Err(NetavarkError::msg("unexpected netlink result 1243"));
         }
         Ok(())
     }
@@ -144,7 +144,7 @@ impl Socket {
             NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE,
         )?;
         if !result.is_empty() {
-            return Err(NetavarkError::msg_str("unexpected netlink result"));
+            return Err(NetavarkError::msg("unexpected netlink result"));
         }
 
         Ok(())
@@ -186,7 +186,7 @@ impl Socket {
         let result =
             self.make_netlink_request(RtnlMessage::NewRoute(msg), NLM_F_ACK | NLM_F_CREATE)?;
         if !result.is_empty() {
-            return Err(NetavarkError::msg_str("unexpected netlink result"));
+            return Err(NetavarkError::msg("unexpected netlink result"));
         }
 
         Ok(())
@@ -258,7 +258,7 @@ impl Socket {
             NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE,
         )?;
         if !result.is_empty() {
-            return Err(NetavarkError::msg_str("unexpected netlink result"));
+            return Err(NetavarkError::msg("unexpected netlink result"));
         }
 
         Ok(())
@@ -324,12 +324,12 @@ impl Socket {
                         return Ok(result);
                     }
                     NetlinkPayload::Noop => {
-                        return Err(NetavarkError::msg_str(
+                        return Err(NetavarkError::msg(
                             "unimplemented netlink message type NOOP",
                         ))
                     }
                     NetlinkPayload::Overrun(_) => {
-                        return Err(NetavarkError::msg_str(
+                        return Err(NetavarkError::msg(
                             "unimplemented netlink message type OVERRUN",
                         ))
                     }


### PR DESCRIPTION
Instead of using two function for types String and str we can just use a generic which implements Into<String>. This allows us to only use one function for both.