### PR TITLE
teardown: handle errors better

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -11,6 +11,36 @@ macro_rules! wrap {
     };
 }
 
+/// Contains a list of errors, this is useful for teardown operations since we
+/// should cleanup as much as possible before return all encountered errors.
+#[derive(Debug)]
+pub struct NetavarkErrorList(Vec<NetavarkError>);
+
+impl NetavarkErrorList {
+    pub fn new() -> Self {
+        Self(vec![])
+    }
+
+    pub fn push(&mut self, err: NetavarkError) {
+        match err {
+            // make sure the flatten the error list, nested lists would just look ugly
+            NetavarkError::List(mut list) => self.0.append(&mut list.0),
+            err => self.0.push(err),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+// clippy wants the default implementation even if it is not needed
+impl Default for NetavarkErrorList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub trait ErrorWrap<T> {
     /// wrap NetavarkResult error into a NetavarkError and add the given msg
     fn wrap<S>(self, msg: S) -> NetavarkResult<T>
@@ -47,6 +77,8 @@ pub enum NetavarkError {
     Serde(serde_json::Error),
 
     Netlink(netlink_packet_core::error::ErrorMessage),
+
+    List(NetavarkErrorList),
 }
 
 // Internal struct for JSON output
@@ -114,6 +146,17 @@ impl fmt::Display for NetavarkError {
             NetavarkError::Sysctl(e) => write!(f, "Sysctl error: {}", e),
             NetavarkError::Serde(e) => write!(f, "JSON Decoding error: {}", e),
             NetavarkError::Netlink(e) => write!(f, "Netlink error: {}", e),
+            NetavarkError::List(list) => {
+                if list.0.len() == 1 {
+                    write!(f, "{}", list.0[0])
+                } else {
+                    write!(f, "netavark encountered multiple errors:")?;
+                    for e in &list.0 {
+                        write!(f, "\n\t- {}", e)?;
+                    }
+                    Ok(())
+                }
+            }
         }
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -118,61 +118,6 @@ impl fmt::Display for NetavarkError {
     }
 }
 
-impl PartialEq for NetavarkError {
-    fn eq(&self, other: &Self) -> bool {
-        match self {
-            NetavarkError::Message(s) => {
-                if let NetavarkError::Message(o) = other {
-                    return s == o;
-                }
-            }
-            NetavarkError::ExitCode(s, i) => {
-                if let NetavarkError::ExitCode(s2, i2) = other {
-                    return s == s2 && i == i2;
-                }
-            }
-            NetavarkError::Chain(s, e) => {
-                if let NetavarkError::Chain(s2, e2) = other {
-                    return s == s2 && e == e2;
-                }
-            }
-            NetavarkError::Io(e) => {
-                if let NetavarkError::Io(e2) = other {
-                    return e.to_string() == e2.to_string();
-                }
-            }
-            NetavarkError::Dbus(e) => {
-                if let NetavarkError::Dbus(e2) = other {
-                    return e.to_string() == e2.to_string();
-                }
-            }
-            NetavarkError::DbusVariant(e) => {
-                if let NetavarkError::DbusVariant(e2) = other {
-                    return e.to_string() == e2.to_string();
-                }
-            }
-            NetavarkError::Sysctl(e) => {
-                if let NetavarkError::Sysctl(e2) = other {
-                    return e.to_string() == e2.to_string();
-                }
-            }
-            NetavarkError::Serde(e) => {
-                if let NetavarkError::Serde(e2) = other {
-                    return e.to_string() == e2.to_string();
-                }
-            }
-            NetavarkError::Netlink(e) => {
-                if let NetavarkError::Netlink(e2) = other {
-                    return e == e2;
-                }
-            }
-        }
-        false
-    }
-}
-
-impl Eq for NetavarkError {}
-
 impl Error for NetavarkError {}
 
 impl From<std::io::Error> for NetavarkError {

--- a/test/testfiles/two-networks.json
+++ b/test/testfiles/two-networks.json
@@ -1,0 +1,58 @@
+{
+    "container_id": "a417588994662895d8b41adf8d74a83ac0cc38eb56d85d8e1268aae1e19e07e1",
+    "container_name": "heuristic_archimedes",
+    "networks": {
+        "t1": {
+            "static_ips": [
+                "10.89.1.2"
+            ],
+            "interface_name": "eth0"
+        },
+        "t2": {
+            "static_ips": [
+                "10.89.2.2"
+            ],
+            "interface_name": "eth1"
+        }
+    },
+    "network_info": {
+        "t1": {
+            "name": "t1",
+            "id": "fae505bba2b3ad2b9bc748f0d322864d44a3c976c642ee347e5276729dfb4d51",
+            "driver": "bridge",
+            "network_interface": "podman2",
+            "created": "2022-10-18T18:34:21.701124201+02:00",
+            "subnets": [
+                {
+                    "subnet": "10.89.1.0/24",
+                    "gateway": "10.89.1.1"
+                }
+            ],
+            "ipv6_enabled": false,
+            "internal": false,
+            "dns_enabled": false,
+            "ipam_options": {
+                "driver": "host-local"
+            }
+        },
+        "t2": {
+            "name": "t2",
+            "id": "d7322dfb9353cb5c1adabfc46555164654f339fa3dd0d2533d103e2a4c5240e2",
+            "driver": "bridge",
+            "network_interface": "podman3",
+            "created": "2022-10-18T18:34:23.266425802+02:00",
+            "subnets": [
+                {
+                    "subnet": "10.89.2.0/24",
+                    "gateway": "10.89.2.1"
+                }
+            ],
+            "ipv6_enabled": false,
+            "internal": false,
+            "dns_enabled": false,
+            "ipam_options": {
+                "driver": "host-local"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a NetavarkErrorList type to store multiple errors in a list. The
teardown operation must cleanup as much as possible before returning all
errors.