### PR TITLE
NetworkOptions::load(): do not open /dev/stdin

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -30,7 +30,7 @@ impl Setup {
 
     pub fn exec(
         &self,
-        input_file: String,
+        input_file: Option<String>,
         config_dir: String,
         aardvark_bin: String,
         rootless: bool,
@@ -42,16 +42,7 @@ impl Setup {
             }
         }
         debug!("{:?}", "Setting up...");
-        let network_options = match network::types::NetworkOptions::load(&input_file) {
-            Ok(opts) => opts,
-            Err(e) => {
-                // TODO: Convert this to a proper typed error
-                return Err(NetavarkError::Message(format!(
-                    "failed to load network options: {}",
-                    e
-                )));
-            }
-        };
+        let network_options = network::types::NetworkOptions::load(input_file)?;
 
         let firewall_driver = match firewall::get_supported_firewall_driver() {
             Ok(driver) => driver,

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -26,21 +26,13 @@ impl Teardown {
 
     pub fn exec(
         &self,
-        input_file: String,
+        input_file: Option<String>,
         config_dir: String,
         aardvark_bin: String,
         rootless: bool,
     ) -> NetavarkResult<()> {
         debug!("{:?}", "Tearing down..");
-        let network_options = match network::types::NetworkOptions::load(&input_file) {
-            Ok(opts) => opts,
-            Err(e) => {
-                return Err(NetavarkError::Message(format!(
-                    "failed to load network options: {}",
-                    e
-                )));
-            }
-        };
+        let network_options = network::types::NetworkOptions::load(input_file)?;
 
         let dns_port = match env::var("NETAVARK_DNS_PORT") {
             Ok(port_string) => match port_string.parse() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,6 @@ fn main() {
     env_logger::builder().format_timestamp(None).init();
     let opts = Opts::parse();
 
-    let file = opts.file.unwrap_or_else(|| String::from("/dev/stdin"));
     // aardvark config directory must be supplied by parent or it defaults to /tmp/aardvark
     let config = opts.config.unwrap_or_else(|| String::from("/tmp"));
     let rootless = opts.rootless.unwrap_or(false);
@@ -46,8 +45,8 @@ fn main() {
         .aardvark_binary
         .unwrap_or_else(|| String::from("/usr/libexec/podman/aardvark-dns"));
     let result = match opts.subcmd {
-        SubCommand::Setup(setup) => setup.exec(file, config, aardvark_bin, rootless),
-        SubCommand::Teardown(teardown) => teardown.exec(file, config, aardvark_bin, rootless),
+        SubCommand::Setup(setup) => setup.exec(opts.file, config, aardvark_bin, rootless),
+        SubCommand::Teardown(teardown) => teardown.exec(opts.file, config, aardvark_bin, rootless),
         SubCommand::Version(version) => version.exec(),
     };
 

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -6,7 +6,9 @@ mod tests {
     #[test]
     // Test setup options loader
     fn test_setup_opts_load() {
-        match network::types::NetworkOptions::load("src/test/config/setupopts.test.json") {
+        match network::types::NetworkOptions::load(Some(
+            "src/test/config/setupopts.test.json".to_owned(),
+        )) {
             Ok(_) => {}
             Err(e) => panic!("{}", e),
         }
@@ -15,7 +17,9 @@ mod tests {
     // Test if we can deserialize values correctly
     #[test]
     fn test_setup_opts_assert() {
-        match network::types::NetworkOptions::load("src/test/config/setupopts.test.json") {
+        match network::types::NetworkOptions::load(Some(
+            "src/test/config/setupopts.test.json".to_owned(),
+        )) {
             Ok(setupopts) => {
                 assert_eq!(setupopts.container_name, "testcontainer")
             }
@@ -27,7 +31,9 @@ mod tests {
     // Try mutating deserialized struct
     #[test]
     fn test_setup_opts_mutablity() {
-        match network::types::NetworkOptions::load("src/test/config/setupopts.test.json") {
+        match network::types::NetworkOptions::load(Some(
+            "src/test/config/setupopts.test.json".to_owned(),
+        )) {
             Ok(mut setupopts) => {
                 assert_eq!(setupopts.container_name, "testcontainer");
                 setupopts.container_name = "mutatedcontainername".to_string();

--- a/test/001-basic.bats
+++ b/test/001-basic.bats
@@ -24,5 +24,5 @@ load helpers
 
 @test "netavark error - invalid config path" {
     expected_rc=1 run_netavark -f /test/1 setup $(get_container_netns_path)
-    assert_json ".error" "failed to load network options: No such file or directory (os error 2)" "Config file does not exists"
+    assert_json ".error" "failed to load network options: IO error: No such file or directory (os error 2)" "Config file does not exists"
 }


### PR DESCRIPTION
There is no need to open /dev/stdin, we should just read directly from fd 0 without having to call open().

Also convert the error inside the function to prevent duplication.