### PR TITLE
Add 'v' to tarball names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,9 @@ vendor-rm-windows:
 vendor-tarball: build vendor
 	VERSION=$(shell bin/netavark --version | cut -f2 -d" ") && \
 	case $$VERSION in *-dev) echo "version ends with -dev" && exit 1;; esac; \
-	tar cvf netavark-$$VERSION-vendor.tar.gz vendor/ && \
+	tar cvf netavark-v$$VERSION-vendor.tar.gz vendor/ && \
 	gzip -c bin/netavark > netavark.gz && \
-	sha256sum netavark.gz netavark-$$VERSION-vendor.tar.gz > sha256sum
+	sha256sum netavark.gz netavark-v$$VERSION-vendor.tar.gz > sha256sum
 	rm -rf vendor/
 
 .PHONY: mock-rpm


### PR DESCRIPTION
The EL spec files have a `v` for version in front of the numberic version.  Easier to just fix in the Makefile.

Signed-off-by: Brent Baude <bbaude@redhat.com>