### PR TITLE
netlink: better errors on invalid querys

### DIFF
--- a/src/network/netlink.rs
+++ b/src/network/netlink.rs
@@ -360,6 +360,13 @@ impl Socket {
                     })?;
                 trace!("read netlink packet: {:?}", rx_packet);
 
+                if rx_packet.header.sequence_number != self.sequence_number {
+                    return Err(NetavarkError::msg(format!(
+                        "netlink: sequence_number out of sync (got {}, want {})",
+                        rx_packet.header.sequence_number, self.sequence_number,
+                    )));
+                }
+
                 match rx_packet.payload {
                     NetlinkPayload::Done => return Ok(result),
                     NetlinkPayload::Error(e) | NetlinkPayload::Ack(e) => {


### PR DESCRIPTION
* netlink: improve error message on invalid netlink result
While unlikely when netlink returns something unexpected we should
provide more details so we know where it failed. This will most likely
only fail when we called something incorrectly or due a kernel bug.
If it run with trace log level we already display the raw netlink
messages so that should be enough info to start debugging.

* netlink: check sequence_number
Make sure we only parse messages that are for us. If the sequence_number
does not match it likely means we screwed up somewhere. Better to catch
this early than having the callers get unexpected responses which causes
hard to debug issues.