### PR TITLE
macvlan: fix name collision on hostns

### DIFF
--- a/src/network/netlink.rs
+++ b/src/network/netlink.rs
@@ -23,8 +23,9 @@ pub struct Socket {
     buffer: [u8; 8192],
 }
 
+#[derive(Clone)]
 pub struct CreateLinkOptions {
-    name: String,
+    pub name: String,
     kind: InfoKind,
     pub info_data: Option<InfoData>,
     pub mtu: u32,
@@ -125,6 +126,16 @@ impl Socket {
             RtnlMessage::NewLink(msg),
             NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE,
         )?;
+        expect_netlink_result!(result, 0);
+
+        Ok(())
+    }
+
+    pub fn set_link_name(&mut self, id: u32, name: String) -> NetavarkResult<()> {
+        let mut msg = LinkMessage::default();
+        msg.header.index = id;
+        msg.nlas.push(Nla::IfName(name));
+        let result = self.make_netlink_request(RtnlMessage::SetLink(msg), NLM_F_ACK)?;
         expect_netlink_result!(result, 0);
 
         Ok(())


### PR DESCRIPTION
When the container interface and host interface use the same link netavark fails with EEXISTS. This is a weird kernel behavior because we directly create the interface in the netns but the kernel still checks in the host ns and thus it will fail if the same name is already used there.

To fix this we need to create the interface with a tmp name then rename it in the netns. For performance reason we still try the quick way first and only fallback to tmp name if required.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>