### PR TITLE
Add support for route metrics

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -22,5 +22,9 @@ pub const DRIVER_MACVLAN: &str = "macvlan";
 pub const OPTION_ISOLATE: &str = "isolate";
 pub const OPTION_MTU: &str = "mtu";
 pub const OPTION_MODE: &str = "mode";
+pub const OPTION_METRIC: &str = "metric";
+
+// 100 is the default metric for most Linux networking tools.
+pub const DEFAULT_METRIC: u32 = 100;
 
 pub const NO_CONTAINER_INTERFACE_ERROR: &str = "no container interface name given";

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -309,7 +309,11 @@ fn open_netlink_socket(netns_path: &str) -> NetavarkResult<(File, RawFd)> {
     Ok((ns, ns_fd))
 }
 
-pub fn add_default_routes(sock: &mut netlink::Socket, gws: &[ipnet::IpNet]) -> NetavarkResult<()> {
+pub fn add_default_routes(
+    sock: &mut netlink::Socket,
+    gws: &[ipnet::IpNet],
+    metric: Option<u32>,
+) -> NetavarkResult<()> {
     let mut ipv4 = false;
     let mut ipv6 = false;
     for addr in gws {
@@ -323,6 +327,7 @@ pub fn add_default_routes(sock: &mut netlink::Socket, gws: &[ipnet::IpNet]) -> N
                 netlink::Route::Ipv4 {
                     dest: ipnet::Ipv4Net::new(Ipv4Addr::new(0, 0, 0, 0), 0)?,
                     gw: v4.addr(),
+                    metric,
                 }
             }
             ipnet::IpNet::V6(v6) => {
@@ -334,6 +339,7 @@ pub fn add_default_routes(sock: &mut netlink::Socket, gws: &[ipnet::IpNet]) -> N
                 netlink::Route::Ipv6 {
                     dest: ipnet::Ipv6Net::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), 0)?,
                     gw: v6.addr(),
+                    metric,
                 }
             }
         };

--- a/src/test/netlink.rs
+++ b/src/test/netlink.rs
@@ -142,6 +142,7 @@ mod tests {
         sock.del_route(&Route::Ipv4 {
             dest: net.parse().unwrap(),
             gw: gw.parse().unwrap(),
+            metric: None,
         })
         .expect("del_route failed");
 

--- a/test/testfiles/metric.json
+++ b/test/testfiles/metric.json
@@ -1,0 +1,37 @@
+{
+    "container_id": "bc14fe7cd3633e7be338522002bb0c3ccb18150da7a6c733735ffdf8ff7e85d1",
+    "container_name": "metrictest",
+    "networks": {
+        "metric": {
+            "interface_name": "eth1",
+            "static_ips": [
+                "10.89.0.2",
+                "fde0::2"
+            ]
+        }
+    },
+    "network_info": {
+        "metric": {
+            "dns_enabled": false,
+            "driver": "bridge",
+            "id": "7ba44a9a709f8093621eae1a1db2ccafc2471bae19cdf9dd2ea7cf3773b9211c",
+            "internal": false,
+            "ipv6_enabled": true,
+            "name": "metric",
+            "network_interface": "metric",
+            "subnets": [
+                {
+                    "gateway": "10.89.0.1",
+                    "subnet": "10.89.0.0/24"
+                },
+                {
+                    "subnet": "fde0::/64",
+                    "gateway": "fde0::1"
+               }
+            ],
+            "options": {
+                "metric": "200"
+             }
+        }
+    }
+}


### PR DESCRIPTION
Metrics allow us to specify which default route will be preferred when a container connects to multiple networks. By default, all routes will get a metric of 100. If two routes go to the same location (e.g. multiple default routes, one for each network, as Netavark does by default), the kernel by default round-robins traffic between all of them, but if the metrics for the routes differ, the route(s) with the lowest metric are chosen.

For confusing reasons, metric is actually called preference in Netlink - and, doubly confusing, there is also a "metrics" option for routes in Netlink as well. Which, naturally, is completely unrelated to route metric. Sigh.