### PR TITLE
Drop indirect dependency on time 0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,12 +194,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -513,7 +510,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1236,17 +1233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,12 +1359,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ deps-serde = ["chrono/serde", "url/serde"]
 
 [dependencies]
 anyhow = "1.0"
-chrono = "0.4.22"
 clap = { version = "3.2.23", features = ["derive"] }
 env_logger = "0.9.1"
 ipnet = { version = "2", features = ["serde"] }
@@ -43,4 +42,4 @@ fs2 = "0.4.3"
 netlink-sys = "0.8.3"
 
 [build-dependencies]
-chrono = "0.4.22"
+chrono = { version = "0.4.22", default-features = false, features = ["clock"] }


### PR DESCRIPTION
Removes chrono as a library dependency, since it wasn't being used anywhere, and reduces the features used by the build dependency to avoid bringing in time 0.1