### PR TITLE
macvlan modes: use upstream consts

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -3,14 +3,6 @@
 // default search domain
 pub static PODMAN_DEFAULT_SEARCH_DOMAIN: &str = "dns.podman";
 
-// Available macvlan modes
-// TODO: remove constants from here after https://github.com/little-dude/netlink/pull/200
-pub const MACVLAN_MODE_PRIVATE: u32 = 1;
-pub const MACVLAN_MODE_VEPA: u32 = 2;
-pub const MACVLAN_MODE_BRIDGE: u32 = 4;
-pub const MACVLAN_MODE_PASSTHRU: u32 = 8;
-pub const MACVLAN_MODE_SOURCE: u32 = 16;
-
 // IPAM drivers
 pub const IPAM_HOSTLOCAL: &str = "host-local";
 pub const IPAM_DHCP: &str = "dhcp";


### PR DESCRIPTION
Fixes a small TODO in the code. Also improve the error message including "io error" make no sense. I also added the actual mode name in the error.
