### PR TITLE
update CI images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,8 +16,8 @@ env:
     CARGO_TARGET_DIR: "$CIRRUS_WORKING_DIR/targets"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
-    FEDORA_NAME: "fedora-36"
-    IMAGE_SUFFIX: "c6535313974624256"
+    FEDORA_NAME: "fedora-37"
+    IMAGE_SUFFIX: "c5518085466095616"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
     AARDVARK_DNS_BRANCH: "main"
     AARDVARK_DNS_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_DNS_BRANCH}"


### PR DESCRIPTION
Bumps the version to fedora 37 and includes the wg tool for PR #472.
