### PR TITLE
fix rust doc comments

### DIFF
--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -31,13 +31,13 @@ pub struct AardvarkEntry<'a> {
 
 #[derive(Debug, Clone)]
 pub struct Aardvark {
-    // aardvark's config directory
+    /// aardvark's config directory
     pub config: String,
-    // tells if container is rootfull or rootless
+    /// tells if container is rootfull or rootless
     pub rootless: bool,
-    // path to the aardvark-dns binary
+    /// path to the aardvark-dns binary
     pub aardvark_bin: String,
-    // port to bind to
+    /// port to bind to
     pub port: String,
 }
 
@@ -51,7 +51,7 @@ impl Aardvark {
         }
     }
 
-    // On success retuns aardvark server's pid or returns -1;
+    /// On success retuns aardvark server's pid or returns -1;
     fn get_aardvark_pid(&mut self) -> i32 {
         let path = Path::new(&self.config).join("aardvark.pid");
         let pid: i32 = match fs::read_to_string(&path) {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -57,7 +57,7 @@ impl<T> ErrorWrap<T> for NetavarkResult<T> {
     }
 }
 
-// The main Netavark error type
+/// The main Netavark error type
 #[derive(Debug)]
 pub enum NetavarkError {
     // A string message
@@ -81,7 +81,7 @@ pub enum NetavarkError {
     List(NetavarkErrorList),
 }
 
-// Internal struct for JSON output
+/// Internal struct for JSON output
 #[derive(Debug, Serialize, Deserialize)]
 struct JsonError {
     pub error: String,
@@ -102,8 +102,8 @@ impl NetavarkError {
         NetavarkError::Chain(msg.into(), Box::new(chained))
     }
 
-    // Print the error in a standardized JSON format recognized by callers of
-    // Netavark.
+    /// Print the error in a standardized JSON format recognized by callers of
+    /// Netavark.
     pub fn print_json(&self) {
         let to_json = JsonError {
             error: self.to_string(),
@@ -117,7 +117,7 @@ impl NetavarkError {
         );
     }
 
-    // Get the exit code that Netavark should exit with
+    /// Get the exit code that Netavark should exit with
     pub fn get_exit_code(&self) -> i32 {
         match *self {
             NetavarkError::ExitCode(_, i) => i,

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -449,7 +449,7 @@ impl firewall::FirewallDriver for FirewallD {
     }
 }
 
-// Create a firewalld zone to hold all our interfaces.
+/// Create a firewalld zone to hold all our interfaces.
 fn create_zone_if_not_exist(conn: &Connection, zone_name: &str) -> NetavarkResult<bool> {
     debug!("Creating firewall zone {}", zone_name);
 
@@ -517,7 +517,7 @@ fn create_zone_if_not_exist(conn: &Connection, zone_name: &str) -> NetavarkResul
     Ok(true)
 }
 
-// Add source subnets to the zone.
+/// Add source subnets to the zone.
 pub fn add_source_subnets_to_zone(
     conn: &Connection,
     zone_name: &str,
@@ -563,7 +563,7 @@ pub fn add_source_subnets_to_zone(
     Ok(())
 }
 
-// Add a policy object for the zone to handle masqeuradeing.
+/// Add a policy object for the zone to handle masquerading.
 fn add_policy_if_not_exist(
     conn: &Connection,
     policy_name: &str,
@@ -652,11 +652,11 @@ fn add_policy_if_not_exist(
     Ok(true)
 }
 
-// Make a port-forward tuple for firewalld
-// Port forward rules are a 4-tuple of:
-// (port, protocol, to-port, to-addr)
-// Port, to-port can be ranges (separated via hyphen)
-// Also accepts IP address to forward to.
+/// Make a port-forward tuple for firewalld
+/// Port forward rules are a 4-tuple of:
+/// (port, protocol, to-port, to-addr)
+/// Port, to-port can be ranges (separated via hyphen)
+/// Also accepts IP address to forward to.
 fn make_port_tuple(port: &PortMapping, addr: &str) -> (String, String, String, String) {
     if port.range > 1 {
         // Subtract 1 as these are 1-indexed strings - range of 2 is 1000-1001

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -237,7 +237,7 @@ impl firewall::FirewallDriver for IptablesDriver {
     }
 }
 
-// Check if firewalld is running
+/// Check if firewalld is running
 fn is_firewalld_running(conn: &Connection) -> bool {
     block_on(conn.call_method(
         Some("org.freedesktop.DBus"),
@@ -249,8 +249,8 @@ fn is_firewalld_running(conn: &Connection) -> bool {
     .is_ok()
 }
 
-// If possible, add a firewalld rule to allow traffic.
-// Ignore all errors, beyond possibly logging them.
+/// If possible, add a firewalld rule to allow traffic.
+/// Ignore all errors, beyond possibly logging them.
 fn add_firewalld_if_possible(net: &types::Subnet) {
     let conn = match block_on(Connection::system()) {
         Ok(conn) => conn,

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -11,28 +11,28 @@ pub mod firewalld;
 pub mod iptables;
 mod varktables;
 
-// Firewall drivers have the ability to set up per-network firewall forwarding
-// and port mappings.
+/// Firewall drivers have the ability to set up per-network firewall forwarding
+/// and port mappings.
 pub trait FirewallDriver {
-    // Set up firewall rules for the given network,
+    /// Set up firewall rules for the given network,
     fn setup_network(&self, network_setup: SetupNetwork) -> NetavarkResult<()>;
-    // Tear down firewall rules for the given network.
+    /// Tear down firewall rules for the given network.
     fn teardown_network(&self, tear: TearDownNetwork) -> NetavarkResult<()>;
 
-    // Set up port-forwarding firewall rules for a given container.
+    /// Set up port-forwarding firewall rules for a given container.
     fn setup_port_forward(&self, setup_pw: PortForwardConfig) -> NetavarkResult<()>;
-    // Tear down port-forwarding firewall rules for a single container.
+    /// Tear down port-forwarding firewall rules for a single container.
     fn teardown_port_forward(&self, teardown_pf: TeardownPortForward) -> NetavarkResult<()>;
 }
 
-// Types of firewall backend
+/// Types of firewall backend
 enum FirewallImpl {
     Iptables,
     Firewalld(Connection),
     Nftables,
 }
 
-// What firewall implementations does this system support?
+/// What firewall implementations does this system support?
 fn get_firewall_impl() -> NetavarkResult<FirewallImpl> {
     // First, check the NETAVARK_FW env var.
     // It respects "firewalld", "iptables", "nftables".
@@ -83,8 +83,8 @@ fn get_firewall_impl() -> NetavarkResult<FirewallImpl> {
     // }
 }
 
-// Get the preferred firewall implementation for the current system
-// configuration.
+/// Get the preferred firewall implementation for the current system
+/// configuration.
 pub fn get_supported_firewall_driver() -> NetavarkResult<Box<dyn FirewallDriver>> {
     match get_firewall_impl() {
         Ok(fw) => match fw {

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -630,7 +630,7 @@ fn create_veth_pair(
     Ok(mac)
 }
 
-// make sure the LinkMessage has the kind bridge
+/// make sure the LinkMessage has the kind bridge
 fn check_link_is_bridge(msg: LinkMessage, br_name: &str) -> NetavarkResult<LinkMessage> {
     for nla in msg.nlas.iter() {
         if let Nla::Info(info) = nla {

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -16,7 +16,7 @@ pub const OPTION_MTU: &str = "mtu";
 pub const OPTION_MODE: &str = "mode";
 pub const OPTION_METRIC: &str = "metric";
 
-// 100 is the default metric for most Linux networking tools.
+/// 100 is the default metric for most Linux networking tools.
 pub const DEFAULT_METRIC: u32 = 100;
 
 pub const NO_CONTAINER_INTERFACE_ERROR: &str = "no container interface name given";

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -1,22 +1,22 @@
 use crate::network::types;
 use std::net::IpAddr;
 
-//  Teardown contains options for tearing down behind a container
+/// Teardown contains options for tearing down behind a container
 #[derive(Debug)]
 pub struct TeardownPortForward<'a> {
     pub config: PortForwardConfig<'a>,
-    // remove network related information
+    /// remove network related information
     pub complete_teardown: bool,
 }
 
-//  SetupNetwork contains options for setting up a container
+/// SetupNetwork contains options for setting up a container
 #[derive(Debug)]
 pub struct SetupNetwork {
-    // network object
+    /// network object
     pub net: types::Network,
-    // hash id for the network
+    /// hash id for the network
     pub network_hash_name: String,
-    // isolation determines whether the network can communicate with others outside of its interface
+    /// isolation determines whether the network can communicate with others outside of its interface
     pub isolation: bool,
 }
 
@@ -28,34 +28,34 @@ pub struct TearDownNetwork {
 
 #[derive(Debug)]
 pub struct PortForwardConfig<'a> {
-    // id of container
+    /// id of container
     pub container_id: String,
-    // port mappings
+    /// port mappings
     pub port_mappings: &'a Option<Vec<types::PortMapping>>,
-    // name of network
+    /// name of network
     pub network_name: String,
-    // hash id for the network
+    /// hash id for the network
     pub network_hash_name: String,
-    // ipv4 address of the container to bind to.
-    // If multiple v4 addresses are present, use the first one for this.
-    // At least one of container_ip_v6 and container_ip_v6 must be set. Both can
-    // be set at the same time as well.
+    /// ipv4 address of the container to bind to.
+    /// If multiple v4 addresses are present, use the first one for this.
+    /// At least one of container_ip_v6 and container_ip_v6 must be set. Both can
+    /// be set at the same time as well.
     pub container_ip_v4: Option<IpAddr>,
-    // subnet associated with the IPv4 address.
-    // Must be set if v4 address is set.
+    /// subnet associated with the IPv4 address.
+    /// Must be set if v4 address is set.
     pub subnet_v4: Option<ipnet::IpNet>,
-    // ipv6 address of the container.
-    // If multiple v6 addresses are present, use the first one for this.
-    // At least one of container_ip_v6 and container_ip_v6 must be set. Both can
-    // be set at the same time as well.
+    /// ipv6 address of the container.
+    /// If multiple v6 addresses are present, use the first one for this.
+    /// At least one of container_ip_v6 and container_ip_v6 must be set. Both can
+    /// be set at the same time as well.
     pub container_ip_v6: Option<IpAddr>,
-    // subnet associated with the ipv6 address.
-    // Must be set if the v6 address is set.
+    /// subnet associated with the ipv6 address.
+    /// Must be set if the v6 address is set.
     pub subnet_v6: Option<ipnet::IpNet>,
-    // port used by DNS that should create forwarding rules
-    // forwarding is not setup if this is 53.
+    /// port used by DNS that should create forwarding rules
+    /// forwarding is not setup if this is 53.
     pub dns_port: u16,
-    // dns servers IPs where forwarding rule to port 53 from dns_port are necessary
+    /// dns servers IPs where forwarding rule to port 53 from dns_port are necessary
     pub dns_server_ips: &'a Vec<IpAddr>,
 }
 

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -83,16 +83,13 @@ pub struct NetworkOptions {
     pub dns_servers: Option<Vec<IpAddr>>,
 }
 
-// PerNetworkOptions are options which should be set on a per network basis
+/// PerNetworkOptions are options which should be set on a per network basis
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PerNetworkOptions {
     /// Aliases contains a list of names which the dns server should resolve
     /// to this container. Should only be set when DNSEnabled is true on the Network.
     /// If aliases are set but there is no dns support for this network the
     /// network interface implementation should ignore this and NOT error.
-
-    // DNS is not yet implemented
-
     #[serde(rename = "aliases")]
     pub aliases: Option<Vec<String>>,
 
@@ -109,7 +106,7 @@ pub struct PerNetworkOptions {
     pub static_mac: Option<String>,
 }
 
-// PortMapping is one or more ports that will be mapped into the container.
+/// PortMapping is one or more ports that will be mapped into the container.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PortMapping {
     /// ContainerPort is the port number that will be exposed from the
@@ -146,18 +143,18 @@ pub struct PortMapping {
     pub range: u16,
 }
 
-// StatusBlock contains the network information about a container
-// connected to one Network.
+/// StatusBlock contains the network information about a container
+/// connected to one Network.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StatusBlock {
-    // Aardvark supports resolving queries with
-    // having fewer than ndots dots. So we dont
-    // need this as of now.
-    // DNS search domains for /etc/resolv.conf
+    /// Aardvark supports resolving queries with
+    /// having fewer than ndots dots. So we dont
+    /// need this as of now.
+    /// DNS search domains for /etc/resolv.conf
     #[serde(rename = "dns_search_domains")]
     pub dns_search_domains: Option<Vec<String>>,
 
-    // DNS nameservers /etc/resolv.conf will be populated by these
+    /// DNS nameservers /etc/resolv.conf will be populated by these
     #[serde(rename = "dns_server_ips")]
     pub dns_server_ips: Option<Vec<IpAddr>>,
 
@@ -208,7 +205,7 @@ pub struct Subnet {
     pub subnet: IpNet,
 }
 
-// LeaseRange contains the range where IP are leased.
+/// LeaseRange contains the range where IP are leased.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LeaseRange {
     /// EndIP last IP in the subnet which should be used to assign ips.


### PR DESCRIPTION
Rust doc comments need three slashes[1]. Using just `//` makes rust think they are a normal comment which should not be included in the API docs. This is important if you use function highlighting in my IDE for example.

[1] https://doc.rust-lang.org/reference/comments.html