### PR TITLE
fix iptables teardown

### DIFF
--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -110,9 +110,7 @@ impl firewall::FirewallDriver for IptablesDriver {
                 );
 
                 for c in &chains {
-                    // Because we only call teardown_network on complete teardown, we
-                    // just send true here
-                    c.remove_rules(true)?;
+                    c.remove_rules(tear.complete_teardown)?;
                 }
                 for c in chains {
                     match &c.td_policy {

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -404,8 +404,10 @@ impl<'a> Bridge<'a> {
             complete_teardown,
         };
 
-        // FIXME store error and continue
-        self.info.firewall.teardown_network(tn)?;
+        if complete_teardown {
+            // FIXME store error and continue
+            self.info.firewall.teardown_network(tn)?;
+        }
 
         let tpf = TeardownPortForward {
             config: spf,

--- a/test/testfiles/two-networks.json
+++ b/test/testfiles/two-networks.json
@@ -1,6 +1,15 @@
 {
     "container_id": "a417588994662895d8b41adf8d74a83ac0cc38eb56d85d8e1268aae1e19e07e1",
     "container_name": "heuristic_archimedes",
+    "port_mappings": [
+        {
+          "host_ip": "127.0.0.1",
+          "container_port": 8080,
+          "host_port": 8080,
+          "range": 1,
+          "protocol": "tcp"
+        }
+      ],
     "networks": {
         "t1": {
             "static_ips": [


### PR DESCRIPTION
Only on a complete teardown we should remove the network forwarding rules.

Fixes #491

