### PR TITLE
remove number of .clone() calls

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -158,8 +158,7 @@ impl Setup {
                 }
             };
 
-            let mut aardvark_interface =
-                Aardvark::new(path_string, rootless, aardvark_bin, dns_port);
+            let aardvark_interface = Aardvark::new(path_string, rootless, aardvark_bin, dns_port);
 
             if let Err(er) = aardvark_interface.commit_netavark_entries(aardvark_entries) {
                 return Err(std::io::Error::new(

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -55,10 +55,9 @@ impl Teardown {
             // stop dns server first before netavark clears the interface
             let path = Path::new(&config_dir).join("aardvark-dns");
             if let Ok(path_string) = path.into_os_string().into_string() {
-                let mut aardvark_interface =
+                let aardvark_interface =
                     Aardvark::new(path_string, rootless, aardvark_bin, dns_port);
-                if let Err(err) =
-                    aardvark_interface.delete_from_netavark_entries(network_options.clone())
+                if let Err(err) = aardvark_interface.delete_from_netavark_entries(&network_options)
                 {
                     error_list.push(err.into());
                 }

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -64,7 +64,7 @@ impl firewall::FirewallDriver for IptablesDriver {
                 let chains = get_network_chains(
                     conn,
                     network.subnet,
-                    network_setup.network_hash_name.clone(),
+                    &network_setup.network_hash_name,
                     is_ipv6,
                     interface.to_string(),
                     network_setup.isolation,
@@ -103,7 +103,7 @@ impl firewall::FirewallDriver for IptablesDriver {
                 let chains = get_network_chains(
                     conn,
                     network.subnet,
-                    tear.config.network_hash_name.clone(),
+                    &tear.config.network_hash_name,
                     is_ipv6,
                     interface.to_string(),
                     tear.config.isolation,

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -134,14 +134,14 @@ impl<'a> VarkChain<'a> {
 
     //  remove a vector of rules
     pub fn remove_rules(&self, complete_teardown: bool) -> NetavarkResult<()> {
-        for rule in &self.rules.clone() {
+        for rule in &self.rules {
             // If the rule policy is Never or this is not a
             // complete teardown of the network, then we skip removal
             // of the rule
-            match rule.clone().td_policy {
+            match &rule.td_policy {
                 None => {}
                 Some(policy) => {
-                    if policy == TeardownPolicy::Never || !complete_teardown {
+                    if *policy == TeardownPolicy::Never || !complete_teardown {
                         continue;
                     }
                 }
@@ -188,14 +188,14 @@ pub fn create_network_chains(chains: Vec<VarkChain<'_>>) -> NetavarkResult<()> {
     Ok(())
 }
 
-pub fn get_network_chains(
-    conn: &'_ IPTables,
+pub fn get_network_chains<'a>(
+    conn: &'a IPTables,
     network: IpNet,
-    network_hash_name: String,
+    network_hash_name: &'a str,
     is_ipv6: bool,
     interface_name: String,
     isolation: bool,
-) -> Vec<VarkChain<'_>> {
+) -> Vec<VarkChain<'a>> {
     let mut chains = Vec::new();
     let prefixed_network_hash_name = format!("{}-{}", "NETAVARK", network_hash_name);
 


### PR DESCRIPTION
In many places we really do not need to clone the values and can just use references with lifetimes.
I also removed the mut declaration in the aardvark interface which is not needed and thus just causes confusion.

There is a lot more I could do but these ones were very simple to fix and I don't want to spend more time on this right now.
