### PR TITLE
update: add support for `netavark update` command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod setup;
 pub mod teardown;
+pub mod update;
 pub mod version;

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -9,7 +9,6 @@ use crate::network::{core_utils, types};
 use clap::Parser;
 use log::{debug, error, info};
 use std::collections::HashMap;
-use std::env;
 use std::fs::{self};
 use std::path::Path;
 
@@ -51,18 +50,7 @@ impl Setup {
 
         let mut response: HashMap<String, types::StatusBlock> = HashMap::new();
 
-        let dns_port = match env::var("NETAVARK_DNS_PORT") {
-            Ok(port_string) => match port_string.parse() {
-                Ok(port) => port,
-                Err(e) => {
-                    return Err(NetavarkError::Message(format!(
-                        "Invalid NETAVARK_DNS_PORT {}: {}",
-                        port_string, e
-                    )))
-                }
-            },
-            Err(_) => 53,
-        };
+        let dns_port = core_utils::get_netavark_dns_port()?;
 
         let (mut hostns, mut netns) =
             core_utils::open_netlink_sockets(&self.network_namespace_path)?;

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -6,7 +6,6 @@ use crate::network::driver::{get_network_driver, DriverInfo};
 use crate::{firewall, network};
 use clap::Parser;
 use log::debug;
-use std::env;
 use std::path::Path;
 
 #[derive(Parser, Debug)]
@@ -36,20 +35,7 @@ impl Teardown {
 
         let mut error_list = NetavarkErrorList::new();
 
-        let dns_port = match env::var("NETAVARK_DNS_PORT") {
-            Ok(port_string) => match port_string.parse() {
-                Ok(port) => port,
-                Err(e) => {
-                    error_list.push(NetavarkError::Message(format!(
-                        "Invalid NETAVARK_DNS_PORT {}: {}",
-                        port_string, e
-                    )));
-                    // default to 53 if there is a error here, we should not prevent cleanup because of it
-                    53
-                }
-            },
-            Err(_) => 53,
-        };
+        let dns_port = core_utils::get_netavark_dns_port()?;
 
         if Path::new(&aardvark_bin).exists() {
             // stop dns server first before netavark clears the interface

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,0 +1,59 @@
+use crate::dns::aardvark::Aardvark;
+use crate::error::{NetavarkError, NetavarkResult};
+use crate::network::core_utils;
+
+use clap::Parser;
+use log::debug;
+use std::path::Path;
+
+#[derive(Parser, Debug)]
+pub struct Update {
+    /// Network name to update
+    #[clap(forbid_empty_values = true, required = true)]
+    network_name: String,
+    /// DNS Servers to update for the network
+    #[clap(long, required = true, forbid_empty_values = true)]
+    network_dns_servers: Vec<String>,
+}
+
+impl Update {
+    /// Updates network dns servers for an already configured network
+    pub fn new(network_name: String, network_dns_servers: Vec<String>) -> Self {
+        Self {
+            network_name,
+            network_dns_servers,
+        }
+    }
+
+    pub fn exec(
+        &self,
+        config_dir: String,
+        aardvark_bin: String,
+        rootless: bool,
+    ) -> NetavarkResult<()> {
+        let dns_port = core_utils::get_netavark_dns_port()?;
+
+        if Path::new(&aardvark_bin).exists() {
+            let path = Path::new(&config_dir).join("aardvark-dns");
+            if let Ok(path_string) = path.into_os_string().into_string() {
+                let aardvark_interface =
+                    Aardvark::new(path_string, rootless, aardvark_bin, dns_port);
+                if let Err(err) = aardvark_interface
+                    .modify_network_dns_servers(&self.network_name, &self.network_dns_servers)
+                {
+                    return Err(NetavarkError::wrap(
+                        "unable to modify network dns servers",
+                        NetavarkError::Io(err),
+                    ));
+                }
+            } else {
+                return Err(NetavarkError::msg(
+                    "Unable to parse aardvark config directory",
+                ));
+            }
+        }
+
+        debug!("Network update complete");
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 use netavark::commands::setup;
 use netavark::commands::teardown;
+use netavark::commands::update;
 use netavark::commands::version;
 
 #[derive(Parser, Debug)]
@@ -28,6 +29,8 @@ struct Opts {
 enum SubCommand {
     /// Configures the given network namespace with the given configuration.
     Setup(setup::Setup),
+    /// Updates network dns servers for an already configured network.
+    Update(update::Update),
     /// Undo any configuration applied via setup command.
     Teardown(teardown::Teardown),
     /// Display info about netavark.
@@ -47,6 +50,7 @@ fn main() {
     let result = match opts.subcmd {
         SubCommand::Setup(setup) => setup.exec(opts.file, config, aardvark_bin, rootless),
         SubCommand::Teardown(teardown) => teardown.exec(opts.file, config, aardvark_bin, rootless),
+        SubCommand::Update(update) => update.exec(config, aardvark_bin, rootless),
         SubCommand::Version(version) => version.exec(),
     };
 

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -9,6 +9,7 @@ use netlink_packet_route::{
 use nix::sched;
 use sha2::{Digest, Sha512};
 use std::collections::HashMap;
+use std::env;
 use std::fmt::Display;
 use std::fs::File;
 use std::io::{self, Error};
@@ -23,6 +24,19 @@ use super::netlink;
 
 pub struct CoreUtils {
     pub networkns: String,
+}
+
+pub fn get_netavark_dns_port() -> Result<u16, NetavarkError> {
+    match env::var("NETAVARK_DNS_PORT") {
+        Ok(port_string) => match port_string.parse() {
+            Ok(port) => Ok(port),
+            Err(e) => Err(NetavarkError::Message(format!(
+                "Invalid NETAVARK_DNS_PORT {}: {}",
+                port_string, e
+            ))),
+        },
+        Err(_) => Ok(53),
+    }
 }
 
 pub fn parse_option<T>(


### PR DESCRIPTION
Netavark update allows container managers to update network scoped DNS servers of any configured network and notify running `aarvark-dns` about it.

```console
netavark-update
Updates network dns servers for an already configured network

USAGE:
    netavark update --network-dns-servers <NETWORK_DNS_SERVERS> <NETWORK_NAME>

ARGS:
    <NETWORK_NAME>    Network name to update

OPTIONS:
    -h, --help                                         Print help information
    -n, --network-dns-servers <NETWORK_DNS_SERVERS>    DNS Servers to update for the network
```