### PR TITLE
Add nspath to commands

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -88,6 +88,7 @@ impl Setup {
                 container_dns_servers: &network_options.dns_servers,
                 netns_host: hostns.fd,
                 netns_container: netns.fd,
+                netns_path: &self.network_namespace_path,
                 network,
                 per_network_opts,
                 port_mappings: &network_options.port_mappings,

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -95,6 +95,7 @@ impl Teardown {
                 container_dns_servers: &network_options.dns_servers,
                 netns_host: hostns.fd,
                 netns_container: netns.fd,
+                netns_path: &self.network_namespace_path,
                 network,
                 per_network_opts,
                 port_mappings: &network_options.port_mappings,

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -22,6 +22,7 @@ pub struct DriverInfo<'a> {
     pub container_dns_servers: &'a Option<Vec<IpAddr>>,
     pub netns_host: RawFd,
     pub netns_container: RawFd,
+    pub netns_path: &'a str,
     pub network: &'a Network,
     pub per_network_opts: &'a PerNetworkOptions,
     pub port_mappings: &'a Option<Vec<PortMapping>>,


### PR DESCRIPTION
Add the ns_path to setup and teardown commands.  This is needed for DHCP macvlan.

Signed-off-by: Brent Baude <bbaude@redhat.com>