### PR TITLE
chrono: use from_timestamp_opt

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,10 @@ fn main() {
     // get timestamp
     let now = match env::var("SOURCE_DATE_EPOCH") {
         Ok(val) => {
-            let naive = NaiveDateTime::from_timestamp(val.parse::<i64>().unwrap(), 0);
+            let naive = match NaiveDateTime::from_timestamp_opt(val.parse::<i64>().unwrap(), 0) {
+                Some(n) => n,
+                None => Utc::now().naive_utc(),
+            };
             let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
             datetime
         }


### PR DESCRIPTION
chrono has deprecated from_timestamp in favor of from_timestamp_opt. this PR allows for new versions of chrono to be used.

Fixes #484

Signed-off-by: Brent Baude <bbaude@redhat.com>