### PR TITLE
remove verify_vendor CI task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -149,31 +149,6 @@ validate_aarch64_task:
   setup_script: *setup
   main_script: *main
 
-
-verify_vendor_task:
-  alias: "verify_vendor"
-  depends_on:
-    - "build"
-  gce_instance: *standard_gce_x86_64
-  cargo_cache: *ro_cargo_cache
-  targets_cache: *ro_targets_cache
-  bin_cache: *ro_bin_cache
-  setup_script: *setup
-  main_script: *main
-
-
-verify_vendor_aarch64_task:
-  alias: "verify_vendor_aarch64"
-  depends_on:
-    - "build_aarch64"
-  ec2_instance: *standard_build_ec2_aarch64
-  cargo_cache: *ro_cargo_cache_aarch64
-  targets_cache: *ro_targets_cache_aarch64
-  bin_cache: *ro_bin_cache_aarch64
-  setup_script: *setup
-  main_script: *main
-
-
 unit_task:
   alias: "unit"
   depends_on:
@@ -279,8 +254,6 @@ success_task:
     - "build_aarch64"
     - "validate"
     - "validate_aarch64"
-    - "verify_vendor"
-    - "verify_vendor_aarch64"
     - "unit"
     - "unit_aarch64"
     - "integration"

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -46,17 +46,6 @@ _run_validate_aarch64() {
     _run_validate
 }
 
-_run_verify_vendor() {
-    # N/B: current repo. dir. contents produced by _run_build() above.
-    if ! git diff --no-ext-diff --quiet --exit-code; then
-        die "Found uncommited and necessary changes to vendoring, please fix, commit, and re-submit."
-    fi
-}
-
-_run_verify_vendor_aarch64() {
-    _run_verify_vendor
-}
-
 _run_unit() {
     make unit
 }


### PR DESCRIPTION
We removed vendoring a long time ago, therefore we do not need this check. I just saw it fail on one of my PRs because of a CI problem.