### PR TITLE
release,make: add rule `make crate-publish` for publishing crates.io

### DIFF
--- a/docs/publish-crate.md
+++ b/docs/publish-crate.md
@@ -1,0 +1,7 @@
+# Publishing netavark crate to crates.io
+### Steps
+* Make sure you have already done `cargo login` on your current session with a valid token.
+* `cd netavark`
+* Git checkout the version which you want to publish.
+* `make crate-publish`
+* New version should be reflected here: https://crates.io/crates/netavark/versions


### PR DESCRIPTION
* Add new rule `make crate-publish` to automate publish at https://crates.io/crates/netavark
* Document steps for publishing to `crates.io`
