### PR TITLE
main: Pass config_dir as `&str`

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -30,7 +30,7 @@ impl Setup {
     pub fn exec(
         &self,
         input_file: Option<String>,
-        config_dir: String,
+        config_dir: &str,
         aardvark_bin: String,
         rootless: bool,
     ) -> NetavarkResult<()> {

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -26,7 +26,7 @@ impl Teardown {
     pub fn exec(
         &self,
         input_file: Option<String>,
-        config_dir: String,
+        config_dir: &str,
         aardvark_bin: String,
         rootless: bool,
     ) -> NetavarkResult<()> {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -27,7 +27,7 @@ impl Update {
 
     pub fn exec(
         &self,
-        config_dir: String,
+        config_dir: &str,
         aardvark_bin: String,
         rootless: bool,
     ) -> NetavarkResult<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
     let opts = Opts::parse();
 
     // aardvark config directory must be supplied by parent or it defaults to /tmp/aardvark
-    let config = opts.config.unwrap_or_else(|| String::from("/tmp"));
+    let config = opts.config.as_deref().unwrap_or("/tmp");
     let rootless = opts.rootless.unwrap_or(false);
     let aardvark_bin = opts
         .aardvark_binary


### PR DESCRIPTION
Generally ownership transfer by passing `String` parameters is unidiomatic.  By passing the config dir as a borrowed `&str` we avoid the need to heap allocate a copy of the string `/tmp`.

(No particular motivation, I just happened to be looking
 at this code)

Signed-off-by: Colin Walters <walters@verbum.org>