### PR TITLE
Cirrus: Add backup to aardvark-binary artifact DL

### DIFF
--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -18,20 +18,28 @@ trap "complete_setup" EXIT
 msg "************************************************************"
 msg "Setting up runtime environment"
 msg "************************************************************"
-
 show_env_vars
 
-req_env_vars AARDVARK_DNS_URL
-
-showrun curl --fail --location -o /tmp/aardvark-dns.zip "$AARDVARK_DNS_URL"
-mkdir -p /usr/libexec/podman
+req_env_vars AARDVARK_DNS_URL AARDVARK_DNS_BRANCH
 cd /usr/libexec/podman
-rm -f aardvark-dns*
-showrun unzip -o /tmp/aardvark-dns.zip
-if [[ $(uname -m) != "x86_64" ]]; then
-    showrun mv aardvark-dns.$(uname -m)-unknown-linux-gnu aardvark-dns
+rm -vf aardvark-dns*
+if showrun curl --fail --location -o /tmp/aardvark-dns.zip "$AARDVARK_DNS_URL" && \
+   unzip -o /tmp/aardvark-dns.zip; then
+
+    if [[ $(uname -m) != "x86_64" ]]; then
+        showrun mv aardvark-dns.$(uname -m)-unknown-linux-gnu aardvark-dns
+    fi
+    showrun chmod a+x /usr/libexec/podman/aardvark-dns
+else
+    warn "Error downloading/extracting the latest pre-compiled aardvark binary from CI"
+    showrun cargo install \
+      --root /usr/libexec/podman \
+      --git https://github.com/containers/aardvark-dns \
+      --branch "$AARDVARK_DNS_BRANCH"
+    mv -v /usr/libexec/podman/bin/aardvark-dns /usr/libexec/podman
 fi
-showrun chmod a+x /usr/libexec/podman/aardvark-dns
+# show aardvark commit in CI logs
+showrun /usr/libexec/podman/aardvark-dns version
 
 # Warning, this isn't the end.  An exit-handler is installed to finalize
 # setup of env. vars.  This is required for runner.sh to operate properly.


### PR DESCRIPTION
Fixes: https://github.com/containers/netavark/pull/518

See also: https://github.com/containers/aardvark-dns/pull/269

Around the time of this commit, a bug was discovered (the hard way) in Cirrus-CI:  If a `[skip-ci]` build merges, it will be marked successful but not publish any artifacts via the "latest" permalink. Since netavark and aardvark depend on each other's latest binaries, this can lead to a chicken-and-egg problem.

While the underlying Cirrus-CI bug has now been fixed, this is still a fragile situation for CI.  At the same time, it's beneficial to developers for CI runs to happen as quickly as possible.  Meaning, CI should try to avoid compiling when possible.

Resolve both issues by attempting to download from the permalink, but if that fails, fallback to compiling and building from the dependent repo using `cargo` (original implementation by @baude).  This is a more complex solution, but should save minutes of developer time for 99.99% of PRs.

Signed-off-by: Chris Evich <cevich@redhat.com>