### PR TITLE
add ipvlan support

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -9,6 +9,7 @@ pub const IPAM_DHCP: &str = "dhcp";
 pub const IPAM_NONE: &str = "none";
 
 pub const DRIVER_BRIDGE: &str = "bridge";
+pub const DRIVER_IPVLAN: &str = "ipvlan";
 pub const DRIVER_MACVLAN: &str = "macvlan";
 
 pub const OPTION_ISOLATE: &str = "isolate";

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -22,6 +22,10 @@ use sysctl::{Sysctl, SysctlError};
 
 use super::netlink;
 
+pub const IPVLAN_MODE_L2: u16 = 0;
+pub const IPVLAN_MODE_L3: u16 = 1;
+pub const IPVLAN_MODE_L3S: u16 = 2;
+
 pub struct CoreUtils {
     pub networkns: String,
 }
@@ -228,6 +232,19 @@ impl CoreUtils {
             // default to bridge
             name => Err(NetavarkError::msg(format!(
                 "invalid macvlan mode \"{}\"",
+                name
+            ))),
+        }
+    }
+
+    pub fn get_ipvlan_mode_from_string(mode: &str) -> NetavarkResult<u16> {
+        match mode {
+            // default to l2 when unset
+            "" | "l2" => Ok(IPVLAN_MODE_L2),
+            "l3" => Ok(IPVLAN_MODE_L3),
+            "l3s" => Ok(IPVLAN_MODE_L3S),
+            name => Err(NetavarkError::msg(format!(
+                "invalid ipvlan mode \"{}\"",
                 name
             ))),
         }

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -8,10 +8,9 @@ use std::net::IpAddr;
 
 use super::{
     bridge::Bridge,
-    constants,
-    macvlan::MacVlan,
-    netlink,
+    constants, netlink,
     types::{Network, PerNetworkOptions, PortMapping, StatusBlock},
+    vlan::Vlan,
 };
 use std::os::unix::io::RawFd;
 
@@ -50,7 +49,7 @@ pub trait NetworkDriver {
 pub fn get_network_driver(info: DriverInfo) -> NetavarkResult<Box<dyn NetworkDriver + '_>> {
     match info.network.driver.as_str() {
         constants::DRIVER_BRIDGE => Ok(Box::new(Bridge::new(info))),
-        constants::DRIVER_MACVLAN => Ok(Box::new(MacVlan::new(info))),
+        constants::DRIVER_IPVLAN | constants::DRIVER_MACVLAN => Ok(Box::new(Vlan::new(info))),
 
         _ => Err(NetavarkError::Message(format!(
             "unknown network driver {}",

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -14,9 +14,9 @@ pub mod constants;
 pub mod core_utils;
 pub mod driver;
 pub mod internal_types;
-pub mod macvlan;
 mod macvlan_dhcp;
 pub mod netlink;
+pub mod vlan;
 
 impl types::NetworkOptions {
     pub fn load(path: Option<String>) -> NetavarkResult<types::NetworkOptions> {

--- a/test/400-ipvlan.bats
+++ b/test/400-ipvlan.bats
@@ -1,0 +1,282 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# macvlan driver test
+#
+
+load helpers
+
+function setup() {
+    basic_setup
+
+    # create a extra interface which we can use to connect the ipvlan to
+    run_in_host_netns ip link add dummy0 type dummy
+}
+
+@test "simple ipvlan setup" {
+    run_netavark --file ${TESTSDIR}/testfiles/ipvlan.json setup $(get_container_netns_path)
+    result="$output"
+
+    mac=$(jq -r '.podman.interfaces.eth0.mac_address' <<< "$result" )
+    # check that interface exists
+    run_in_container_netns ip -j --details link show eth0
+    link_info="$output"
+    assert_json "$link_info" ".[].address" "=="  "$mac" "MAC matches container mac"
+    assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
+    assert_json "$link_info" ".[].linkinfo.info_kind" "==" "ipvlan" "Container interface is a ipvlan device"
+
+    ipaddr="10.88.0.2/16"
+    run_in_container_netns ip addr show eth0
+    assert "$output" "=~" "$ipaddr" "IP address matches container address"
+    assert_json "$result" ".podman.interfaces.eth0.subnets[0].ipnet" "==" "$ipaddr" "Result contains correct IP address"
+
+    # check gateway assignment
+    run_in_container_netns ip r
+    assert "$output" "=~" "default via 10.88.0.1" "gateway must be there in default route"
+    assert_json "$result" ".podman.interfaces.eth0.subnets[0].gateway" == "10.88.0.1" "Result contains gateway address"
+
+    run_in_container_netns cat /proc/sys/net/ipv6/conf/eth0/autoconf
+    assert "0" "autoconf is disabled"
+
+    run_netavark --file ${TESTSDIR}/testfiles/ipvlan.json teardown $(get_container_netns_path)
+    assert "" "no errors"
+}
+
+@test "ipvlan setup internal" {
+    run_netavark --file ${TESTSDIR}/testfiles/ipvlan-internal.json setup $(get_container_netns_path)
+    result="$output"
+
+    mac=$(jq -r '.podman.interfaces.eth0.mac_address' <<< "$result" )
+    # check that interface exists
+    run_in_container_netns ip -j --details link show eth0
+    link_info="$output"
+    assert_json "$link_info" ".[].address" "=="  "$mac" "MAC matches container mac"
+    assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
+    assert_json "$link_info" ".[].linkinfo.info_kind" "==" "ipvlan" "Container interface is a ipvlan device"
+
+    ipaddr="10.88.0.2/16"
+    run_in_container_netns ip addr show eth0
+    assert "$output" "=~" "$ipaddr" "IP address matches container address"
+    assert_json "$result" ".podman.interfaces.eth0.subnets[0].ipnet" "==" "$ipaddr" "Result contains correct IP address"
+
+    # internal ipvlan must not contain
+    run_in_container_netns ip r
+    assert "$output" !~ 'default' "ipvlan must not contain default gateway in route at all"
+}
+
+@test "ipvlan setup with mtu" {
+    run_netavark --file ${TESTSDIR}/testfiles/ipvlan-mtu.json setup $(get_container_netns_path)
+    result="$output"
+
+    mac=$(jq -r '.podman.interfaces.eth0.mac_address' <<< "$result" )
+    # check that interface exists
+    run_in_container_netns ip -j --details link show eth0
+    link_info="$output"
+    assert_json "$link_info" ".[].mtu" "=="  "1400" "MTU matches configured MTU"
+    assert_json "$link_info" ".[].address" "=="  "$mac" "MAC matches container mac"
+    assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
+    assert_json "$link_info" ".[].linkinfo.info_kind" "==" "ipvlan" "Container interface is a ipvlan device"
+
+    ipaddr="10.88.0.2"
+    run_in_container_netns ip -j addr show eth0
+    link_info="$output"
+    assert_json "$link_info" ".[].addr_info[0].local" "==" "$ipaddr" "IP address matches container address"
+    assert_json "$link_info" ".[].addr_info[0].prefixlen" "==" "16" "IP prefix matches container subnet"
+    assert_json "$result" ".podman.interfaces.eth0.subnets[0].ipnet" "==" "$ipaddr/16" "Result contains correct IP address"
+}
+
+@test "ipvlan modes" {
+    for mode in l2 l3 l3s; do
+        # echo here so we know which test failed
+        echo "mode $mode"
+
+        read -r -d '\0' config <<EOF
+{
+   "container_id": "someID",
+   "container_name": "someName",
+   "networks": {
+      "podman": {
+         "static_ips": [
+            "10.88.0.2"
+         ],
+         "interface_name": "eth0"
+      }
+   },
+   "network_info": {
+      "podman": {
+         "name": "podman",
+         "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+         "driver": "ipvlan",
+         "network_interface": "dummy0",
+         "subnets": [
+            {
+               "subnet": "10.88.0.0/16",
+               "gateway": "10.88.0.1"
+            }
+         ],
+         "ipv6_enabled": false,
+         "internal": false,
+         "dns_enabled": false,
+         "ipam_options": {
+            "driver": "host-local"
+         },
+         "options": {
+            "mode": "$mode"
+         }
+      }
+   }
+}\0
+EOF
+
+    run_netavark setup $(get_container_netns_path) <<<"$config"
+    run_in_container_netns ip -j --details link show eth0
+    link_info="$output"
+    assert_json "$link_info" ".[].mtu" "=="  "1500" "MTU matches expected MTU"
+    assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
+    assert_json "$link_info" ".[].linkinfo.info_kind" "==" "ipvlan" "Container interface is a ipvlan device"
+    assert_json "$link_info" ".[].linkinfo.info_data.mode" "==" "$mode" "Container interface has correct ipvlan mode"
+
+    run_netavark teardown $(get_container_netns_path) <<<"$config"
+    done
+}
+
+@test "ipvlan ipam none" {
+           read -r -d '\0' config <<EOF
+{
+   "container_id": "someID",
+   "container_name": "someName",
+   "networks": {
+      "podman": {
+         "interface_name": "eth0"
+      }
+   },
+   "network_info": {
+      "podman": {
+         "name": "podman",
+         "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+         "driver": "ipvlan",
+         "network_interface": "dummy0",
+         "subnets": [],
+         "ipv6_enabled": false,
+         "internal": false,
+         "dns_enabled": false,
+         "ipam_options": {
+            "driver": "none"
+         }
+      }
+   }
+}\0
+EOF
+
+    run_netavark setup $(get_container_netns_path) <<<"$config"
+    result="$output"
+
+    mac=$(jq -r '.podman.interfaces.eth0.mac_address' <<< "$result" )
+    # check that interface exists
+    run_in_container_netns ip -j link show eth0
+    link_info="$output"
+    assert_json "$link_info" ".[].address" "=="  "$mac" "MAC matches container mac"
+    assert_json "$link_info" '.[].flags[] | select(.=="UP")' "=="  "UP" "Container interface is up"
+
+    run_in_container_netns ip -j --details addr show eth0
+    assert_json "$link_info" ".[].addr_info" "==" "null" "No ip addresses configured"
+
+    # check gateway assignment
+    run_in_container_netns ip r
+    assert "$output" "==" "" "No routes configured"
+}
+
+
+@test "ipvlan same interface name on host" {
+
+           read -r -d '\0' config <<EOF
+{
+   "container_id": "someID",
+   "container_name": "someName",
+   "networks": {
+      "podman": {
+         "static_ips": [
+            "10.88.0.2"
+         ],
+         "interface_name": "eth0"
+      }
+   },
+   "network_info": {
+      "podman": {
+         "name": "podman",
+         "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+         "driver": "ipvlan",
+         "network_interface": "eth0",
+         "subnets": [
+            {
+               "subnet": "10.88.0.0/16",
+               "gateway": "10.88.0.1"
+            }
+         ],
+         "ipv6_enabled": false,
+         "internal": false,
+         "dns_enabled": false,
+         "ipam_options": {
+            "driver": "host-local"
+         }
+      }
+   }
+}\0
+EOF
+
+   run_in_host_netns ip link add eth0 type dummy
+
+   run_netavark setup $(get_container_netns_path) <<<"$config"
+
+   run_in_container_netns ip link show eth0
+
+   run_netavark teardown $(get_container_netns_path) <<<"$config"
+}
+
+@test "ipvlan same interface name on container" {
+
+   read -r -d '\0' config <<EOF
+{
+   "container_id": "someID",
+   "container_name": "someName",
+   "networks": {
+      "podman": {
+         "static_ips": [
+            "10.88.0.2"
+         ],
+         "interface_name": "eth0"
+      }
+   },
+   "network_info": {
+      "podman": {
+         "name": "podman",
+         "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+         "driver": "ipvlan",
+         "network_interface": "dummy0",
+         "subnets": [
+            {
+               "subnet": "10.88.0.0/16",
+               "gateway": "10.88.0.1"
+            }
+         ],
+         "ipv6_enabled": false,
+         "internal": false,
+         "dns_enabled": false,
+         "ipam_options": {
+            "driver": "host-local"
+         }
+      }
+   }
+}\0
+EOF
+
+   run_in_container_netns ip link add eth0 type dummy
+
+   expected_rc=1 run_netavark setup $(get_container_netns_path) <<<"$config"
+
+   # make sure the tmp interface is not leaked on the host or netns
+   run_in_host_netns ip -o link show
+   assert "${#lines[@]}" == 2 "only two interfaces (lo, dummy0) on the host, the tmp ipvlan interface should be gone"
+
+   run_in_container_netns ip -o link show
+   assert "${#lines[@]}" == 2 "only two interfaces (lo, eth0) in the netns, the tmp ipvlan interface should be gone"
+}

--- a/test/testfiles/ipvlan-internal.json
+++ b/test/testfiles/ipvlan-internal.json
@@ -1,0 +1,32 @@
+{
+    "container_id": "someID",
+    "container_name": "someName",
+    "networks": {
+       "podman": {
+          "static_ips": [
+             "10.88.0.2"
+          ],
+          "interface_name": "eth0"
+       }
+    },
+    "network_info": {
+       "podman": {
+          "name": "podman",
+          "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+          "driver": "ipvlan",
+          "network_interface": "dummy0",
+          "subnets": [
+             {
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
+             }
+          ],
+          "ipv6_enabled": false,
+          "internal": true,
+          "dns_enabled": false,
+          "ipam_options": {
+             "driver": "host-local"
+          }
+       }
+    }
+ }

--- a/test/testfiles/ipvlan-mtu.json
+++ b/test/testfiles/ipvlan-mtu.json
@@ -1,0 +1,35 @@
+{
+    "container_id": "someID",
+    "container_name": "someName",
+    "networks": {
+       "podman": {
+          "static_ips": [
+             "10.88.0.2"
+          ],
+          "interface_name": "eth0"
+       }
+    },
+    "network_info": {
+       "podman": {
+          "name": "podman",
+          "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+          "driver": "ipvlan",
+          "network_interface": "dummy0",
+          "subnets": [
+             {
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
+             }
+          ],
+          "ipv6_enabled": false,
+          "internal": false,
+          "dns_enabled": false,
+          "ipam_options": {
+             "driver": "host-local"
+          },
+          "options": {
+             "mtu":   "1400"
+          }
+       }
+    }
+ }

--- a/test/testfiles/ipvlan.json
+++ b/test/testfiles/ipvlan.json
@@ -1,0 +1,32 @@
+{
+    "container_id": "someID",
+    "container_name": "someName",
+    "networks": {
+       "podman": {
+          "static_ips": [
+             "10.88.0.2"
+          ],
+          "interface_name": "eth0"
+       }
+    },
+    "network_info": {
+       "podman": {
+          "name": "podman",
+          "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+          "driver": "ipvlan",
+          "network_interface": "dummy0",
+          "subnets": [
+             {
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
+             }
+          ],
+          "ipv6_enabled": false,
+          "internal": false,
+          "dns_enabled": true,
+          "ipam_options": {
+             "driver": "host-local"
+          }
+       }
+    }
+ }


### PR DESCRIPTION
Status:
- it compiles and there are integration tests which pass
- I tested this with podman and was able to ping the container from another physical device on the network.
- This is a ton of copy&paste because macvlan and ipvlan are so similar, we might want to reduce that. Let's discuss this.
  - `get_default_route_interface` should be easy to move to e.g. core_utils
  - `setup` could be moved bei either using generics or by passing `CreateLinkOptions` as an argument
  - the integration tests could completely move to generated testfiles to we can use a variable for the driver name