### PR TITLE
fix make docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ integration: $(CARGO_TARGET_DIR)
 validate: $(CARGO_TARGET_DIR)
 	cargo fmt --all -- --check
 	cargo clippy -p netavark -- -D warnings
+	$(MAKE) docs
 
 .PHONY: vendor-tarball
 vendor-tarball: build install.cargo-vendor-filterer

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -39,6 +39,7 @@ _run_build_aarch64() {
 }
 
 _run_validate() {
+    make -C docs .install.mandown
     make validate
 }
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@ DATADIR ?= ${PREFIX}/share
 MANDIR ?= $(DATADIR)/man
 MANDOWN ?= $(shell export PATH; command -v mandown)
 
-docs: $(patsubst %.md,%,$(wildcard *.md))
+docs: $(patsubst %.md,%,$(wildcard *.1.md))
 
 %.1: %.1.md
 	$(MANDOWN) $< > $@

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,12 +1,16 @@
 PREFIX ?= /usr/local
 DATADIR ?= ${PREFIX}/share
 MANDIR ?= $(DATADIR)/man
-MANDOWN ?= $(shell export PATH; command -v mandown)
+MANDOWN ?= mandown
 
 docs: $(patsubst %.md,%,$(wildcard *.1.md))
 
 %.1: %.1.md
 	$(MANDOWN) $< > $@
+
+.PHONY: .install.mandown
+.install.mandown:
+	cargo install mandown
 
 .PHONY: install
 install:


### PR DESCRIPTION
Regression caused by 011f899919c9. We only want to build actual man pages of course and not general docs.
This commit fixes the wildcard target to only use the `.1.md` files instead of all markdown files.
Also add the step to the validate target to make sure CI tests this target.

Fixes #524