### PR TITLE
Fix UDS path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,10 +1249,11 @@ dependencies = [
 [[package]]
 name = "netavark_proxy"
 version = "0.1.0"
-source = "git+https://github.com/containers/netavark-dhcp-proxy#e38a730bb0c9d2c075348b29abfc4e02644def55"
+source = "git+https://github.com/containers/netavark-dhcp-proxy#d628692795efa57a1ddc4d55c64399e7b1afae35"
 dependencies = [
  "clap",
  "env_logger 0.10.0",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -1263,6 +1264,7 @@ dependencies = [
  "netavark 1.4.0",
  "nispor",
  "prost",
+ "rand",
  "rtnetlink",
  "serde",
  "serde_json",

--- a/src/network/macvlan_dhcp.rs
+++ b/src/network/macvlan_dhcp.rs
@@ -1,7 +1,7 @@
 use crate::error::{NetavarkError, NetavarkResult};
 use crate::network::types::NetAddress;
 use ipnet::IpNet;
-use netavark_proxy::DEFAULT_UDS_PATH;
+use netavark_proxy::proxy_conf::DEFAULT_UDS_PATH;
 use std::net::IpAddr;
 use std::str::FromStr;
 


### PR DESCRIPTION
The const for default the netavark dhcp proxy UDS path was changed to a different module in its project. This is required to continue to build against newer versions of the proxy.

Signed-off-by: Brent Baude <bbaude@redhat.com>