### PR TITLE
Convert a few words to more inclusive ones

### DIFF
--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -531,7 +531,7 @@ fn create_veth_pair(
     host: &mut netlink::Socket,
     netns: &mut netlink::Socket,
     data: &InternalData,
-    master_index: u32,
+    primary_index: u32,
     internal: bool,
     hostns_fd: RawFd,
     netns_fd: RawFd,
@@ -547,7 +547,7 @@ fn create_veth_pair(
 
     let mut host_veth = netlink::CreateLinkOptions::new(String::from(""), InfoKind::Veth);
     host_veth.mtu = data.mtu;
-    host_veth.master_index = master_index;
+    host_veth.primary_index = primary_index;
     host_veth.info_data = Some(InfoData::Veth(VethInfo::Peer(peer)));
 
     host.create_link(host_veth).map_err(|err| match err {

--- a/src/network/netlink.rs
+++ b/src/network/netlink.rs
@@ -30,7 +30,7 @@ pub struct CreateLinkOptions {
     kind: InfoKind,
     pub info_data: Option<InfoData>,
     pub mtu: u32,
-    pub master_index: u32,
+    pub primary_index: u32,
     pub link: u32,
     pub mac: Vec<u8>,
     pub netns: RawFd,
@@ -459,7 +459,7 @@ impl CreateLinkOptions {
             kind,
             info_data: None,
             mtu: 0,
-            master_index: 0,
+            primary_index: 0,
             link: 0,
             mac: vec![],
             // 0 is a valid fd, so use -1 by default
@@ -491,9 +491,9 @@ pub fn parse_create_link_options(msg: &mut LinkMessage, options: CreateLinkOptio
         msg.nlas.push(Nla::Address(options.mac));
     }
 
-    // add master device
-    if options.master_index != 0 {
-        msg.nlas.push(Nla::Master(options.master_index));
+    // add primary device
+    if options.primary_index != 0 {
+        msg.nlas.push(Nla::Master(options.primary_index));
     }
 
     // add link device

--- a/src/network/vlan.rs
+++ b/src/network/vlan.rs
@@ -239,12 +239,12 @@ fn setup(
     netns_fd: RawFd,
     kind_data: &KindData,
 ) -> NetavarkResult<String> {
-    let master_ifname = match data.host_interface_name.as_ref() {
+    let primary_ifname = match data.host_interface_name.as_ref() {
         "" => get_default_route_interface(host)?,
         host_name => host_name.to_string(),
     };
 
-    let link = host.get_link(netlink::LinkID::Name(master_ifname))?;
+    let link = host.get_link(netlink::LinkID::Name(primary_ifname))?;
 
     let opts = match kind_data {
         KindData::IpVlan { mode } => {


### PR DESCRIPTION
To make the code base more inclusive, I've changed a few variable names from "master*" to "primary*".

[NO NEW TESTS NEEDED]

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>