### PR TITLE
Switch to explicit platform list for `cargo vendor-filterer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ categories = ["containers", "networking", "podman"]
 exclude = ["/.cirrus.yml", "/.github/*", "/hack/*"]
 build = "build.rs"
 
+[package.metadata.vendor-filter]
+# This list is not exhaustive.
+platforms = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "powerpc64le-unknown-linux-gnu", 
+             "s390x-unknown-linux-gnu", "riscv64gc-unknown-linux-gnu",
+             "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl",
+             ]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["serde", "deps-serde"]

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ validate: $(CARGO_TARGET_DIR)
 .PHONY: vendor-tarball
 vendor-tarball: build install.cargo-vendor-filterer
 	VERSION=$(shell bin/netavark --version | cut -f2 -d" ") && \
-	cargo vendor-filterer '--platform=*-unknown-linux-*' --format=tar.gz --prefix vendor/ && \
+	cargo vendor-filterer --format=tar.gz --prefix vendor/ && \
 	mv vendor.tar.gz netavark-v$$VERSION-vendor.tar.gz && \
 	gzip -c bin/netavark > netavark.gz && \
 	sha256sum netavark.gz netavark-v$$VERSION-vendor.tar.gz > sha256sum


### PR DESCRIPTION
See https://github.com/coreos/cargo-vendor-filterer/issues/50 This fixes an error trying to vendor for m68k.

Also while we have the patient open, move the platform list to `Cargo.toml` in declarative format.