### PR TITLE
Cirrus: Reduce requested CPUs for compile-tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -231,7 +231,7 @@ ubuntu20_build_task:
       - "build"
     gce_instance: *standard_gce_x86_64
     container:
-        cpu: 8
+        cpu: 2 # Do not increase, will result in scheduling delays
         memory: "8Gb"
         image: quay.io/libpod/ubuntu20rust
     script:
@@ -244,7 +244,7 @@ centos9_build_task:
       - "build"
     gce_instance: *standard_gce_x86_64
     container:
-        cpu: 8
+        cpu: 2 # Do not increase, will result in scheduling delays
         memory: "8Gb"
         image: quay.io/libpod/centos9rust
     script:


### PR DESCRIPTION
Cirrus-CI sandboxes container-based tasks that request 4 or more CPUs within the community-cluster.  Depending on cluster load, this can result in heavy-CPU bound tasks being queued for an extended period of time - or even timing out all together.

Since the `ubuntu_20` and `centos9` tasks are only checking buildability, reduce their requested CPUs so they can finish more reliably in relation to all the other VM-based tasks.  This matches settings already in place for similar tasks in the aardvark-dns repo.

Signed-off-by: Chris Evich <cevich@redhat.com>