### PR TITLE
Support none parameter on NETAVARK_FW

### DIFF
--- a/src/firewall/fwnone.rs
+++ b/src/firewall/fwnone.rs
@@ -1,0 +1,32 @@
+use crate::firewall;
+use crate::firewall::NetavarkResult;
+use crate::network::internal_types::{
+    PortForwardConfig, SetupNetwork, TearDownNetwork, TeardownPortForward,
+};
+
+// Iptables driver - uses direct iptables commands via the iptables crate.
+pub struct Fwnone {}
+
+pub fn new() -> NetavarkResult<Box<dyn firewall::FirewallDriver>> {
+    Ok(Box::new(Fwnone {}))
+}
+
+impl firewall::FirewallDriver for Fwnone {
+    fn setup_network(&self, _network_setup: SetupNetwork) -> NetavarkResult<()> {
+        Ok(())
+    }
+
+    // teardown_network should only be called in the case of
+    // a complete teardown.
+    fn teardown_network(&self, _tear: TearDownNetwork) -> NetavarkResult<()> {
+        Ok(())
+    }
+
+    fn setup_port_forward(&self, _setup_portfw: PortForwardConfig) -> NetavarkResult<()> {
+        Ok(())
+    }
+
+    fn teardown_port_forward(&self, _tear: TeardownPortForward) -> NetavarkResult<()> {
+        Ok(())
+    }
+}

--- a/test/500-bridge-fwnone.bats
+++ b/test/500-bridge-fwnone.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# bridge driver tests with none firewall driver
+#
+
+load helpers
+
+fw_driver=none
+
+@test "check none firewall driver is in use" {
+    RUST_LOG=netavark=info NETAVARK_FW="none" run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json setup $(get_container_netns_path)
+    assert "${lines[0]}" "==" "[INFO  netavark::firewall] Not using firewall" "none firewall driver is in use"
+}


### PR DESCRIPTION
Passing environment valuepair NETAVARK_FW=none disables all firewall/portmapper related features leaving configuration of firewall to user.