### PR TITLE
fix default route metric test name

### DIFF
--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -758,7 +758,7 @@ EOF
     assert_json "$default_route_v6" '.[0].metric' == "200" "v6 route metric matches v4"
 }
 
-@test "$fw_drive - default route metric" {
+@test "$fw_driver - default route metric" {
     run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json setup $(get_container_netns_path)
 
     run_in_container_netns ip -j route list match 0.0.0.0


### PR DESCRIPTION
The variable is called fw_driver, the typo resulted in the driver name missing. Not a issue but it looks odd in the test logs.