### PR TITLE
spec.rpkg: list netavark-dhcp-proxy in files list

### DIFF
--- a/netavark.spec.rpkg
+++ b/netavark.spec.rpkg
@@ -61,7 +61,7 @@ popd
 %files
 %license LICENSE
 %dir %{_libexecdir}/podman
-%{_libexecdir}/podman/%{name}
+%{_libexecdir}/podman/%{name}*
 %{_mandir}/man1/%{name}.1*
 
 %changelog


### PR DESCRIPTION
/usr/libexec/podman/netavark-dhcp-proxy is now installed so the spec file should mention it in the files list.