### PR TITLE
packit: Update build release tag correctly

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -18,7 +18,7 @@ git archive --prefix=netavark-$HEAD_VERSION/ -o netavark-$HEAD_VERSION.tar.gz HE
 sed -i "s/^Version:.*/Version: $HEAD_VERSION/" netavark.spec
 
 # Update Release in spec with Packit's release envvar
-sed -i "s/^Release: %autorelease/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" netavark.spec
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" netavark.spec
 
 # Update Source tarball name in spec
 sed -i "s/^Source:.*.tar.gz/Source: %{name}-$HEAD_VERSION.tar.gz/" netavark.spec


### PR DESCRIPTION
.packit.sh was searching for the wrong release string and as a result not replacing anything, resulting in all packit builds ending up with release tag `1`.

Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/package/netavark/

This commit will correctly update the release tag.