### PR TITLE
update to mozim 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,19 +511,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -1142,15 +1129,14 @@ dependencies = [
 
 [[package]]
 name = "mozim"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55347cda9f63c59f65bb21d7bc2abd98a3beb159b92738907da2f75e1edd7bc"
+checksum = "fae7c98c95699590f1921d4ee780d8ae0143add56ad90fe37f0b54800251ab99"
 dependencies = [
  "byteorder",
- "clap",
  "dhcproto",
- "env_logger 0.9.3",
  "etherparse",
+ "futures",
  "libc",
  "log",
  "nispor",
@@ -1191,7 +1177,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "env_logger 0.10.0",
+ "env_logger",
  "fs2",
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ netlink-sys = "0.8.4"
 tokio = { version = "1.26", features = ["rt", "rt-multi-thread", "signal", "fs"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.8"
-mozim = "0.1"
+mozim = "0.2"
 prost = "0.11"
 futures-channel="0.3"
 futures-core = "0.3"

--- a/src/dhcp_proxy/dhcp_service.rs
+++ b/src/dhcp_proxy/dhcp_service.rs
@@ -45,7 +45,7 @@ pub enum DhcpClient {
 pub struct DhcpService {
     client: Option<DhcpClient>,
     network_config: NetworkConfig,
-    timeout: isize,
+    timeout: u32,
 }
 
 trait IP4Conv {
@@ -75,7 +75,7 @@ impl IP6Conv for IpAddr {
 }
 
 impl DhcpService {
-    pub fn new(nc: &NetworkConfig, timeout: isize) -> Result<DhcpService, DhcpServiceError> {
+    pub fn new(nc: &NetworkConfig, timeout: u32) -> Result<DhcpService, DhcpServiceError> {
         let client = Self::create_client(nc)?;
         Ok(DhcpService {
             client: Some(client),
@@ -183,10 +183,7 @@ impl DhcpService {
         match version {
             //V4
             0 => {
-                let config = match DhcpV4Config::new_proxy(iface, &nc.container_mac_addr) {
-                    Ok(c) => c,
-                    Err(e) => return Err(DhcpServiceError::new(InvalidArgument, e.to_string())),
-                };
+                let config = DhcpV4Config::new_proxy(iface, &nc.container_mac_addr);
                 match DhcpV4Client::init(config, None) {
                     Ok(client) => Ok(DhcpClient::V4Client(Box::new(client))),
                     Err(err) => Err(DhcpServiceError::new(InvalidArgument, err.to_string())),

--- a/src/dhcp_proxy/proxy_conf.rs
+++ b/src/dhcp_proxy/proxy_conf.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_CONFIG_DIR: &str = "";
 // Default Network configuration path
 pub const DEFAULT_NETWORK_CONFIG: &str = "/dev/stdin";
 // Default epoll wait time before dhcp socket times out
-pub const DEFAULT_TIMEOUT: isize = 8;
+pub const DEFAULT_TIMEOUT: u32 = 8;
 // Proxy server gRPC socket file name
 pub const PROXY_SOCK_NAME: &str = "nv-proxy.sock";
 // Where leases are stored on the filesystem

--- a/src/dhcp_proxy_server/server.rs
+++ b/src/dhcp_proxy_server/server.rs
@@ -50,7 +50,7 @@ struct NetavarkProxyService<W: Write + Clear> {
     // cache is the lease hashmap
     cache: Arc<Mutex<LeaseCache<W>>>,
     // the timeout for the dora operation
-    dora_timeout: isize,
+    dora_timeout: u32,
     // channel send-side for resetting the inactivity timeout
     timeout_sender: Arc<Mutex<Sender<i32>>>,
 }
@@ -186,7 +186,7 @@ struct Opts {
     uds: Option<String>,
     /// optional time in seconds to time out after looking for a lease
     #[clap(short, long)]
-    timeout: Option<isize>,
+    timeout: Option<u32>,
     /// activity timeout
     #[clap(short, long)]
     activity_timout: Option<u64>,


### PR DESCRIPTION
A fixes for the breaking changes:
- timeout is u32
- DhcpV4Config::new_proxy() no longer return an Result type

This also fixes the build issue on i686.
Fixes #578