### PR TITLE
update: should allow empty `network_dns_servers`

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -12,7 +12,7 @@ pub struct Update {
     #[clap(forbid_empty_values = true, required = true)]
     network_name: String,
     /// DNS Servers to update for the network
-    #[clap(long, required = true, forbid_empty_values = true)]
+    #[clap(long, required = true, forbid_empty_values = false)]
     network_dns_servers: Vec<String>,
 }
 

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -150,6 +150,18 @@ fw_driver=iptables
     assert "${lines[0]}" =~ "10.89.3.1,fd10:88:a::1 8.8.8.8" "aardvark set to listen to all IPs"
     assert "${lines[1]}" =~ "^[0-9a-f]{64} 10.89.3.2 fd10:88:a::2 somename 8.8.8.8,1.1.1.1$" "aardvark config's container"
     assert "${#lines[@]}" = 2 "too many lines in aardvark config"
+
+    # remove network and check running and verify if aardvark config has no nameserver
+    NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge-network-container-dns-server.json \
+        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
+        update podman1 --network-dns-servers ""
+
+    # check aardvark config and running
+    run_helper cat "$NETAVARK_TMPDIR/config/aardvark-dns/podman1"
+    assert "${lines[0]}" =~ "10.89.3.1,fd10:88:a::1" "aardvark set to listen to all IPs"
+    assert "${lines[1]}" =~ "^[0-9a-f]{64} 10.89.3.2 fd10:88:a::2 somename 8.8.8.8,1.1.1.1$" "aardvark config's container"
+    assert "${#lines[@]}" = 2 "too many lines in aardvark config"
+
 }
 
 @test "$fw_driver - ipv6 bridge" {


### PR DESCRIPTION
`podman network update test --dns-drop 8.8.8.8` converges to a case when there are no nameservers for a network and netavark handles it correctly here: https://github.com/containers/netavark/blob/main/src/dns/aardvark.rs#L366

So allow users to update exisiting network with empty list of `network_dns_servers`