### PR TITLE
Include Systemd Unit Files in RPM Package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ DESTDIR ?=
 PREFIX ?= /usr/local
 LIBEXECDIR ?= ${PREFIX}/libexec
 LIBEXECPODMAN ?= ${LIBEXECDIR}/podman
+SYSTEMDDIR ?= ${PREFIX}/lib/systemd/system
 
 SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo -Z)
 # Get crate version by parsing the line that starts with version.
@@ -86,12 +87,17 @@ install:
 	install ${SELINUXOPT} -D -m0755 bin/netavark $(DESTDIR)/$(LIBEXECPODMAN)/netavark
 	install ${SELINUXOPT} -D -m0755 bin/netavark-dhcp-proxy $(DESTDIR)/$(LIBEXECPODMAN)/netavark-dhcp-proxy
 	$(MAKE) -C docs install
+	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/netavark-dhcp-proxy.socket ${DESTDIR}${SYSTEMDDIR}/netavark-dhcp-proxy.socket
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/netavark-dhcp-proxy.service ${DESTDIR}${SYSTEMDDIR}/netavark-dhcp-proxy.service
 
 .PHONY: uninstall
 uninstall:
 	rm -f $(DESTDIR)/$(LIBEXECPODMAN)/netavark
 	rm -f $(DESTDIR)/$(LIBEXECPODMAN)/netavark-dhcp-proxy
 	rm -f $(PREFIX)/share/man/man1/netavark*.1
+	rm -f ${DESTDIR}${SYSTEMDDIR}/netavark-dhcp-proxy.service
+	rm -f ${DESTDIR}${SYSTEMDDIR}/netavark-dhcp-proxy.socket
 
 .PHONY: test
 test: unit integration

--- a/netavark.spec.rpkg
+++ b/netavark.spec.rpkg
@@ -34,6 +34,8 @@ BuildRequires: git-core
 BuildRequires: go-md2man
 BuildRequires: protobuf-c
 BuildRequires: protobuf-compiler
+%{?systemd_requires}
+BuildRequires: systemd
 Recommends: aardvark-dns
 Provides: container-network-stack
 %if 0%{?fedora}
@@ -58,12 +60,20 @@ popd
 %install
 %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} install
 
+%preun
+%systemd_preun %{name}-dhcp-proxy.service
+
+%postun
+%systemd_postun %{name}-dhcp-proxy.service
+
 %files
 %license LICENSE
 %dir %{_libexecdir}/podman
 %{_libexecdir}/podman/%{name}
 %{_libexecdir}/podman/%{name}-dhcp-proxy
 %{_mandir}/man1/%{name}.1*
+%{_unitdir}/%{name}-dhcp-proxy.service
+%{_unitdir}/%{name}-dhcp-proxy.socket
 
 %changelog
 {{{ git_dir_changelog }}}


### PR DESCRIPTION
Currently, the COPR package does not include the Systemd unit files under `contrib/systemd/system`, which are desirable for use with the new DHCP proxy functionality. This PR adds these unit files to the COPR RPM package file, as well as the Makefile install and uninstall tasks.