### PR TITLE
Cirrus: Fix success failing on artifact extraction

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,7 +65,7 @@ build_task:
     folder: "$CIRRUS_WORKING_DIR/bin"
     # Avoid binary pollution by scoping this to only this specific build.
     # Adjust vX if cache schema changes.
-    fingerprint_key: "bin_v2_${CIRRUS_TAG}${DEST_BRANCH}${CIRRUS_PR}_amd64" # Cache only within same tag, branch, or PR (branch will be 'pull/#')
+    fingerprint_key: "bin_v3_${CIRRUS_TAG}${DEST_BRANCH}${CIRRUS_PR}_amd64" # Cache only within same tag, branch, or PR (branch will be 'pull/#')
     reupload_on_changes: true
   setup_script: &setup "$SCRIPT_BASE/setup.sh"
   main_script: &main "$SCRIPT_BASE/runner.sh $CIRRUS_TASK_NAME"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,14 +103,12 @@ build_aarch64_task:
   upload_caches: [ "cargo", "targets", "bin" ]
   # Downstream CI needs the aarch64 binaries from this CI system.
   # However, we don't want to confuse architectures.
-  art_prep_script:
-    - cd bin
-    - ls -la
-    - mv netavark netavark.$(uname -m)-unknown-linux-gnu
-    - mv netavark.debug netavark.debug.$(uname -m)-unknown-linux-gnu
-    - mv netavark.info netavark.info.$(uname -m)-unknown-linux-gnu
-    - mv netavark-dhcp-proxy-client netavark-dhcp-proxy-client.$(uname -m)-unknown-linux-gnu
-    - mv netavark-dhcp-proxy-client.debug netavark-dhcp-proxy-client.debug.$(uname -m)-unknown-linux-gnu
+  art_prep_script: |
+    cd bin
+    ls -la
+    for filename in ./*; do
+      mv "$filename" "${filename}.$(uname -m)-unknown-linux-gnu"
+    done
   armbinary_artifacts:  # See success_task
     path: ./bin/netavark*
 


### PR DESCRIPTION
[There's a clash w/ the x86_64 binary `netavark-dhcp-proxy`](https://cirrus-ci.com/task/5061451941937152):

```
unzip armbinary.zip
+ unzip armbinary.zip
Archive:  armbinary.zip
replace bin/netavark-dhcp-proxy? [y]es, [n]o, [A]ll, [N]one, [r]ename:
NULL
(EOF or read error, treating as "[N]one" ...)
```

Rather than hard-code every new binary file, simply rename them all in a loop.