### PR TITLE
Quit Leasing when Client disconnects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,12 @@ netlink-sys = "0.8.4"
 tokio = { version = "1.26", features = ["rt", "rt-multi-thread", "signal", "fs"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.8"
-mozim = "0.2"
+mozim = "0.2.1"
 prost = "0.11"
-futures-channel="0.3"
-futures-core = "0.3"
-futures-util = "0.3"
-nispor = "1.2.7"
+futures-channel="0.3.26"
+futures-core = "0.3.26"
+futures-util = "0.3.26"
+nispor = "1.2.10"
 http = "0.2.8"
 macaddr = "1.0.1"
 tower = { version = "0.4" }

--- a/src/dhcp_proxy/dhcp_service.rs
+++ b/src/dhcp_proxy/dhcp_service.rs
@@ -2,13 +2,14 @@ use crate::dhcp_proxy::dhcp_service::DhcpServiceErrorKind::{
     Bug, InvalidArgument, NoLease, Timeout,
 };
 use std::convert::TryFrom;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::dhcp_proxy::lib::g_rpc::{Lease as NetavarkLease, Lease, NetworkConfig};
-use log::warn;
+use log::{debug, warn};
 use mozim::{
-    DhcpError, DhcpV4Client, DhcpV4Config, DhcpV4Lease as MozimV4Lease, DhcpV4Lease, ErrorKind,
+    DhcpError, DhcpV4ClientAsync, DhcpV4Config, DhcpV4Lease as MozimV4Lease, DhcpV4Lease, ErrorKind,
 };
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use tokio_stream::StreamExt;
 
 use tonic::{Code, Status};
 
@@ -22,6 +23,7 @@ pub enum DhcpServiceErrorKind {
     LeaseExpired,
     Unimplemented,
 }
+
 /// A DhcpServiceError is an error caused in the process of finding a dhcp lease
 pub struct DhcpServiceError {
     kind: DhcpServiceErrorKind,
@@ -38,14 +40,14 @@ impl DhcpServiceError {
 ///
 /// These clients are managed differently. so it is important to keep these separate.
 pub enum DhcpClient {
-    V4Client(Box<DhcpV4Client>),
+    V4Client(Box<DhcpV4ClientAsync>),
     V6Client(/*TODO implement v6 client*/),
 }
+
 /// DHCP service is responsible for creating, handling, and managing the dhcp lease process.
 pub struct DhcpService {
     client: Option<DhcpClient>,
     network_config: NetworkConfig,
-    timeout: u32,
 }
 
 trait IP4Conv {
@@ -75,21 +77,20 @@ impl IP6Conv for IpAddr {
 }
 
 impl DhcpService {
-    pub fn new(nc: &NetworkConfig, timeout: u32) -> Result<DhcpService, DhcpServiceError> {
-        let client = Self::create_client(nc)?;
+    pub fn new(nc: &NetworkConfig, timeout: &u32) -> Result<DhcpService, DhcpServiceError> {
+        let client = Self::create_client(nc, timeout)?;
         Ok(DhcpService {
             client: Some(client),
             network_config: nc.clone(),
-            timeout,
         })
     }
     /// Based on the IP version, use the dhcp client to process a dhcp lease using DORA.
     /// Note: By using process you pass ownership of the dhcp service.
-    pub fn get_lease(mut self) -> Result<NetavarkLease, DhcpServiceError> {
+    pub async fn get_lease(mut self) -> Result<NetavarkLease, DhcpServiceError> {
         // match the ip version to create the correct dhcp client
         if let Some(client) = self.client.take() {
             return match client {
-                DhcpClient::V4Client(v4_client) => self.get_v4_lease(*v4_client),
+                DhcpClient::V4Client(v4_client) => self.get_v4_lease(*v4_client).await,
                 DhcpClient::V6Client() => self.get_v6_lease(),
             };
         }
@@ -103,9 +104,11 @@ impl DhcpService {
         // match the ip version to create the correct dhcp client
         if let Some(client) = self.client.take() {
             return match client {
-                DhcpClient::V4Client(mut v4_client) => {
-                    let v4_lease = DhcpV4Lease::try_from(lease.clone())?;
-                    v4_client.release(&v4_lease)
+                DhcpClient::V4Client(_v4_client) => {
+                    let _v4_lease = DhcpV4Lease::try_from(lease.clone())?;
+                    Ok(())
+                    // TODO add release to mozim for async client
+                    // v4_client.release(&v4_lease)
                 }
                 DhcpClient::V6Client() => self.release_v6_lease(),
             };
@@ -124,37 +127,29 @@ impl DhcpService {
     /// * `client`: a IPv4 mozim dhcp client. When this method is called, it takes ownership of client.
     ///
     /// returns: Result<Lease, DhcpSearchError>. Either finds a lease successfully, finds no lease, or fails
-    fn get_v4_lease(&self, mut client: DhcpV4Client) -> Result<NetavarkLease, DhcpServiceError> {
-        let timeout = self.timeout;
-        loop {
-            match client.poll(timeout) {
-                Ok(events) => {
-                    for event in events {
-                        match client.process(event) {
-                            Ok(Some(new_lease)) => {
-                                log::debug!("successfully found a lease");
-                                let mut netavark_lease =
-                                    <NetavarkLease as From<MozimV4Lease>>::from(new_lease);
-                                netavark_lease.add_domain_name(&self.network_config.domain_name);
-                                netavark_lease
-                                    .add_mac_address(&self.network_config.container_mac_addr);
-                                return Ok(netavark_lease);
-                            }
-                            Err(err) => {
-                                return Err(DhcpServiceError::new(NoLease, err.to_string()))
-                            }
-                            Ok(None) => { /*No lease found, keep looking for one*/ }
-                        };
-                    }
-                }
-                Err(dhcp_error) => {
-                    log::error!("DHCP socket timed out: {}", dhcp_error.to_string());
-                    return Err(DhcpServiceError::new(Timeout, dhcp_error.to_string()));
-                }
-            };
-            log::info!("Socket timed out, retrying for a lease");
+    ///
+    async fn get_v4_lease(
+        &self,
+        mut client: DhcpV4ClientAsync,
+    ) -> Result<NetavarkLease, DhcpServiceError> {
+        if let Some(Ok(lease)) = client.next().await {
+            debug!(
+                "successfully found a lease for {:?}",
+                &self.network_config.container_mac_addr
+            );
+
+            let mut netavark_lease = <NetavarkLease as From<MozimV4Lease>>::from(lease);
+            netavark_lease.add_domain_name(&self.network_config.domain_name);
+            netavark_lease.add_mac_address(&self.network_config.container_mac_addr);
+
+            return Ok(netavark_lease);
         }
+        Err(DhcpServiceError::new(
+            Timeout,
+            "Could not find a lease within the timeout limit".to_string(),
+        ))
     }
+
     /// TODO
     /// Performs a DHCP DORA on a IPv6 network configuration.
     /// # Arguments
@@ -176,15 +171,16 @@ impl DhcpService {
     /// * `iface`: network interface name
     /// * `version`: Version - can be Ipv4 or Ipv6
     ///
-    /// returns: Result<DhcpV4Client, DhcpError>. If there are no invalid arguments, mozim creates a client.
-    fn create_client(nc: &NetworkConfig) -> Result<DhcpClient, DhcpServiceError> {
+    /// returns: Result<DhcpClient, DhcpError>. DhcpClient is either a V4 or V6 client.
+    fn create_client(nc: &NetworkConfig, timeout: &u32) -> Result<DhcpClient, DhcpServiceError> {
         let version = &nc.version;
         let iface = &nc.host_iface;
         match version {
             //V4
             0 => {
-                let config = DhcpV4Config::new_proxy(iface, &nc.container_mac_addr);
-                match DhcpV4Client::init(config, None) {
+                let mut config = DhcpV4Config::new_proxy(iface, &nc.container_mac_addr);
+                config.set_timeout(*timeout);
+                match DhcpV4ClientAsync::init(config, None) {
                     Ok(client) => Ok(DhcpClient::V4Client(Box::new(client))),
                     Err(err) => Err(DhcpServiceError::new(InvalidArgument, err.to_string())),
                 }

--- a/src/dhcp_proxy/lib.rs
+++ b/src/dhcp_proxy/lib.rs
@@ -1,6 +1,7 @@
 extern crate core;
 
 use crate::dhcp_proxy::lib::g_rpc::{Lease, NetworkConfig};
+
 use std::convert::TryFrom;
 use std::error::Error;
 
@@ -245,6 +246,7 @@ impl NetworkConfig {
         Ok(lease)
     }
 }
+
 trait VectorConv {
     fn to_v4_addrs(&self) -> Result<Option<Vec<Ipv4Addr>>, AddrParseError>;
     fn to_v6_addrs(&self) -> Result<Option<Vec<Ipv6Addr>>, AddrParseError>;

--- a/src/proto/proxy.proto
+++ b/src/proto/proxy.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package netavark_proxy;
 
 service NetavarkProxy {
+  //  Client side streaming to detect client disconnection
   rpc Setup(NetworkConfig) returns (Lease) {}
   rpc Teardown(NetworkConfig) returns (Lease) {}
   rpc Clean(Empty) returns (OperationResponse) {}


### PR DESCRIPTION
Attention:
This is a rebase of
https://github.com/containers/netavark-dhcp-proxy/pull/61 which was written by Jack Baude. Jack is tied up in school and I simply performed the rebase to netavark after ithe netavark and netavark-dhcp-proxy projects were merged.

In the case where a client asks the proxy server for a leased address, it is possible that the client would quit (hangup) before the server could respond.  Or more likely, the server is having difficulty obtaining a lease and the client quits.  In either case, when the client quits, the server needs to stop trying to aquire a lease.

* start using mozim 0.2.1 with async lease capabilities.
* fixed timeout type to match mozim 0.2.1
* detect client disconnection with tokio oneshot channel
* use async lease DORA