### PR TITLE
iptables: fix incorrect debug statement

### DIFF
--- a/src/firewall/varktables/helpers.rs
+++ b/src/firewall/varktables/helpers.rs
@@ -17,9 +17,9 @@ pub fn append_unique(
         Err(e) => return Err(NetavarkError::Message(e.to_string())),
     };
     if exists {
+        debug_rule_exists(table, chain, rule.to_string());
         return Ok(());
     }
-    debug_rule_exists(table, chain, rule.to_string());
     if let Err(e) = driver
         .append(table, chain, rule)
         .map(|_| debug_rule_create(table, chain, rule.to_string()))


### PR DESCRIPTION
We should only log that the rule exists when this is the case. I noticed this while debugging #641.