### PR TITLE
dhcp-proxy: use better error when connection fails

### DIFF
--- a/src/dhcp_proxy_client/client.rs
+++ b/src/dhcp_proxy_client/client.rs
@@ -5,6 +5,7 @@ use tonic::{Code, Status};
 
 use netavark::dhcp_proxy::lib::g_rpc::{Lease, NetworkConfig};
 use netavark::dhcp_proxy::proxy_conf::{DEFAULT_NETWORK_CONFIG, DEFAULT_UDS_PATH};
+use netavark::error::NetavarkError;
 
 pub mod commands;
 
@@ -57,9 +58,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let r = match result {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("Error: {}", e.message());
             eprintln!("Error: {e}");
-            process_failure(e)
+            match e {
+                NetavarkError::DHCPProxy(status) => process_failure(status),
+                _ => process::exit(1),
+            }
         }
     };
 

--- a/src/dhcp_proxy_client/commands/setup.rs
+++ b/src/dhcp_proxy_client/commands/setup.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
 use log::debug;
-use netavark::dhcp_proxy::lib::g_rpc::{Lease, NetworkConfig};
-use tonic::Status;
+use netavark::{
+    dhcp_proxy::lib::g_rpc::{Lease, NetworkConfig},
+    error::NetavarkError,
+};
 
 #[derive(Parser, Debug)]
 pub struct Setup {
@@ -15,7 +17,7 @@ impl Setup {
         Self { config }
     }
 
-    pub async fn exec(&self, p: &str) -> Result<Lease, Status> {
+    pub async fn exec(&self, p: &str) -> Result<Lease, NetavarkError> {
         debug!("{:?}", "Setting up...");
         debug!(
             "input: {:#?}",

--- a/src/dhcp_proxy_client/commands/teardown.rs
+++ b/src/dhcp_proxy_client/commands/teardown.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
 use log::debug;
-use netavark::dhcp_proxy::lib::g_rpc::{Lease, NetworkConfig};
-use tonic::Status;
+use netavark::{
+    dhcp_proxy::lib::g_rpc::{Lease, NetworkConfig},
+    error::NetavarkError,
+};
 
 #[derive(Parser, Debug)]
 pub struct Teardown {
@@ -15,7 +17,7 @@ impl Teardown {
         Self { config }
     }
 
-    pub async fn exec(&self, p: &str) -> Result<Lease, Status> {
+    pub async fn exec(&self, p: &str) -> Result<Lease, NetavarkError> {
         debug!("Entering teardown");
         self.config.clone().drop_lease(p).await
     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -78,6 +78,8 @@ pub enum NetavarkError {
 
     Netlink(netlink_packet_core::error::ErrorMessage),
 
+    DHCPProxy(tonic::Status),
+
     List(NetavarkErrorList),
 }
 
@@ -146,6 +148,7 @@ impl fmt::Display for NetavarkError {
             NetavarkError::Sysctl(e) => write!(f, "Sysctl error: {}", e),
             NetavarkError::Serde(e) => write!(f, "JSON Decoding error: {}", e),
             NetavarkError::Netlink(e) => write!(f, "Netlink error: {}", e),
+            NetavarkError::DHCPProxy(e) => write!(f, "dhcp proxy error: {}", e),
             NetavarkError::List(list) => {
                 if list.0.len() == 1 {
                     write!(f, "{}", list.0[0])
@@ -202,5 +205,11 @@ impl From<ipnet::PrefixLenError> for NetavarkError {
 impl From<netlink_packet_core::error::ErrorMessage> for NetavarkError {
     fn from(err: netlink_packet_core::error::ErrorMessage) -> Self {
         NetavarkError::Netlink(err)
+    }
+}
+
+impl From<tonic::Status> for NetavarkError {
+    fn from(err: tonic::Status) -> Self {
+        NetavarkError::DHCPProxy(err)
     }
 }


### PR DESCRIPTION
Wrap the tonic status errors in the netavark error type, this allows us to create better error messages.

Also a bit complicated but special case when the socket is not found and return a message to consider enabling the netavark-dhcp-proxy.socket. old error:
`unable to obtain lease: status: Internal, message: "transport error", details: [], metadata: MetadataMap { headers: {} }` new error:
`unable to obtain lease: socket "/run/podman/nv-proxy.sock": No such file or directory (os error 2), is the netavark-dhcp-proxy.socket enabled?`