### PR TITLE
Static routes

### DIFF
--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -1,3 +1,4 @@
+use super::netlink;
 use crate::network::types;
 use std::net::IpAddr;
 
@@ -66,6 +67,7 @@ pub struct IPAMAddresses {
     // if using macvlan and dhcp, then true
     pub dhcp_enabled: bool,
     pub gateway_addresses: Vec<ipnet::IpNet>,
+    pub routes: Vec<netlink::Route>,
     pub ipv6_enabled: bool,
     // result for podman
     pub net_addresses: Vec<types::NetAddress>,

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -196,7 +196,7 @@ pub struct NetAddress {
 /// Subnet for a network.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Subnet {
-    /// Subnet for this Network in CIDR form.
+    /// Gateway IP for this Network.
     #[serde(rename = "gateway")]
     pub gateway: Option<IpAddr>,
 
@@ -204,7 +204,7 @@ pub struct Subnet {
     #[serde(rename = "lease_range")]
     pub lease_range: Option<LeaseRange>,
 
-    /// Gateway IP for this Network.
+    /// Subnet for this Network in CIDR form.
     #[serde(rename = "subnet")]
     pub subnet: IpNet,
 }

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -50,6 +50,10 @@ pub struct Network {
     #[serde(rename = "subnets")]
     pub subnets: Option<Vec<Subnet>>,
 
+    /// Static routes to use for this network.
+    #[serde(rename = "routes")]
+    pub routes: Option<Vec<Route>>,
+
     /// Network DNS servers for aardvark-dns.
     #[serde(rename = "network_dns_servers")]
     pub network_dns_servers: Option<Vec<IpAddr>>,
@@ -207,6 +211,22 @@ pub struct Subnet {
     /// Subnet for this Network in CIDR form.
     #[serde(rename = "subnet")]
     pub subnet: IpNet,
+}
+
+/// Static routes for a network.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Route {
+    /// Gateway IP for this route.
+    #[serde(rename = "gateway")]
+    pub gateway: IpAddr,
+
+    /// Destination for this route in CIDR form.
+    #[serde(rename = "destination")]
+    pub destination: IpNet,
+
+    /// Route Metric
+    #[serde(rename = "metric")]
+    pub metric: Option<u32>,
 }
 
 /// LeaseRange contains the range where IP are leased.

--- a/src/network/vlan.rs
+++ b/src/network/vlan.rs
@@ -223,6 +223,11 @@ impl driver::NetworkDriver for Vlan<'_> {
             )?
         }
 
+        let routes = core_utils::create_route_list(&self.info.network.routes)?;
+        for route in routes.iter() {
+            netlink_sockets.1.del_route(route)?;
+        }
+
         netlink_sockets.1.del_link(netlink::LinkID::Name(
             self.info.per_network_opts.interface_name.to_string(),
         ))?;
@@ -339,6 +344,11 @@ fn setup(
         .wrap(format!("set {} up", kind_data))?;
 
     core_utils::add_default_routes(netns, &data.ipam.gateway_addresses, data.metric)?;
+
+    // add static routes
+    for route in data.ipam.routes.iter() {
+        netns.add_route(route)?
+    }
 
     get_mac_address(dev.nlas)
 }

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -111,6 +111,41 @@ fw_driver=iptables
     expected_rc=1 run_in_host_netns ip addr show podman0
 }
 
+@test "$fw_driver - bridge with static routes" {
+    # add second interface and routes through that interface to test proper teardown
+    run_in_container_netns ip link add type dummy
+    run_in_container_netns ip a add 10.91.0.10/24 dev dummy0
+    run_in_container_netns ip link set dummy0 up
+
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-staticroutes.json setup $(get_container_netns_path)
+
+    # check static routes
+    run_in_container_netns ip r
+    assert "$output" "=~" "10.89.0.0/24 via 10.88.0.2" "static route not set"
+    assert "$output" "=~" "10.90.0.0/24 via 10.88.0.3" "static route not set"
+    assert "$output" "=~" "10.92.0.0/24 via 10.91.0.1" "static route not set"
+
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-staticroutes.json teardown $(get_container_netns_path)
+
+    # check static routes get removed
+    assert "$output" "!~" "10.89.0.0/24 via 10.88.0.2" "static route not set"
+    assert "$output" "!~" "10.90.0.0/24 via 10.88.0.3" "static route not set"
+    assert "$output" "!~" "10.92.0.0/24 via 10.91.0.1" "static route not removed"
+}
+
+@test "$fw_driver - bridge with no default gateway" {
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-nogateway.json setup $(get_container_netns_path)
+
+    run_in_container_netns ip r
+    assert "$output" "!~" "default" "default gateway exists"
+
+    run_in_container_netns ip -6 r
+    assert "$output" "!~" "default" "default gateway exists"
+
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-nogateway.json teardown $(get_container_netns_path)
+    assert "" "no errors"
+}
+
 @test "$fw_driver - bridge driver must generate config for aardvark with multiple custom dns server with network dns servers and perform update" {
     # get a random port directly to avoid low ports e.g. 53 would not create iptables
     dns_port=$((RANDOM+10000))
@@ -199,6 +234,31 @@ fw_driver=iptables
     run_in_host_netns ping6 -c 1 fd10:88:a::2
 
     run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge.json teardown $(get_container_netns_path)
+}
+
+@test "$fw_driver - ipv6 bridge with static routes" {
+    # add second interface and routes through that interface to test proper teardown
+    run_in_container_netns ip link add type dummy
+    run_in_container_netns ip a add fd10:49:b::2/64 dev dummy0
+    run_in_container_netns ip link set dummy0 up
+
+    run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge-staticroutes.json setup $(get_container_netns_path)
+
+    # check static routes
+    run_in_container_netns ip -6 -br r
+    assert "$output" "=~" "fd10:89:b::/64 via fd10:88:a::ac02" "static route not set"
+    assert "$output" "=~" "fd10:89:c::/64 via fd10:88:a::ac03" "static route not set"
+    assert "$output" "=~" "fd10:51:b::/64 via fd10:49:b::30" "static route not set"
+
+    run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge-staticroutes.json teardown $(get_container_netns_path)
+
+    # check static routes get removed
+    run_in_container_netns ip -6 -br r
+    assert "$output" "!~" "fd10:89:b::/64 via fd10:88:a::ac02" "static route not removed"
+    assert "$output" "!~" "fd10:89:c::/64 via fd10:88:a::ac03" "static route not removed"
+    assert "$output" "!~" "fd10:51:b::/64 via fd10:49:b::30" "static route not removed"
+
+    run_in_container_netns ip link delete dummy0
 }
 
 @test "$fw_driver - bridge driver must generate config for aardvark with custom dns server" {

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -92,6 +92,41 @@ function teardown() {
     # run_in_host_netns firewall-cmd ...
 }
 
+@test "$fw_driver - bridge with static routes" {
+    # add second interface and routes through that interface to test proper teardown
+    run_in_container_netns ip link add type dummy
+    run_in_container_netns ip a add 10.91.0.10/24 dev dummy0
+    run_in_container_netns ip link set dummy0 up
+
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-staticroutes.json setup $(get_container_netns_path)
+
+    # check static routes
+    run_in_container_netns ip r
+    assert "$output" "=~" "10.89.0.0/24 via 10.88.0.2" "static route not set"
+    assert "$output" "=~" "10.90.0.0/24 via 10.88.0.3" "static route not set"
+    assert "$output" "=~" "10.92.0.0/24 via 10.91.0.1" "static route not set"
+
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-staticroutes.json teardown $(get_container_netns_path)
+
+    # check static routes get removed
+    assert "$output" "!~" "10.89.0.0/24 via 10.88.0.2" "static route not set"
+    assert "$output" "!~" "10.90.0.0/24 via 10.88.0.3" "static route not set"
+    assert "$output" "!~" "10.92.0.0/24 via 10.91.0.1" "static route not removed"
+}
+
+@test "$fw_driver - bridge with no default gateway" {
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-nogateway.json setup $(get_container_netns_path)
+
+    run_in_container_netns ip r
+    assert "$output" "!~" "default" "default gateway exists"
+
+    run_in_container_netns ip -6 r
+    assert "$output" "!~" "default" "default gateway exists"
+
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-nogateway.json teardown $(get_container_netns_path)
+    assert "" "no errors"
+}
+
 @test "$fw_driver - ipv6 bridge" {
 
     ### FIXME set sysctl in netavark
@@ -132,6 +167,31 @@ function teardown() {
     assert "$output" =~ "127.0.0.1" "Loopback adapter is up (has address)"
 
     run_in_host_netns ping6 -c 1 fd10:88:a::2
+}
+
+@test "$fw_driver - ipv6 bridge with static routes" {
+    # add second interface and routes through that interface to test proper teardown
+    run_in_container_netns ip link add type dummy
+    run_in_container_netns ip a add fd10:49:b::2/64 dev dummy0
+    run_in_container_netns ip link set dummy0 up
+
+    run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge-staticroutes.json setup $(get_container_netns_path)
+
+    # check static routes
+    run_in_container_netns ip -6 -br r
+    assert "$output" "=~" "fd10:89:b::/64 via fd10:88:a::ac02" "static route not set"
+    assert "$output" "=~" "fd10:89:c::/64 via fd10:88:a::ac03" "static route not set"
+    assert "$output" "=~" "fd10:51:b::/64 via fd10:49:b::30" "static route not set"
+
+    run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge-staticroutes.json teardown $(get_container_netns_path)
+
+    # check static routes get removed
+    run_in_container_netns ip -6 -br r
+    assert "$output" "!~" "fd10:89:b::/64 via fd10:88:a::ac02" "static route not removed"
+    assert "$output" "!~" "fd10:89:c::/64 via fd10:88:a::ac03" "static route not removed"
+    assert "$output" "!~" "fd10:51:b::/64 via fd10:49:b::30" "static route not removed"
+
+    run_in_container_netns ip link delete dummy0
 }
 
 @test "$fw_driver - dual stack dns with alt port" {

--- a/test/300-macvlan.bats
+++ b/test/300-macvlan.bats
@@ -41,6 +41,49 @@ function setup() {
     assert "" "no errors"
 }
 
+@test "macvlan setup with static routes" {
+    # add second interface and routes through that interface to test proper teardown
+    run_in_container_netns ip link add type dummy
+    run_in_container_netns ip a add 10.91.0.10/24 dev dummy0
+    run_in_container_netns ip link set dummy0 up
+
+    run_netavark --file ${TESTSDIR}/testfiles/macvlan-staticroutes.json setup $(get_container_netns_path)
+
+    # check static routes
+    run_in_container_netns ip r
+    assert "$output" "=~" "10.89.0.0/24 via 10.88.0.2" "static route not set"
+    assert "$output" "=~" "10.90.0.0/24 via 10.88.0.3" "static route not set"
+    assert "$output" "=~" "10.92.0.0/24 via 10.91.0.1" "static route not set"
+    run_in_container_netns ip -6 r
+    assert "$output" "=~" "fd:2f2f::/64 via fd:1f1f::20" "static route not set"
+
+    run_netavark --file ${TESTSDIR}/testfiles/macvlan-staticroutes.json teardown $(get_container_netns_path)
+    assert "" "no errors"
+
+    # check static routes get removed
+    run_in_container_netns ip r
+    assert "$output" "!~" "10.89.0.0/24 via 10.88.0.2" "static route not removed"
+    assert "$output" "!~" "10.90.0.0/24 via 10.88.0.3" "static route not removed"
+    assert "$output" "!~" "10.92.0.0/24 via 10.91.0.1" "static route not removed"
+    run_in_container_netns ip -6 r
+    assert "$output" "!~" "fd:2f2f::/64 via fd:1f1f::20" "static route not removed"
+
+    run_in_container_netns ip link delete dummy0
+}
+
+@test "macvlan setup no default gateway" {
+    run_netavark --file ${TESTSDIR}/testfiles/macvlan-nogateway.json setup $(get_container_netns_path)
+
+    run_in_container_netns ip r
+    assert "$output" "!~" "default" "default gateway exists"
+
+    run_in_container_netns ip -6 r
+    assert "$output" "!~" "default" "default gateway exists"
+
+    run_netavark --file ${TESTSDIR}/testfiles/macvlan-nogateway.json teardown $(get_container_netns_path)
+    assert "" "no errors"
+}
+
 @test "macvlan setup internal" {
     run_netavark --file ${TESTSDIR}/testfiles/macvlan-internal.json setup $(get_container_netns_path)
     result="$output"

--- a/test/testfiles/bridge-nogateway.json
+++ b/test/testfiles/bridge-nogateway.json
@@ -1,0 +1,35 @@
+{
+    "container_id": "6ce776ea58b5",
+    "container_name": "testcontainer",
+    "networks": {
+        "podman": {
+            "interface_name": "eth0",
+            "static_ips": [
+                "10.88.0.2",
+                "fd:1f1f::2"
+            ]
+        }
+    },
+    "network_info": {
+        "podman": {
+            "dns_enabled": false,
+            "driver": "bridge",
+            "id": "53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
+            "internal": false,
+            "ipv6_enabled": true,
+            "name": "podman",
+            "network_interface": "podman0",
+            "subnets": [
+                {
+                    "subnet": "10.88.0.0/24"
+                },
+                {
+                    "subnet": "fd:1f1f::/64"
+                }
+            ],
+            "options": {
+                "no_auto_gateway": "1"
+            }
+        }
+    }
+}

--- a/test/testfiles/bridge-staticroutes.json
+++ b/test/testfiles/bridge-staticroutes.json
@@ -1,0 +1,43 @@
+{
+    "container_id": "6ce776ea58b5",
+    "container_name": "testcontainer",
+    "networks": {
+        "podman": {
+            "interface_name": "eth0",
+            "static_ips": [
+                "10.88.0.2"
+            ]
+        }
+    },
+    "network_info": {
+        "podman": {
+            "dns_enabled": false,
+            "driver": "bridge",
+            "id": "53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
+            "internal": false,
+            "ipv6_enabled": false,
+            "name": "podman",
+            "network_interface": "podman0",
+            "subnets": [
+                {
+                    "gateway": "10.88.0.1",
+                    "subnet": "10.88.0.0/16"
+                }
+            ],
+            "routes": [
+                {
+                    "destination": "10.89.0.0/24",
+                    "gateway": "10.88.0.2"
+                },
+                {
+                    "destination": "10.90.0.0/24",
+                    "gateway": "10.88.0.3"
+                },
+                {
+                    "destination": "10.92.0.0/24",
+                    "gateway": "10.91.0.1"
+                }
+            ]
+        }
+    }
+}

--- a/test/testfiles/ipv6-bridge-staticroutes.json
+++ b/test/testfiles/ipv6-bridge-staticroutes.json
@@ -1,0 +1,46 @@
+{
+    "container_id": "f031bf33eecba75d0d84952337b1ceef6a239eb8e94b48aee0993d0791345325",
+    "container_name": "somename",
+    "networks": {
+        "podman1": {
+            "static_ips": [
+                "fd10:88:a::2"
+            ],
+            "interface_name": "eth0"
+        }
+    },
+    "network_info": {
+        "podman1": {
+            "name": "podman1",
+            "id": "ec79dd0cad82083c8ac5cc23e9542e4ddea813dff60d68258d36e84f6393b63b",
+            "driver": "bridge",
+            "network_interface": "podman1",
+            "subnets": [
+                {
+                    "subnet": "fd10:88:a::/64",
+                    "gateway": "fd10:88:a::1"
+                }
+            ],
+            "routes": [
+                {
+                    "destination": "fd10:89:b::/64",
+                    "gateway": "fd10:88:a::ac02"
+                },
+                {
+                    "destination": "fd10:89:c::/64",
+                    "gateway": "fd10:88:a::ac03"
+                },
+                {
+                    "destination": "fd10:51:b::/64",
+                    "gateway": "fd10:49:b::30"
+                }
+            ],
+            "ipv6_enabled": true,
+            "internal": false,
+            "dns_enabled": false,
+            "ipam_options": {
+                "driver": "host-local"
+            }
+        }
+    }
+}

--- a/test/testfiles/ipvlan-nogateway.json
+++ b/test/testfiles/ipvlan-nogateway.json
@@ -1,0 +1,38 @@
+{
+    "container_id": "someID",
+    "container_name": "someName",
+    "networks": {
+       "podman": {
+          "static_ips": [
+             "10.88.0.2",
+             "fd:1f1f::2"
+          ],
+          "interface_name": "eth0"
+       }
+    },
+    "network_info": {
+       "podman": {
+          "name": "podman",
+          "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+          "driver": "ipvlan",
+          "network_interface": "dummy0",
+          "subnets": [
+             {
+                "subnet": "10.88.0.0/16"
+             },
+             {
+               "subnet": "fd:1f1f::/64"
+             }
+          ],
+          "options": {
+            "no_auto_gateway": "1"
+          },
+          "ipv6_enabled": true,
+          "internal": false,
+          "dns_enabled": true,
+          "ipam_options": {
+             "driver": "host-local"
+          }
+       }
+    }
+ }

--- a/test/testfiles/ipvlan-staticroutes.json
+++ b/test/testfiles/ipvlan-staticroutes.json
@@ -1,0 +1,55 @@
+{
+    "container_id": "someID",
+    "container_name": "someName",
+    "networks": {
+       "podman": {
+          "static_ips": [
+             "10.88.0.2",
+             "fd:1f1f::2"
+          ],
+          "interface_name": "eth0"
+       }
+    },
+    "network_info": {
+       "podman": {
+          "name": "podman",
+          "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+          "driver": "ipvlan",
+          "network_interface": "dummy0",
+          "subnets": [
+             {
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
+             },
+             {
+               "subnet": "fd:1f1f::/64",
+               "gateway": "fd:1f1f::1"
+             }
+          ],
+          "routes": [
+            {
+                "destination": "10.89.0.0/24",
+                "gateway": "10.88.0.2"
+            },
+            {
+                "destination": "10.90.0.0/24",
+                "gateway": "10.88.0.3"
+            },
+            {
+               "destination": "10.92.0.0/24",
+               "gateway": "10.91.0.1"
+            },
+            {
+               "destination": "fd:2f2f::/64",
+               "gateway": "fd:1f1f::20"
+            }
+         ],
+          "ipv6_enabled": true,
+          "internal": false,
+          "dns_enabled": true,
+          "ipam_options": {
+             "driver": "host-local"
+          }
+       }
+    }
+ }

--- a/test/testfiles/macvlan-nogateway.json
+++ b/test/testfiles/macvlan-nogateway.json
@@ -1,0 +1,38 @@
+{
+    "container_id": "someID",
+    "container_name": "someName",
+    "networks": {
+       "podman": {
+          "static_ips": [
+             "10.88.0.2",
+             "fd:1f1f::2"
+          ],
+          "interface_name": "eth0"
+       }
+    },
+    "network_info": {
+       "podman": {
+          "name": "podman",
+          "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+          "driver": "macvlan",
+          "network_interface": "dummy0",
+          "subnets": [
+             {
+                "subnet": "10.88.0.0/16"
+             },
+             {
+                "subnet": "fd:1f1f::/64"
+             }
+          ],
+          "options": {
+            "no_auto_gateway": "1"
+          },
+          "ipv6_enabled": true,
+          "internal": false,
+          "dns_enabled": true,
+          "ipam_options": {
+             "driver": "host-local"
+          }
+       }
+    }
+ }

--- a/test/testfiles/macvlan-staticroutes.json
+++ b/test/testfiles/macvlan-staticroutes.json
@@ -1,0 +1,55 @@
+{
+    "container_id": "someID",
+    "container_name": "someName",
+    "networks": {
+       "podman": {
+          "static_ips": [
+             "10.88.0.2",
+             "fd:1f1f::2"
+          ],
+          "interface_name": "eth0"
+       }
+    },
+    "network_info": {
+       "podman": {
+          "name": "podman",
+          "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+          "driver": "macvlan",
+          "network_interface": "dummy0",
+          "subnets": [
+             {
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
+             },
+             {
+               "subnet": "fd:1f1f::/64",
+               "gateway": "fd:1f1f::1"
+             }
+          ],
+          "routes": [
+            {
+                "destination": "10.89.0.0/24",
+                "gateway": "10.88.0.2"
+            },
+            {
+                "destination": "10.90.0.0/24",
+                "gateway": "10.88.0.3"
+            },
+            {
+               "destination": "10.92.0.0/24",
+               "gateway": "10.91.0.1"
+            },
+            {
+               "destination": "fd:2f2f::/64",
+               "gateway": "fd:1f1f::20"
+            }
+         ],
+          "ipv6_enabled": true,
+          "internal": false,
+          "dns_enabled": true,
+          "ipam_options": {
+             "driver": "host-local"
+          }
+       }
+    }
+ }


### PR DESCRIPTION
This PR adds the ability to configure static routes. Discussion is in #678 

Supports both ipv4 and ipv6 routes including optional route metric. 

Example json:

```
"network_info": {
        "podman": {
            "dns_enabled": false,
            "driver": "bridge",
            "id": "53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
            "internal": false,
            "ipv6_enabled": false,
            "name": "podman",
            "network_interface": "podman0",
            "subnets": [
                {
                    "gateway": "10.88.0.1",
                    "subnet": "10.88.0.0/16"
                }
            ],
            "routes": [
                {
                    "destination": "10.89.0.0/24",
                    "gateway": "10.88.0.2",
                    "metric": "120"
                },
                {
                    "destination": "10.90.0.0/24",
                    "gateway": "10.88.0.3"
                }
            ]
        }
    }
```