### PR TITLE
[release-v1.5.0] aardvark: no error when aardvark config is not there

### DIFF
--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -163,6 +163,22 @@ fw_driver=iptables
     assert "${#lines[@]}" = 2 "too many lines in aardvark config"
 }
 
+# netavark must do no-op on upates when no aardvark config is there
+@test "run netavark update - no-op" {
+    # get a random port directly to avoid low ports e.g. 53 would not create iptables
+    dns_port=$((RANDOM+10000))
+
+    rootless=false
+    if [[ ! -e "/run/dbus/system_bus_socket" ]]; then
+        rootless=true
+    fi
+
+    mkdir -p "$NETAVARK_TMPDIR/config"
+    NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge-network-container-dns-server.json \
+        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
+        update podman1 --network-dns-servers 8.8.8.8
+}
+
 @test "$fw_driver - ipv6 bridge" {
     run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge.json setup $(get_container_netns_path)
     result="$output"


### PR DESCRIPTION
`network update` maybe called by podman when no container is running in such case no aardvark config is present so netavark must return as-in without throwing error since podman database is still updated.

Closes: **BZ#2188566**
Closes: **BZ#2188524**
Closes: **BZ#2182898**
Closes: **BZ#2188340**

Backport of: https://github.com/containers/netavark/pull/677