### PR TITLE
aardvark-dns pid: return better errors

### DIFF
--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -47,7 +47,7 @@ impl Teardown {
                     Aardvark::new(path_string, rootless, aardvark_bin, dns_port);
                 if let Err(err) = aardvark_interface.delete_from_netavark_entries(&network_options)
                 {
-                    error_list.push(err.into());
+                    error_list.push(NetavarkError::wrap("remove aardvark entries", err));
                 }
             } else {
                 error_list.push(NetavarkError::msg(

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -48,7 +48,7 @@ impl Update {
                 {
                     return Err(NetavarkError::wrap(
                         "unable to modify network dns servers",
-                        NetavarkError::Io(err),
+                        err,
                     ));
                 }
             } else {


### PR DESCRIPTION
Ed reported a flake in podman where aardvark-dns pid was not found hen we tried to stop it. It is not clear why but the error report is far from optimal, we should never throw away the original error context. This is very important to understand what is going on.

Port most over to our netavark error type and wrap where needed. Also change the pid type to pid_t. It is i32 so it did not cause any issues before but this makes it more obvious that we have the correct type.

[1] https://github.com/containers/podman/issues/18325