### PR TITLE
simplify path printing

### DIFF
--- a/src/commands/dhcp_proxy.rs
+++ b/src/commands/dhcp_proxy.rs
@@ -223,10 +223,7 @@ pub async fn serve(opts: Opts) -> NetavarkResult<()> {
         Duration::from_secs(opts.activity_timeout.unwrap_or(DEFAULT_INACTIVITY_TIMEOUT));
 
     let uds_path = get_proxy_sock_fqname(optional_run_dir);
-    debug!(
-        "socket path: {}",
-        &uds_path.clone().into_os_string().into_string().unwrap()
-    );
+    debug!("socket path: {}", &uds_path.display());
 
     let mut is_systemd_activated = false;
 

--- a/src/network/plugin.rs
+++ b/src/network/plugin.rs
@@ -39,13 +39,8 @@ impl NetworkDriver for PluginDriver<'_> {
         _netlink_sockets: (&mut super::netlink::Socket, &mut super::netlink::Socket),
     ) -> NetavarkResult<(types::StatusBlock, Option<AardvarkEntry>)> {
         let result = self.exec_plugin(true, self.info.netns_path).wrap(format!(
-            "plugin \"{}\" failed",
-            &self
-                .path
-                .file_name()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default()
+            "plugin {:?} failed",
+            &self.path.file_name().unwrap_or_default()
         ))?;
         // The unwrap should be safe, only if the exec_plugin has a bug this
         // could fail, in which case the test should catch it.
@@ -57,13 +52,8 @@ impl NetworkDriver for PluginDriver<'_> {
         _netlink_sockets: (&mut super::netlink::Socket, &mut super::netlink::Socket),
     ) -> NetavarkResult<()> {
         self.exec_plugin(false, self.info.netns_path).wrap(format!(
-            "plugin \"{}\" failed",
-            &self
-                .path
-                .file_name()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap_or_default()
+            "plugin {:?} failed",
+            &self.path.file_name().unwrap_or_default()
         ))?;
         Ok(())
     }


### PR DESCRIPTION
Just to remove some code that is not needed. The Debug trait will already print the path name with quotes so we can remove them from the format string.