### PR TITLE
add no_default_gateway option

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -16,6 +16,7 @@ pub const OPTION_ISOLATE: &str = "isolate";
 pub const OPTION_MTU: &str = "mtu";
 pub const OPTION_MODE: &str = "mode";
 pub const OPTION_METRIC: &str = "metric";
+pub const OPTION_NO_DEFAULT_ROUTE: &str = "no_default_route";
 
 /// 100 is the default metric for most Linux networking tools.
 pub const DEFAULT_METRIC: u32 = 100;

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -133,16 +133,16 @@ fw_driver=iptables
     assert "$output" "!~" "10.92.0.0/24 via 10.91.0.1" "static route not removed"
 }
 
-@test "$fw_driver - bridge with no default gateway" {
-    run_netavark --file ${TESTSDIR}/testfiles/bridge-nogateway.json setup $(get_container_netns_path)
+@test "$fw_driver - bridge with no default route" {
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-nodefaultroute.json setup $(get_container_netns_path)
 
     run_in_container_netns ip r
-    assert "$output" "!~" "default" "default gateway exists"
+    assert "$output" "!~" "default" "default route exists"
 
     run_in_container_netns ip -6 r
-    assert "$output" "!~" "default" "default gateway exists"
+    assert "$output" "!~" "default" "default route exists"
 
-    run_netavark --file ${TESTSDIR}/testfiles/bridge-nogateway.json teardown $(get_container_netns_path)
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-nodefaultroute.json teardown $(get_container_netns_path)
     assert "" "no errors"
 }
 

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -114,16 +114,16 @@ function teardown() {
     assert "$output" "!~" "10.92.0.0/24 via 10.91.0.1" "static route not removed"
 }
 
-@test "$fw_driver - bridge with no default gateway" {
-    run_netavark --file ${TESTSDIR}/testfiles/bridge-nogateway.json setup $(get_container_netns_path)
+@test "$fw_driver - bridge with no default route" {
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-nodefaultroute.json setup $(get_container_netns_path)
 
     run_in_container_netns ip r
-    assert "$output" "!~" "default" "default gateway exists"
+    assert "$output" "!~" "default" "default route exists"
 
     run_in_container_netns ip -6 r
-    assert "$output" "!~" "default" "default gateway exists"
+    assert "$output" "!~" "default" "default route exists"
 
-    run_netavark --file ${TESTSDIR}/testfiles/bridge-nogateway.json teardown $(get_container_netns_path)
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-nodefaultroute.json teardown $(get_container_netns_path)
     assert "" "no errors"
 }
 

--- a/test/300-macvlan.bats
+++ b/test/300-macvlan.bats
@@ -71,16 +71,16 @@ function setup() {
     run_in_container_netns ip link delete dummy0
 }
 
-@test "macvlan setup no default gateway" {
-    run_netavark --file ${TESTSDIR}/testfiles/macvlan-nogateway.json setup $(get_container_netns_path)
+@test "macvlan setup no default route" {
+    run_netavark --file ${TESTSDIR}/testfiles/macvlan-nodefaultroute.json setup $(get_container_netns_path)
 
     run_in_container_netns ip r
-    assert "$output" "!~" "default" "default gateway exists"
+    assert "$output" "!~" "default" "default route exists"
 
     run_in_container_netns ip -6 r
-    assert "$output" "!~" "default" "default gateway exists"
+    assert "$output" "!~" "default" "default route exists"
 
-    run_netavark --file ${TESTSDIR}/testfiles/macvlan-nogateway.json teardown $(get_container_netns_path)
+    run_netavark --file ${TESTSDIR}/testfiles/macvlan-nodefaultroute.json teardown $(get_container_netns_path)
     assert "" "no errors"
 }
 

--- a/test/400-ipvlan.bats
+++ b/test/400-ipvlan.bats
@@ -71,16 +71,16 @@ function setup() {
     run_in_container_netns ip link delete dummy0
 }
 
-@test "ipvlan setup with no default gateway" {
-    run_netavark --file ${TESTSDIR}/testfiles/ipvlan-nogateway.json setup $(get_container_netns_path)
+@test "ipvlan setup no default route" {
+    run_netavark --file ${TESTSDIR}/testfiles/ipvlan-nodefaultroute.json setup $(get_container_netns_path)
 
     run_in_container_netns ip r
-    assert "$output" "!~" "default" "default gateway exists"
+    assert "$output" "!~" "default" "default route exists"
 
     run_in_container_netns ip -6 r
-    assert "$output" "!~" "default" "default gateway exists"
+    assert "$output" "!~" "default" "default route exists"
 
-    run_netavark --file ${TESTSDIR}/testfiles/ipvlan-nogateway.json teardown $(get_container_netns_path)
+    run_netavark --file ${TESTSDIR}/testfiles/ipvlan-nodefaultroute.json teardown $(get_container_netns_path)
     assert "" "no errors"
 }
 

--- a/test/testfiles/bridge-nodefaultroute.json
+++ b/test/testfiles/bridge-nodefaultroute.json
@@ -5,8 +5,7 @@
         "podman": {
             "interface_name": "eth0",
             "static_ips": [
-                "10.88.0.2",
-                "fd:1f1f::2"
+                "10.88.0.2"
             ]
         }
     },
@@ -16,19 +15,17 @@
             "driver": "bridge",
             "id": "53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
             "internal": false,
-            "ipv6_enabled": true,
+            "ipv6_enabled": false,
             "name": "podman",
             "network_interface": "podman0",
             "subnets": [
                 {
-                    "subnet": "10.88.0.0/24"
-                },
-                {
-                    "subnet": "fd:1f1f::/64"
+                    "gateway": "10.88.0.1",
+                    "subnet": "10.88.0.0/16"
                 }
             ],
             "options": {
-                "no_auto_gateway": "1"
+                "no_default_route": "true"
             }
         }
     }

--- a/test/testfiles/ipvlan-nodefaultroute.json
+++ b/test/testfiles/ipvlan-nodefaultroute.json
@@ -4,8 +4,7 @@
     "networks": {
        "podman": {
           "static_ips": [
-             "10.88.0.2",
-             "fd:1f1f::2"
+             "10.88.0.2"
           ],
           "interface_name": "eth0"
        }
@@ -18,20 +17,18 @@
           "network_interface": "dummy0",
           "subnets": [
              {
-                "subnet": "10.88.0.0/16"
-             },
-             {
-               "subnet": "fd:1f1f::/64"
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
              }
           ],
-          "options": {
-            "no_auto_gateway": "1"
-          },
-          "ipv6_enabled": true,
+          "ipv6_enabled": false,
           "internal": false,
           "dns_enabled": true,
           "ipam_options": {
              "driver": "host-local"
+          },
+          "options": {
+            "no_default_route": "true"
           }
        }
     }

--- a/test/testfiles/macvlan-nodefaultroute.json
+++ b/test/testfiles/macvlan-nodefaultroute.json
@@ -4,8 +4,7 @@
     "networks": {
        "podman": {
           "static_ips": [
-             "10.88.0.2",
-             "fd:1f1f::2"
+             "10.88.0.2"
           ],
           "interface_name": "eth0"
        }
@@ -18,20 +17,18 @@
           "network_interface": "dummy0",
           "subnets": [
              {
-                "subnet": "10.88.0.0/16"
-             },
-             {
-                "subnet": "fd:1f1f::/64"
+                "subnet": "10.88.0.0/16",
+                "gateway": "10.88.0.1"
              }
           ],
-          "options": {
-            "no_auto_gateway": "1"
-          },
-          "ipv6_enabled": true,
+          "ipv6_enabled": false,
           "internal": false,
           "dns_enabled": true,
           "ipam_options": {
              "driver": "host-local"
+          },
+          "options": {
+            "no_default_route": "true"
           }
        }
     }


### PR DESCRIPTION
This PR adds the option to enable no_default_gateway in the options map. The result is that netavark will not add default routes to the network namespace.

This fixes the issue that DNS would not work in containers/common#1440 when using no_auto_gateway. The solution is to use this new no_default_gateway instead of no_auto_gateway.