### PR TITLE
feature: isolation among all netavark bridge 

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -13,6 +13,9 @@ pub const DRIVER_IPVLAN: &str = "ipvlan";
 pub const DRIVER_MACVLAN: &str = "macvlan";
 
 pub const OPTION_ISOLATE: &str = "isolate";
+pub const ISOLATE_OPTION_TRUE: &str = "true";
+pub const ISOLATE_OPTION_FALSE: &str = "false";
+pub const ISOLATE_OPTION_STRICT: &str = "strict";
 pub const OPTION_MTU: &str = "mtu";
 pub const OPTION_MODE: &str = "mode";
 pub const OPTION_METRIC: &str = "metric";

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -18,7 +18,7 @@ pub struct SetupNetwork {
     /// hash id for the network
     pub network_hash_name: String,
     /// isolation determines whether the network can communicate with others outside of its interface
-    pub isolation: bool,
+    pub isolation: IsolateOption,
 }
 
 #[derive(Debug)]
@@ -72,4 +72,12 @@ pub struct IPAMAddresses {
     // result for podman
     pub net_addresses: Vec<types::NetAddress>,
     pub nameservers: Vec<IpAddr>,
+}
+
+// IsolateOption is used to select isolate option value
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum IsolateOption {
+    Strict,
+    Nomal,
+    Never,
 }

--- a/test/testfiles/isolate3.json
+++ b/test/testfiles/isolate3.json
@@ -1,0 +1,37 @@
+{
+    "container_id": "01f0b94d5f4c1",
+    "container_name": "isolatedcontainer1",
+    "networks": {
+        "isolate3": {
+            "interface_name": "eth3",
+            "static_ips": [
+                "10.89.2.2",
+                "fd92::2"
+            ]
+        }
+    },
+    "network_info": {
+        "isolate3": {
+            "dns_enabled": false,
+            "driver": "bridge",
+            "id": "f3ac3c903b76f20e8a122b1eb2ba393ab2519ba516626be5b490b66dc96b54b7",
+            "internal": false,
+            "ipv6_enabled": false,
+            "name": "isolate3",
+            "network_interface": "isolate3",
+            "subnets": [
+                {
+                    "gateway": "10.89.2.1",
+                    "subnet": "10.89.2.0/24"
+                },
+                {
+                    "subnet": "fd92::/64",
+                    "gateway": "fd92::1"
+               }
+            ],
+            "options": {
+                "isolate": "strict"
+             }
+        }
+    }
+}

--- a/test/testfiles/isolate4.json
+++ b/test/testfiles/isolate4.json
@@ -1,0 +1,37 @@
+{
+    "container_id": "01f0b94d5f4c1",
+    "container_name": "isolatedcontainer1",
+    "networks": {
+        "isolate4": {
+            "interface_name": "eth4",
+            "static_ips": [
+                "10.89.3.2",
+                "fd93::2"
+            ]
+        }
+    },
+    "network_info": {
+        "isolate4": {
+            "dns_enabled": false,
+            "driver": "bridge",
+            "id": "f3ac3c903b76f20e8a122b1eb2ba393ab2519ba516626be5b490b66dc96b54b7",
+            "internal": false,
+            "ipv6_enabled": false,
+            "name": "isolate4",
+            "network_interface": "isolate4",
+            "subnets": [
+                {
+                    "gateway": "10.89.3.1",
+                    "subnet": "10.89.3.0/24"
+                },
+                {
+                    "subnet": "fd93::/64",
+                    "gateway": "fd93::1"
+               }
+            ],
+            "options": {
+                "isolate": "strict"
+             }
+        }
+    }
+}


### PR DESCRIPTION
Currently, it appears that isolation is only enabled when both bridges are in isolate mode.  
This means that communication with networks that do not have isolate enabled is still possible.

What about using `isolate=strict` to deny communication with networks that do not have isolate enabled?  
Specifically, add a new chain of iptables and add a DROP rule to the chain for networks that do not have isolate enabled.

Here is a table showing the connectivity between networks before and after this change:

before:

```
|send\recv  |nonisol1   |nonisol1   |isol1      |isol2      |
|-----------|-----------|-----------|-----------|-----------|
|nonisol1   |     o     |     o     |     o     |     o     |
|nonisol2   |     o     |     o     |     o     |     o     |
|isol1      |     o     |     o     |     o     |     x     |
|isol2      |     o     |     o     |     x     |     o     |
```

after:

```
|send\recv  |nonisol1   |nonisol1   |isol1      |isol2      |strictisol1|strictisol2|
|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
|nonisol1   |     o     |     o     |     o     |     o     |     x     |     x     |
|nonisol2   |     o     |     o     |     o     |     o     |     x     |     x     |
|isol1      |     o     |     o     |     o     |     x     |     x     |     x     |
|isol2      |     o     |     o     |     x     |     o     |     x     |     x     |
|strictisol1|     x     |     x     |     x     |     x     |     o     |     x     |
|strictisol2|     x     |     x     |     x     |     x     |     x     |     o     |
```
