### PR TITLE
Bump to v1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "netavark"
-version = "1.5.1"
+version = "1.5.2-dev"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "netavark"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netavark"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netavark"
-version = "1.5.1"
+version = "1.5.2-dev"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"


### PR DESCRIPTION
Minor release for RHEL.
bclim option (https://github.com/containers/netavark/pull/699):
https://bugzilla.redhat.com/show_bug.cgi?id=2210111
https://bugzilla.redhat.com/show_bug.cgi?id=2210113

--dns-add no error without container (https://github.com/containers/netavark/pull/681):
https://bugzilla.redhat.com/show_bug.cgi?id=2210118
https://bugzilla.redhat.com/show_bug.cgi?id=2210117