### PR TITLE
netavark: make --config required for dns

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -32,7 +32,7 @@ impl Setup {
     pub fn exec(
         &self,
         input_file: Option<String>,
-        config_dir: &str,
+        config_dir: Option<String>,
         aardvark_bin: String,
         plugin_directories: Option<Vec<String>>,
         rootless: bool,
@@ -128,7 +128,14 @@ impl Setup {
 
         if !aardvark_entries.is_empty() {
             if Path::new(&aardvark_bin).exists() {
-                let path = Path::new(&config_dir).join("aardvark-dns");
+                let path = match config_dir {
+                    Some(dir) => Path::new(&dir).join("aardvark-dns"),
+                    None => {
+                        return Err(NetavarkError::msg(
+                            "dns is requested but --config not specified",
+                        ))
+                    }
+                };
 
                 match fs::create_dir(path.as_path()) {
                     Ok(_) => {}

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -28,14 +28,21 @@ impl Update {
 
     pub fn exec(
         &mut self,
-        config_dir: &str,
+        config_dir: Option<String>,
         aardvark_bin: String,
         rootless: bool,
     ) -> NetavarkResult<()> {
         let dns_port = core_utils::get_netavark_dns_port()?;
 
         if Path::new(&aardvark_bin).exists() {
-            let path = Path::new(&config_dir).join("aardvark-dns");
+            let path = match config_dir {
+                Some(dir) => Path::new(&dir).join("aardvark-dns"),
+                None => {
+                    return Err(NetavarkError::msg(
+                        "dns is requested but --config not specified",
+                    ))
+                }
+            };
             if let Ok(path_string) = path.into_os_string().into_string() {
                 let aardvark_interface =
                     Aardvark::new(path_string, rootless, aardvark_bin, dns_port);

--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -1,6 +1,4 @@
 use crate::error::{NetavarkError, NetavarkResult};
-use crate::network::constants::DRIVER_BRIDGE;
-use crate::network::types;
 
 use fs2::FileExt;
 use libc::pid_t;
@@ -403,20 +401,10 @@ impl Aardvark {
         Ok(())
     }
 
-    pub fn delete_from_netavark_entries(
-        &self,
-        network_options: &types::NetworkOptions,
-    ) -> NetavarkResult<()> {
-        let mut modified = false;
-        for (key, network) in &network_options.network_info {
-            if network.dns_enabled && network.driver == DRIVER_BRIDGE {
-                modified = true;
-                self.delete_entry(&network_options.container_id, key)?;
-            }
+    pub fn delete_from_netavark_entries(&self, entries: Vec<AardvarkEntry>) -> NetavarkResult<()> {
+        for entry in &entries {
+            self.delete_entry(entry.container_id, entry.network_name)?;
         }
-        if modified {
-            self.notify(false)?;
-        }
-        Ok(())
+        self.notify(false)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
     let opts = Opts::parse();
 
     // aardvark config directory must be supplied by parent or it defaults to /tmp/aardvark
-    let config = opts.config.as_deref().unwrap_or("/tmp");
+    let config = opts.config;
     let rootless = opts.rootless.unwrap_or(false);
     let aardvark_bin = opts
         .aardvark_binary

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -150,19 +150,7 @@ fw_driver=iptables
     # get a random port directly to avoid low ports e.g. 53 would not create iptables
     dns_port=$((RANDOM+10000))
 
-    # hack to make aardvark-dns run when really root or when running as user with
-    # podman unshare --rootless-netns; since netavark runs aardvark with systemd-run
-    # it needs to know if it should use systemd user instance or not.
-    # iptables are still setup identically.
-    rootless=false
-    if [[ ! -e "/run/dbus/system_bus_socket" ]]; then
-        rootless=true
-    fi
-
-    mkdir -p "$NETAVARK_TMPDIR/config"
-
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge-network-container-dns-server.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         setup $(get_container_netns_path)
 
     # check aardvark config and running
@@ -177,7 +165,6 @@ fw_driver=iptables
     assert "${lines[1]}" =~ ".*aardvark-dns --config $NETAVARK_TMPDIR/config/aardvark-dns -p $dns_port run" "aardvark not running or bad options"
 
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge-network-container-dns-server.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         update podman1 --network-dns-servers 8.8.8.8
 
     # check aardvark config and running
@@ -188,7 +175,6 @@ fw_driver=iptables
 
     # remove network and check running and verify if aardvark config has no nameserver
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge-network-container-dns-server.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         update podman1 --network-dns-servers ""
 
     # check aardvark config and running
@@ -204,14 +190,7 @@ fw_driver=iptables
     # get a random port directly to avoid low ports e.g. 53 would not create iptables
     dns_port=$((RANDOM+10000))
 
-    rootless=false
-    if [[ ! -e "/run/dbus/system_bus_socket" ]]; then
-        rootless=true
-    fi
-
-    mkdir -p "$NETAVARK_TMPDIR/config"
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge-network-container-dns-server.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         update podman1 --network-dns-servers 8.8.8.8
 }
 
@@ -281,19 +260,7 @@ fw_driver=iptables
     # get a random port directly to avoid low ports e.g. 53 would not create iptables
     dns_port=$((RANDOM+10000))
 
-    # hack to make aardvark-dns run when really root or when running as user with
-    # podman unshare --rootless-netns; since netavark runs aardvark with systemd-run
-    # it needs to know if it should use systemd user instance or not.
-    # iptables are still setup identically.
-    rootless=false
-    if [[ ! -e "/run/dbus/system_bus_socket" ]]; then
-        rootless=true
-    fi
-
-    mkdir -p "$NETAVARK_TMPDIR/config"
-
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge-custom-dns-server.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         setup $(get_container_netns_path)
 
     # check aardvark config and running
@@ -312,19 +279,7 @@ fw_driver=iptables
     # get a random port directly to avoid low ports e.g. 53 would not create iptables
     dns_port=$((RANDOM+10000))
 
-    # hack to make aardvark-dns run when really root or when running as user with
-    # podman unshare --rootless-netns; since netavark runs aardvark with systemd-run
-    # it needs to know if it should use systemd user instance or not.
-    # iptables are still setup identically.
-    rootless=false
-    if [[ ! -e "/run/dbus/system_bus_socket" ]]; then
-        rootless=true
-    fi
-
-    mkdir -p "$NETAVARK_TMPDIR/config"
-
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge-multiple-custom-dns-server.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         setup $(get_container_netns_path)
 
     # check aardvark config and running
@@ -343,19 +298,7 @@ fw_driver=iptables
     # get a random port directly to avoid low ports e.g. 53 would not create iptables
     dns_port=$((RANDOM+10000))
 
-    # hack to make aardvark-dns run when really root or when running as user with
-    # podman unshare --rootless-netns; since netavark runs aardvark with systemd-run
-    # it needs to know if it should use systemd user instance or not.
-    # iptables are still setup identically.
-    rootless=false
-    if [[ ! -e "/run/dbus/system_bus_socket" ]]; then
-        rootless=true
-    fi
-
-    mkdir -p "$NETAVARK_TMPDIR/config"
-
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge-network-container-dns-server.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         setup $(get_container_netns_path)
 
     # check aardvark config and running
@@ -374,19 +317,7 @@ fw_driver=iptables
     # get a random port directly to avoid low ports e.g. 53 would not create iptables
     dns_port=$((RANDOM+10000))
 
-    # hack to make aardvark-dns run when really root or when running as user with
-    # podman unshare --rootless-netns; since netavark runs aardvark with systemd-run
-    # it needs to know if it should use systemd user instance or not.
-    # iptables are still setup identically.
-    rootless=false
-    if [[ ! -e "/run/dbus/system_bus_socket" ]]; then
-        rootless=true
-    fi
-
-    mkdir -p "$NETAVARK_TMPDIR/config"
-
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         setup $(get_container_netns_path)
 
     # check iptables
@@ -415,7 +346,6 @@ fw_driver=iptables
     assert "${lines[0]}" =~ "10.89.3.2" "ipv6 dns resolution works"
 
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         teardown $(get_container_netns_path)
 
     # check iptables got removed

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -198,20 +198,8 @@ function teardown() {
     # get a random port directly to avoid low ports e.g. 53 would not create iptables
     dns_port=$((RANDOM+10000))
 
-    # hack to make aardvark-dns run when really root or when running as user with
-    # podman unshare --rootless-netns; since netavark runs aardvark with systemd-run
-    # it needs to know if it should use systemd user instance or not.
-    # iptables are still setup identically.
-    rootless=false
-    if [[ ! -e "/run/dbus/system_bus_socket" ]]; then
-        rootless=true
-    fi
-
-    mkdir -p "$NETAVARK_TMPDIR/config"
-
     NETAVARK_FW=firewalld NETAVARK_DNS_PORT="$dns_port" \
         run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         setup $(get_container_netns_path)
 
     # check iptables
@@ -242,7 +230,6 @@ function teardown() {
 
     NETAVARK_FW=firewalld NETAVARK_DNS_PORT="$dns_port" \
         run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
-        --rootless "$rootless" --config "$NETAVARK_TMPDIR/config" \
         teardown $(get_container_netns_path)
 
     # check iptables got removed


### PR DESCRIPTION
Using /tmp as default makes no sense, all callers that need dns should give us a proper path. Podman already does this so it should not cause any backwards compat problems.

I had to change the teardown logic a bit as we first need to confirm if we have network with dns before we should check if --config was given.

Also rework tests to always set --config to avoid code duplication.