### PR TITLE
Add ACCEPT rule in firewall for bridge network with internal dns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 .idea/*
 src/proto-build/netavark_proxy.rs
 contrib/systemd/*/*.service
+.vscode*

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -26,7 +26,11 @@ pub fn new(conn: Connection) -> Result<Box<dyn firewall::FirewallDriver>, Netava
 }
 
 impl firewall::FirewallDriver for FirewallD {
-    fn setup_network(&self, network_setup: internal_types::SetupNetwork) -> NetavarkResult<()> {
+    fn setup_network(
+        &self,
+        network_setup: internal_types::SetupNetwork,
+        _dns_port: u16,
+    ) -> NetavarkResult<()> {
         let mut need_reload = false;
 
         need_reload |= match create_zone_if_not_exist(&self.conn, ZONENAME) {

--- a/src/firewall/fwnone.rs
+++ b/src/firewall/fwnone.rs
@@ -12,7 +12,7 @@ pub fn new() -> NetavarkResult<Box<dyn firewall::FirewallDriver>> {
 }
 
 impl firewall::FirewallDriver for Fwnone {
-    fn setup_network(&self, _network_setup: SetupNetwork) -> NetavarkResult<()> {
+    fn setup_network(&self, _network_setup: SetupNetwork, _dns_port: u16) -> NetavarkResult<()> {
         Ok(())
     }
 

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -40,7 +40,7 @@ pub fn new() -> NetavarkResult<Box<dyn firewall::FirewallDriver>> {
 }
 
 impl firewall::FirewallDriver for IptablesDriver {
-    fn setup_network(&self, network_setup: SetupNetwork) -> NetavarkResult<()> {
+    fn setup_network(&self, network_setup: SetupNetwork, dns_port: u16) -> NetavarkResult<()> {
         let interface = match network_setup.net.network_interface {
             Some(iface) => iface,
             None => {
@@ -67,6 +67,7 @@ impl firewall::FirewallDriver for IptablesDriver {
                     is_ipv6,
                     interface.to_string(),
                     network_setup.isolation,
+                    dns_port,
                 );
 
                 create_network_chains(chains)?;
@@ -106,6 +107,7 @@ impl firewall::FirewallDriver for IptablesDriver {
                     is_ipv6,
                     interface.to_string(),
                     tear.config.isolation,
+                    tear.dns_port,
                 );
 
                 for c in &chains {

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -15,7 +15,7 @@ mod varktables;
 /// and port mappings.
 pub trait FirewallDriver {
     /// Set up firewall rules for the given network,
-    fn setup_network(&self, network_setup: SetupNetwork) -> NetavarkResult<()>;
+    fn setup_network(&self, network_setup: SetupNetwork, dns_port: u16) -> NetavarkResult<()>;
     /// Tear down firewall rules for the given network.
     fn teardown_network(&self, tear: TearDownNetwork) -> NetavarkResult<()>;
 

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -363,7 +363,7 @@ impl<'a> Bridge<'a> {
             data.isolate,
         )?;
 
-        self.info.firewall.setup_network(sn)?;
+        self.info.firewall.setup_network(sn, spf.dns_port)?;
 
         if spf.port_mappings.is_some() {
             // Need to enable sysctl localnet so that traffic can pass
@@ -414,6 +414,7 @@ impl<'a> Bridge<'a> {
 
         let tn = TearDownNetwork {
             config: sn,
+            dns_port: spf.dns_port,
             complete_teardown,
         };
 

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -24,6 +24,7 @@ pub struct SetupNetwork {
 #[derive(Debug)]
 pub struct TearDownNetwork {
     pub config: SetupNetwork,
+    pub dns_port: u16,
     pub complete_teardown: bool,
 }
 


### PR DESCRIPTION
When running container in non default podman network with dns enabled and default INPUT host firewall policy is DROP, name resolution does not work in container. To fix this, a firewall rule to allow dns traffic was added. 

Signed-off-by: Chetan Giradkar <cgiradka@redhat.com>