### PR TITLE
Add protoc dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Netavark is a tool for configuring networking for Linux containers. Its features
 - [go-md2man](https://github.com/cpuguy83/go-md2man)
 - [Rust](https://www.rust-lang.org/tools/install)
 - [Podman](https://podman.io/docs) 4.0+
+- [protoc](https://grpc.io/docs/protoc-installation/)
 
 ## Build
 


### PR DESCRIPTION
Without `protoc` installed, the `make` command fails looking for it.