### PR TITLE
bump nix to 0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
  "netlink-packet-utils",
  "netlink-sys",
  "nispor",
- "nix 0.26.2",
+ "nix 0.27.1",
  "once_cell",
  "prost",
  "rand",
@@ -1412,6 +1412,17 @@ dependencies = [
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = "1.0.106"
 sysctl = "0.5.4"
 url = "2.4.1"
 zbus = { version = "3.14.1" }
-nix = "0.26.2"
+nix = { version = "0.27.1", features = ["sched", "signal", "user"] }
 rand = "0.8.5"
 sha2 = "0.10.7"
 netlink-packet-utils = "0.5.2"

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -283,7 +283,10 @@ impl CoreUtils {
 }
 
 pub fn join_netns(fd: RawFd) -> NetavarkResult<()> {
-    match sched::setns(fd, sched::CloneFlags::CLONE_NEWNET) {
+    match sched::setns(
+        unsafe { BorrowedFd::borrow_raw(fd) },
+        sched::CloneFlags::CLONE_NEWNET,
+    ) {
         Ok(_) => Ok(()),
         Err(e) => Err(NetavarkError::wrap(
             "setns",


### PR DESCRIPTION
The nix crate removes all features by default so we need to explicitly list what we use.
Second, the io API's changed and all use the AsFd trait now. This is great for IO safety but will require larger changes to migrate from RawFd. Thus I went the easy way and use unsafe (not really unsafe here) and construct and a new File object (which impl AsFd) for the setns call.