### PR TITLE
rust io safety: convert RawFd to BorrowedFd<>

### DIFF
--- a/examples/host-device-plugin.rs
+++ b/examples/host-device-plugin.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::HashMap,
     net::{Ipv4Addr, Ipv6Addr},
+    os::fd::AsFd,
 };
 
 use netavark::{
@@ -80,7 +81,8 @@ impl Plugin for Exec {
             }
         }
 
-        host.netlink.set_link_ns(link.header.index, netns.fd)?;
+        host.netlink
+            .set_link_ns(link.header.index, netns.file.as_fd())?;
 
         // interfaces map, but we only ever expect one, for response
         let mut interfaces: HashMap<String, types::NetInterface> = HashMap::new();
@@ -113,7 +115,9 @@ impl Plugin for Exec {
 
         let link = netns.netlink.get_link(netlink::LinkID::Name(name))?;
 
-        netns.netlink.set_link_ns(link.header.index, host.fd)?;
+        netns
+            .netlink
+            .set_link_ns(link.header.index, host.file.as_fd())?;
 
         Ok(())
     }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -12,6 +12,7 @@ use clap::Parser;
 use log::{debug, error, info};
 use std::collections::HashMap;
 use std::fs::{self};
+use std::os::fd::AsFd;
 use std::path::Path;
 
 #[derive(Parser, Debug)]
@@ -75,8 +76,8 @@ impl Setup {
                     container_id: &network_options.container_id,
                     container_name: &network_options.container_name,
                     container_dns_servers: &network_options.dns_servers,
-                    netns_host: hostns.fd,
-                    netns_container: netns.fd,
+                    netns_host: hostns.file.as_fd(),
+                    netns_container: netns.file.as_fd(),
                     netns_path: &self.network_namespace_path,
                     network,
                     per_network_opts,

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -8,6 +8,7 @@ use crate::{firewall, network};
 use clap::builder::NonEmptyStringValueParser;
 use clap::Parser;
 use log::debug;
+use std::os::fd::AsFd;
 use std::path::Path;
 
 #[derive(Parser, Debug)]
@@ -105,8 +106,8 @@ impl Teardown {
                     container_id: &network_options.container_id,
                     container_name: &network_options.container_name,
                     container_dns_servers: &network_options.dns_servers,
-                    netns_host: hostns.fd,
-                    netns_container: netns.fd,
+                    netns_host: hostns.file.as_fd(),
+                    netns_container: netns.file.as_fd(),
                     netns_path: &self.network_namespace_path,
                     network,
                     per_network_opts,

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -4,7 +4,7 @@ use crate::{
     firewall::FirewallDriver,
 };
 
-use std::{net::IpAddr, path::Path};
+use std::{net::IpAddr, os::fd::BorrowedFd, path::Path};
 
 use super::{
     bridge::Bridge,
@@ -14,15 +14,14 @@ use super::{
     vlan::Vlan,
 };
 use std::os::unix::fs::PermissionsExt;
-use std::os::unix::io::RawFd;
 
 pub struct DriverInfo<'a> {
     pub firewall: &'a dyn FirewallDriver,
     pub container_id: &'a String,
     pub container_name: &'a String,
     pub container_dns_servers: &'a Option<Vec<IpAddr>>,
-    pub netns_host: RawFd,
-    pub netns_container: RawFd,
+    pub netns_host: BorrowedFd<'a>,
+    pub netns_container: BorrowedFd<'a>,
     pub netns_path: &'a str,
     pub network: &'a Network,
     pub per_network_opts: &'a PerNetworkOptions,


### PR DESCRIPTION
This is much safer because we no longer pass a single int around. With BorrowedFd<> the compiler will actually make sure the underlying file will not be closed before we use it.

I could have made every struct generic to accept the AsFd trait but that would have resulted in IMO more complex code without benefit.

Fixes #806