### PR TITLE
Update rust container build files

### DIFF
--- a/contrib/container_images/Dockerfile.Fedora
+++ b/contrib/container_images/Dockerfile.Fedora
@@ -1,2 +1,2 @@
-FROM registry.fedoraproject.org/fedora:38
+FROM registry.fedoraproject.org/fedora:39
 RUN dnf -y install cargo protobuf-compiler && dnf -y clean all

--- a/contrib/container_images/Dockerfile.UbuntuLatest
+++ b/contrib/container_images/Dockerfile.UbuntuLatest
@@ -1,2 +1,2 @@
-FROM docker.io/library/ubuntu:latest
+FROM docker.io/library/ubuntu:rolling
 RUN apt-get update && apt-get -y install cargo protobuf-compiler libprotobuf-dev


### PR DESCRIPTION
We need 1.67 and ubuntu:latest (which tracks LTS) still does not have it and there have been no updates to the image in 20 or more days.  Change from latest to rolling.

Update from fedora 38 to 39 and rename the Containerfile to exclude the fedora version.

when this PR merges, we need to update quay.io for the Fedora build.