### PR TITLE
Add firewalld reload service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.0.0",
  "futures-lite",
- "rustix 0.38.14",
+ "rustix 0.38.21",
  "windows-sys",
 ]
 
@@ -1137,7 +1137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.14",
+ "rustix 0.38.21",
  "windows-sys",
 ]
 
@@ -1185,9 +1185,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "log"
@@ -1323,6 +1323,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sysctl",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -1723,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1799,14 +1800,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.7",
+ "linux-raw-sys 0.4.11",
  "windows-sys",
 ]
 
@@ -2005,14 +2006,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall",
- "rustix 0.38.14",
+ "rustix 0.38.21",
  "windows-sys",
 ]
 
@@ -2431,7 +2432,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.14",
+ "rustix 0.38.21",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,4 @@ tonic-build = "0.10"
 [dev-dependencies]
 once_cell = "1.18.0"
 rand = "0.8.5"
+tempfile = "3.8.1"

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ client: bin $(CARGO_TARGET_DIR)
 docs: ## build the docs on the host
 	$(MAKE) -C docs
 
-NV_UNIT_FILES = contrib/systemd/system/netavark-dhcp-proxy.service
+NV_UNIT_FILES = contrib/systemd/system/netavark-dhcp-proxy.service \
+				contrib/systemd/system/netavark-firewalld-reload.service
 
 %.service: %.service.in
 	sed -e 's;@@NETAVARK@@;$(LIBEXECPODMAN)/netavark;g' $< >$@.tmp.$$ \
@@ -99,6 +100,7 @@ install: $(NV_UNIT_FILES)
 	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/netavark-dhcp-proxy.socket ${DESTDIR}${SYSTEMDDIR}/netavark-dhcp-proxy.socket
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/netavark-dhcp-proxy.service ${DESTDIR}${SYSTEMDDIR}/netavark-dhcp-proxy.service
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/netavark-firewalld-reload.service ${DESTDIR}${SYSTEMDDIR}/netavark-firewalld-reload.service
 
 .PHONY: uninstall
 uninstall:

--- a/contrib/systemd/system/netavark-firewalld-reload.service.in
+++ b/contrib/systemd/system/netavark-firewalld-reload.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Listen for the firewalld reload event and reapply all netavark firewall rules.
+# This causes systemd to stop this unit when firewalld is stopped.
+PartOf=firewalld.service
+After=firewalld.service
+
+[Service]
+ExecStart=@@NETAVARK@@ firewalld-reload
+
+[Install]
+# If the unit is enabled add a wants to firewalld so it is only started when firewalld is started.
+WantedBy=firewalld.service

--- a/rpm/netavark.spec
+++ b/rpm/netavark.spec
@@ -107,9 +107,11 @@ cd docs
 
 %preun
 %systemd_preun %{name}-dhcp-proxy.service
+%systemd_preun %{name}-firewalld-reload.service
 
 %postun
 %systemd_postun %{name}-dhcp-proxy.service
+%systemd_postun %{name}-firewalld-reload.service
 
 %files
 %license LICENSE
@@ -118,6 +120,7 @@ cd docs
 %{_mandir}/man1/%{name}.1*
 %{_unitdir}/%{name}-dhcp-proxy.service
 %{_unitdir}/%{name}-dhcp-proxy.socket
+%{_unitdir}/%{name}-firewalld-reload.service
 
 %changelog
 %if %{defined autochangelog}

--- a/src/commands/firewalld_reload.rs
+++ b/src/commands/firewalld_reload.rs
@@ -1,0 +1,32 @@
+use zbus::{blocking::Connection, dbus_proxy, CacheProperties};
+
+use crate::error::NetavarkResult;
+
+#[dbus_proxy(
+    interface = "org.fedoraproject.FirewallD1",
+    default_service = "org.fedoraproject.FirewallD1",
+    default_path = "/org/fedoraproject/FirewallD1"
+)]
+trait FirewallDDbus {}
+
+const SIGNAL_NAME: &str = "Reloaded";
+
+pub fn listen(_config_dir: Option<String>) -> NetavarkResult<()> {
+    // Setup fw rules on start because we are started after firewalld
+    // this means at the time firewalld stated the fw rules were flushed
+    // and we need to add them back.
+
+    // TODO add rules here
+
+    let conn = Connection::system()?;
+    let proxy = FirewallDDbusProxyBlocking::builder(&conn)
+        .cache_properties(CacheProperties::No)
+        .build()?;
+
+    for _ in proxy.receive_signal(SIGNAL_NAME)? {
+        log::debug!("got firewalld reload signal");
+        // TODO add rules here
+    }
+
+    Ok(())
+}

--- a/src/commands/firewalld_reload.rs
+++ b/src/commands/firewalld_reload.rs
@@ -1,6 +1,10 @@
 use zbus::{blocking::Connection, dbus_proxy, CacheProperties};
 
-use crate::error::NetavarkResult;
+use crate::{
+    error::{ErrorWrap, NetavarkResult},
+    firewall::{get_supported_firewall_driver, state::read_fw_config},
+    network::constants,
+};
 
 #[dbus_proxy(
     interface = "org.fedoraproject.FirewallD1",
@@ -11,21 +15,47 @@ trait FirewallDDbus {}
 
 const SIGNAL_NAME: &str = "Reloaded";
 
-pub fn listen(_config_dir: Option<String>) -> NetavarkResult<()> {
-    // Setup fw rules on start because we are started after firewalld
-    // this means at the time firewalld stated the fw rules were flushed
-    // and we need to add them back.
-
-    // TODO add rules here
+pub fn listen(config_dir: Option<String>) -> NetavarkResult<()> {
+    let config_dir = config_dir
+        .as_deref()
+        .unwrap_or(constants::DEFAULT_CONFIG_DIR);
+    log::debug!("looking for firewall configs in {}", config_dir);
 
     let conn = Connection::system()?;
     let proxy = FirewallDDbusProxyBlocking::builder(&conn)
         .cache_properties(CacheProperties::No)
         .build()?;
 
+    // Setup fw rules on start because we are started after firewalld
+    // this means at the time firewalld stated the fw rules were flushed
+    // and we need to add them back.
+    // It is important to keep things like "systemctl restart firewalld" working.
+    reload_rules(config_dir);
+
+    // This loops forever until the process is killed or there is some dbus error.
     for _ in proxy.receive_signal(SIGNAL_NAME)? {
-        log::debug!("got firewalld reload signal");
-        // TODO add rules here
+        log::debug!("got firewalld {} signal", SIGNAL_NAME);
+        reload_rules(config_dir);
+    }
+
+    Ok(())
+}
+
+fn reload_rules(config_dir: &str) {
+    if let Err(e) = reload_rules_inner(config_dir) {
+        log::error!("failed to reload firewall rules: {e}");
+    }
+}
+
+fn reload_rules_inner(config_dir: &str) -> NetavarkResult<()> {
+    let conf = read_fw_config(config_dir).wrap("read firewall config")?;
+    let fw_driver = get_supported_firewall_driver(Some(conf.driver))?;
+
+    for net in conf.net_confs {
+        fw_driver.setup_network(net)?;
+    }
+    for port in &conf.port_confs {
+        fw_driver.setup_port_forward(port.into())?;
     }
 
     Ok(())

--- a/src/commands/firewalld_reload.rs
+++ b/src/commands/firewalld_reload.rs
@@ -49,13 +49,17 @@ fn reload_rules(config_dir: &str) {
 
 fn reload_rules_inner(config_dir: &str) -> NetavarkResult<()> {
     let conf = read_fw_config(config_dir).wrap("read firewall config")?;
-    let fw_driver = get_supported_firewall_driver(Some(conf.driver))?;
+    // If we got no conf there are no containers so nothing to do.
+    if let Some(conf) = conf {
+        let fw_driver = get_supported_firewall_driver(Some(conf.driver))?;
 
-    for net in conf.net_confs {
-        fw_driver.setup_network(net)?;
-    }
-    for port in &conf.port_confs {
-        fw_driver.setup_port_forward(port.into())?;
+        for net in conf.net_confs {
+            fw_driver.setup_network(net)?;
+        }
+        for port in &conf.port_confs {
+            fw_driver.setup_port_forward(port.into())?;
+        }
+        log::info!("Successfully reloaded firewall rules");
     }
 
     Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod dhcp_proxy;
+pub mod firewalld_reload;
 pub mod setup;
 pub mod teardown;
 pub mod update;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,17 @@
+use crate::error::{NetavarkError, NetavarkResult};
+
 pub mod dhcp_proxy;
 pub mod firewalld_reload;
 pub mod setup;
 pub mod teardown;
 pub mod update;
 pub mod version;
+
+fn get_config_dir(dir: Option<String>, cmd: &str) -> NetavarkResult<String> {
+    dir.ok_or_else(|| {
+        NetavarkError::msg(format!(
+            "--config not specified but required for netavark {}",
+            cmd
+        ))
+    })
+}

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,3 +1,4 @@
+use crate::commands::get_config_dir;
 use crate::dns::aardvark::Aardvark;
 use crate::error::{NetavarkError, NetavarkResult};
 use crate::network::core_utils;
@@ -33,16 +34,9 @@ impl Update {
         rootless: bool,
     ) -> NetavarkResult<()> {
         let dns_port = core_utils::get_netavark_dns_port()?;
-
+        let config_dir = get_config_dir(config_dir, "update")?;
         if Path::new(&aardvark_bin).exists() {
-            let path = match config_dir {
-                Some(dir) => Path::new(&dir).join("aardvark-dns"),
-                None => {
-                    return Err(NetavarkError::msg(
-                        "dns is requested but --config not specified",
-                    ))
-                }
-            };
+            let path = Path::new(&config_dir).join("aardvark-dns");
             if let Ok(path_string) = path.into_os_string().into_string() {
                 let aardvark_interface =
                     Aardvark::new(path_string, rootless, aardvark_bin, dns_port);

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -26,11 +26,7 @@ pub fn new(conn: Connection) -> Result<Box<dyn firewall::FirewallDriver>, Netava
 }
 
 impl firewall::FirewallDriver for FirewallD {
-    fn setup_network(
-        &self,
-        network_setup: internal_types::SetupNetwork,
-        _dns_port: u16,
-    ) -> NetavarkResult<()> {
+    fn setup_network(&self, network_setup: internal_types::SetupNetwork) -> NetavarkResult<()> {
         let mut need_reload = false;
 
         need_reload |= match create_zone_if_not_exist(&self.conn, ZONENAME) {

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -26,6 +26,10 @@ pub fn new(conn: Connection) -> Result<Box<dyn firewall::FirewallDriver>, Netava
 }
 
 impl firewall::FirewallDriver for FirewallD {
+    fn driver_name(&self) -> &str {
+        firewall::FIREWALLD
+    }
+
     fn setup_network(&self, network_setup: internal_types::SetupNetwork) -> NetavarkResult<()> {
         let mut need_reload = false;
 

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -469,7 +469,7 @@ fn create_zone_if_not_exist(conn: &Connection, zone_name: &str) -> NetavarkResul
             ))
         }
     };
-    for (_, &zone) in zones.iter().enumerate() {
+    for &zone in zones.iter() {
         if zone == zone_name {
             debug!("Zone exists and is running");
             return Ok(false);
@@ -493,7 +493,7 @@ fn create_zone_if_not_exist(conn: &Connection, zone_name: &str) -> NetavarkResul
             ))
         }
     };
-    for (_, &zone) in zones_perm.iter().enumerate() {
+    for &zone in zones_perm.iter() {
         if zone == zone_name {
             debug!("Zone exists and is not running");
             return Ok(true);
@@ -589,7 +589,7 @@ fn add_policy_if_not_exist(
             ))
         }
     };
-    for (_, &policy) in policies.iter().enumerate() {
+    for &policy in policies.iter() {
         if policy == policy_name {
             debug!("Policy exists and is running");
             return Ok(false);
@@ -613,7 +613,7 @@ fn add_policy_if_not_exist(
             ))
         }
     };
-    for (_, &policy) in perm_policies.iter().enumerate() {
+    for &policy in perm_policies.iter() {
         if policy == policy_name {
             debug!("Policy exists and is not running");
             return Ok(true);

--- a/src/firewall/fwnone.rs
+++ b/src/firewall/fwnone.rs
@@ -12,7 +12,7 @@ pub fn new() -> NetavarkResult<Box<dyn firewall::FirewallDriver>> {
 }
 
 impl firewall::FirewallDriver for Fwnone {
-    fn setup_network(&self, _network_setup: SetupNetwork, _dns_port: u16) -> NetavarkResult<()> {
+    fn setup_network(&self, _network_setup: SetupNetwork) -> NetavarkResult<()> {
         Ok(())
     }
 

--- a/src/firewall/fwnone.rs
+++ b/src/firewall/fwnone.rs
@@ -12,6 +12,10 @@ pub fn new() -> NetavarkResult<Box<dyn firewall::FirewallDriver>> {
 }
 
 impl firewall::FirewallDriver for Fwnone {
+    fn driver_name(&self) -> &str {
+        firewall::NONE
+    }
+
     fn setup_network(&self, _network_setup: SetupNetwork) -> NetavarkResult<()> {
         Ok(())
     }

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -40,7 +40,7 @@ pub fn new() -> NetavarkResult<Box<dyn firewall::FirewallDriver>> {
 }
 
 impl firewall::FirewallDriver for IptablesDriver {
-    fn setup_network(&self, network_setup: SetupNetwork, dns_port: u16) -> NetavarkResult<()> {
+    fn setup_network(&self, network_setup: SetupNetwork) -> NetavarkResult<()> {
         let interface = match network_setup.net.network_interface {
             Some(iface) => iface,
             None => {
@@ -67,7 +67,7 @@ impl firewall::FirewallDriver for IptablesDriver {
                     is_ipv6,
                     interface.to_string(),
                     network_setup.isolation,
-                    dns_port,
+                    network_setup.dns_port,
                 );
 
                 create_network_chains(chains)?;
@@ -107,7 +107,7 @@ impl firewall::FirewallDriver for IptablesDriver {
                     is_ipv6,
                     interface.to_string(),
                     tear.config.isolation,
-                    tear.dns_port,
+                    tear.config.dns_port,
                 );
 
                 for c in &chains {

--- a/src/firewall/iptables.rs
+++ b/src/firewall/iptables.rs
@@ -39,6 +39,10 @@ pub fn new() -> NetavarkResult<Box<dyn firewall::FirewallDriver>> {
 }
 
 impl firewall::FirewallDriver for IptablesDriver {
+    fn driver_name(&self) -> &str {
+        firewall::IPTABLES
+    }
+
     fn setup_network(&self, network_setup: SetupNetwork) -> NetavarkResult<()> {
         if let Some(subnet) = network_setup.subnets {
             for network in subnet {

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -9,6 +9,7 @@ use zbus::blocking::Connection;
 pub mod firewalld;
 pub mod fwnone;
 pub mod iptables;
+pub mod state;
 mod varktables;
 
 /// Firewall drivers have the ability to set up per-network firewall forwarding

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -15,7 +15,7 @@ mod varktables;
 /// and port mappings.
 pub trait FirewallDriver {
     /// Set up firewall rules for the given network,
-    fn setup_network(&self, network_setup: SetupNetwork, dns_port: u16) -> NetavarkResult<()>;
+    fn setup_network(&self, network_setup: SetupNetwork) -> NetavarkResult<()>;
     /// Tear down firewall rules for the given network.
     fn teardown_network(&self, tear: TearDownNetwork) -> NetavarkResult<()>;
 

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -12,6 +12,11 @@ pub mod iptables;
 pub mod state;
 mod varktables;
 
+const IPTABLES: &str = "iptables";
+const FIREWALLD: &str = "firewalld";
+const NFTABLES: &str = "nftables";
+const NONE: &str = "none";
+
 /// Firewall drivers have the ability to set up per-network firewall forwarding
 /// and port mappings.
 pub trait FirewallDriver {
@@ -24,6 +29,9 @@ pub trait FirewallDriver {
     fn setup_port_forward(&self, setup_pw: PortForwardConfig) -> NetavarkResult<()>;
     /// Tear down port-forwarding firewall rules for a single container.
     fn teardown_port_forward(&self, teardown_pf: TeardownPortForward) -> NetavarkResult<()>;
+
+    /// Return the name of the driver.
+    fn driver_name(&self) -> &str;
 }
 
 /// Types of firewall backend
@@ -35,13 +43,16 @@ enum FirewallImpl {
 }
 
 /// What firewall implementations does this system support?
-fn get_firewall_impl() -> NetavarkResult<FirewallImpl> {
-    // First, check the NETAVARK_FW env var.
+fn get_firewall_impl(driver_name: Option<String>) -> NetavarkResult<FirewallImpl> {
     // It respects "firewalld", "iptables", "nftables", "none".
-    if let Ok(var) = env::var("NETAVARK_FW") {
+
+    // If not requested lookup in NETAVARK_FW env var as well.
+    let driver = driver_name.or_else(|| env::var("NETAVARK_FW").ok());
+
+    if let Some(var) = driver {
         debug!("Forcibly using firewall driver {}", var);
         match var.to_lowercase().as_str() {
-            "firewalld" => {
+            FIREWALLD => {
                 let conn = match Connection::system() {
                     Ok(c) => c,
                     Err(e) => {
@@ -53,9 +64,9 @@ fn get_firewall_impl() -> NetavarkResult<FirewallImpl> {
                 };
                 return Ok(FirewallImpl::Firewalld(conn));
             }
-            "iptables" => return Ok(FirewallImpl::Iptables),
-            "nftables" => return Ok(FirewallImpl::Nftables),
-            "none" => return Ok(FirewallImpl::Fwnone),
+            IPTABLES => return Ok(FirewallImpl::Iptables),
+            NFTABLES => return Ok(FirewallImpl::Nftables),
+            NONE => return Ok(FirewallImpl::Fwnone),
             any => {
                 return Err(NetavarkError::Message(format!(
                     "Must provide a valid firewall backend, got {any}"
@@ -87,8 +98,10 @@ fn get_firewall_impl() -> NetavarkResult<FirewallImpl> {
 
 /// Get the preferred firewall implementation for the current system
 /// configuration.
-pub fn get_supported_firewall_driver() -> NetavarkResult<Box<dyn FirewallDriver>> {
-    match get_firewall_impl() {
+pub fn get_supported_firewall_driver(
+    driver_name: Option<String>,
+) -> NetavarkResult<Box<dyn FirewallDriver>> {
+    match get_firewall_impl(driver_name) {
         Ok(fw) => match fw {
             FirewallImpl::Iptables => {
                 info!("Using iptables firewall driver");

--- a/src/firewall/state.rs
+++ b/src/firewall/state.rs
@@ -1,0 +1,227 @@
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{ErrorKind, Write},
+    path::{Path, PathBuf},
+};
+
+use serde::de::DeserializeOwned;
+
+use crate::{
+    error::NetavarkResult,
+    network::internal_types::{PortForwardConfig, PortForwardConfigOwned, SetupNetwork},
+};
+
+/// File layout looks like this
+/// $config/firewall/
+///                 - firewall-driver -> name of the firewall driver
+///                 - networks/$netID -> network config setup
+///                 - ports/$netID_$conID -> port config
+
+const FIREWALL_DIR: &str = "firewall";
+const FIREWALL_DRIVER_FILE: &str = "firewall-driver";
+const NETWORK_CONF_DIR: &str = "networks";
+const PORT_CONF_DIR: &str = "ports";
+
+struct FilePaths {
+    fw_driver_file: PathBuf,
+    net_conf_file: PathBuf,
+    port_conf_file: PathBuf,
+}
+
+fn firewall_config_dir(config_dir: &str) -> PathBuf {
+    Path::new(config_dir).join(FIREWALL_DIR)
+}
+
+/// Assemble file paths for the config files, when create_dirs is set to true
+/// it will create the parent dirs as well so the caller does not have to.
+///
+/// As a special case when network_id and container_id is empty it will return
+/// the paths for the directories instead which are used to walk the dir for all configs.
+fn get_file_paths(
+    config_dir: &str,
+    network_id: &str,
+    container_id: &str,
+    create_dirs: bool,
+) -> NetavarkResult<FilePaths> {
+    let path = firewall_config_dir(config_dir);
+    let fw_driver_file = path.join(FIREWALL_DRIVER_FILE);
+    let mut net_conf_file = path.join(NETWORK_CONF_DIR);
+    let mut port_conf_file = path.join(PORT_CONF_DIR);
+
+    if create_dirs {
+        fs::create_dir_all(path)?;
+        fs::create_dir_all(&net_conf_file)?;
+        fs::create_dir_all(&port_conf_file)?;
+    }
+    if !network_id.is_empty() && !container_id.is_empty() {
+        net_conf_file.push(network_id);
+        port_conf_file.push(network_id.to_string() + "_" + container_id);
+    }
+
+    Ok(FilePaths {
+        fw_driver_file,
+        net_conf_file,
+        port_conf_file,
+    })
+}
+
+/// Store the firewall configs on disk.
+/// This should be caller after firewall setup to allow the firewalld reload
+/// service to read the configs later and readd the rules.
+pub fn write_fw_config(
+    config_dir: &str,
+    network_id: &str,
+    container_id: &str,
+    fw_driver: &str,
+    net_conf: &SetupNetwork,
+    port_conf: &PortForwardConfig,
+) -> NetavarkResult<()> {
+    let paths = get_file_paths(config_dir, network_id, container_id, true)?;
+    File::create(paths.fw_driver_file)?.write_all(fw_driver.as_bytes())?;
+
+    match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(paths.net_conf_file)
+    {
+        Ok(f) => serde_json::to_writer(f, &net_conf)?,
+        Err(ref e) if e.kind() == ErrorKind::AlreadyExists => (),
+        Err(e) => {
+            return Err(e.into());
+        }
+    };
+
+    let ports_file = File::create(paths.port_conf_file)?;
+    serde_json::to_writer(ports_file, &port_conf)?;
+
+    Ok(())
+}
+
+/// Remove firewall config files.
+/// On firewall teardown remove the specific config files again so the
+/// firewalld reload service does not keep using them.
+pub fn remove_fw_config(
+    config_dir: &str,
+    network_id: &str,
+    container_id: &str,
+    complete_teardown: bool,
+) -> NetavarkResult<()> {
+    let paths = get_file_paths(config_dir, network_id, container_id, false)?;
+    fs::remove_file(paths.port_conf_file)?;
+    if complete_teardown {
+        fs::remove_file(paths.net_conf_file)?;
+    }
+    Ok(())
+}
+
+pub struct FirewallConfig {
+    /// Name of the firewall driver
+    pub driver: String,
+    /// All the network firewall configs
+    pub net_confs: Vec<SetupNetwork>,
+    /// All port forwarding configs
+    pub port_confs: Vec<PortForwardConfigOwned>,
+}
+
+/// Read all firewall configs files from the dir.
+pub fn read_fw_config(config_dir: &str) -> NetavarkResult<FirewallConfig> {
+    let paths = get_file_paths(config_dir, "", "", false)?;
+
+    let driver = fs::read_to_string(paths.fw_driver_file)?;
+
+    let net_confs = read_dir_conf(paths.net_conf_file)?;
+    let port_confs = read_dir_conf(paths.port_conf_file)?;
+
+    Ok(FirewallConfig {
+        driver,
+        net_confs,
+        port_confs,
+    })
+}
+
+fn read_dir_conf<T: DeserializeOwned>(dir: PathBuf) -> NetavarkResult<Vec<T>> {
+    let mut confs = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let content = fs::read_to_string(entry.path())?;
+        // Note one might think we should use from_reader() instated of reading
+        // into one string. However the files we act on are small enough that it
+        // should't matter to have the content into memory at once and based on
+        // https://github.com/serde-rs/json/issues/160 this here is much faster.
+        let conf: T = serde_json::from_str(&content)?;
+        confs.push(conf);
+    }
+    Ok(confs)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use crate::network::internal_types::IsolateOption;
+
+    use super::*;
+    use tempfile::Builder;
+
+    #[test]
+    fn test_fw_config() {
+        let network_id = "abc";
+        let container_id = "123";
+        let driver = "iptables";
+
+        let tmpdir = Builder::new().prefix("netavark-tests").tempdir().unwrap();
+        let config_dir = tmpdir.path().to_str().unwrap();
+
+        let net_conf = SetupNetwork {
+            subnets: Some(vec!["10.0.0.0/24".parse().unwrap()]),
+            bridge_name: "bridge".to_string(),
+            network_hash_name: "hash".to_string(),
+            isolation: IsolateOption::Never,
+            dns_port: 53,
+        };
+        let net_conf_json = r#"{"subnets":["10.0.0.0/24"],"bridge_name":"bridge","network_hash_name":"hash","isolation":"Never","dns_port":53}"#;
+
+        let port_conf = PortForwardConfig {
+            container_id: container_id.to_string(),
+            port_mappings: &None,
+            network_name: "name".to_string(),
+            network_hash_name: "hash".to_string(),
+            container_ip_v4: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))),
+            subnet_v4: Some("10.0.0.0/24".parse().unwrap()),
+            container_ip_v6: None,
+            subnet_v6: None,
+            dns_port: 53,
+            dns_server_ips: &vec![],
+        };
+        let port_conf_json = r#"{"container_id":"123","port_mappings":null,"network_name":"name","network_hash_name":"hash","container_ip_v4":"10.0.0.2","subnet_v4":"10.0.0.0/24","container_ip_v6":null,"subnet_v6":null,"dns_port":53,"dns_server_ips":[]}"#;
+
+        let res = write_fw_config(
+            config_dir,
+            network_id,
+            container_id,
+            driver,
+            &net_conf,
+            &port_conf,
+        );
+
+        assert!(res.is_ok(), "write_fw_config failed");
+
+        let paths = get_file_paths(config_dir, network_id, container_id, false).unwrap();
+
+        let res = fs::read_to_string(paths.fw_driver_file).unwrap();
+        assert_eq!(res, "iptables", "read fw driver");
+
+        let res = fs::read_to_string(paths.net_conf_file).unwrap();
+        assert_eq!(res, net_conf_json, "read net conf");
+
+        let res = fs::read_to_string(paths.port_conf_file).unwrap();
+        assert_eq!(res, port_conf_json, "read port conf");
+
+        let res = read_fw_config(config_dir).unwrap();
+        assert_eq!(res.driver, driver, "correct fw driver");
+        assert_eq!(res.net_confs, vec![net_conf], "same net configs");
+        let port_confs_ref: Vec<PortForwardConfig> =
+            res.port_confs.iter().map(|f| f.into()).collect();
+        assert_eq!(port_confs_ref, vec![port_conf], "same port configs");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 
 use netavark::commands::dhcp_proxy;
+use netavark::commands::firewalld_reload;
 use netavark::commands::setup;
 use netavark::commands::teardown;
 use netavark::commands::update;
@@ -41,6 +42,9 @@ enum SubCommand {
     Version(version::Version),
     /// Start dhcp-proxy
     DHCPProxy(dhcp_proxy::Opts),
+    /// Listen for the firewalld reload event and reload fw rules
+    #[command(name = "firewalld-reload")]
+    FirewallDReload,
 }
 
 fn main() {
@@ -71,6 +75,7 @@ fn main() {
         SubCommand::Update(mut update) => update.exec(config, aardvark_bin, rootless),
         SubCommand::Version(version) => version.exec(),
         SubCommand::DHCPProxy(proxy) => dhcp_proxy::serve(proxy),
+        SubCommand::FirewallDReload => firewalld_reload::listen(config),
     };
 
     match result {

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -316,6 +316,7 @@ impl<'a> Bridge<'a> {
             net: self.info.network.clone(),
             network_hash_name: id_network_hash.clone(),
             isolation: isolate,
+            dns_port: self.info.dns_port,
         };
 
         let mut has_ipv4 = false;
@@ -367,7 +368,7 @@ impl<'a> Bridge<'a> {
             data.isolate,
         )?;
 
-        self.info.firewall.setup_network(sn, spf.dns_port)?;
+        self.info.firewall.setup_network(sn)?;
 
         if spf.port_mappings.is_some() {
             // Need to enable sysctl localnet so that traffic can pass
@@ -418,7 +419,6 @@ impl<'a> Bridge<'a> {
 
         let tn = TearDownNetwork {
             config: sn,
-            dns_port: spf.dns_port,
             complete_teardown,
         };
 

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -255,10 +255,12 @@ impl driver::NetworkDriver for Bridge<'_> {
                 .unwrap_or_else(|err| error_list.push(err))
         }
 
+        let bridge_name = get_interface_name(self.info.network.network_interface.clone())?;
+
         let complete_teardown = match remove_link(
             host_sock,
             netns_sock,
-            &get_interface_name(self.info.network.network_interface.clone())?,
+            &bridge_name,
             &self.info.per_network_opts.interface_name,
         ) {
             Ok(teardown) => teardown,
@@ -275,7 +277,7 @@ impl driver::NetworkDriver for Bridge<'_> {
             return Ok(());
         }
 
-        match self.teardown_firewall(complete_teardown) {
+        match self.teardown_firewall(complete_teardown, bridge_name) {
             Ok(_) => {}
             Err(err) => {
                 error_list.push(err);
@@ -309,11 +311,18 @@ impl<'a> Bridge<'a> {
         container_addresses: &Vec<IpNet>,
         nameservers: &'a Vec<IpAddr>,
         isolate: IsolateOption,
+        bridge_name: String,
     ) -> NetavarkResult<(SetupNetwork, PortForwardConfig)> {
         let id_network_hash =
             CoreUtils::create_network_hash(&self.info.network.name, MAX_HASH_SIZE);
         let sn = SetupNetwork {
-            net: self.info.network.clone(),
+            subnets: self
+                .info
+                .network
+                .subnets
+                .as_ref()
+                .map(|nets| nets.iter().map(|n| n.subnet).collect()),
+            bridge_name,
             network_hash_name: id_network_hash.clone(),
             isolation: isolate,
             dns_port: self.info.dns_port,
@@ -366,6 +375,7 @@ impl<'a> Bridge<'a> {
             &data.ipam.container_addresses,
             &data.ipam.nameservers,
             data.isolate,
+            data.bridge_interface_name.clone(),
         )?;
 
         self.info.firewall.setup_network(sn)?;
@@ -387,7 +397,11 @@ impl<'a> Bridge<'a> {
         Ok(())
     }
 
-    fn teardown_firewall(&self, complete_teardown: bool) -> NetavarkResult<()> {
+    fn teardown_firewall(
+        &self,
+        complete_teardown: bool,
+        bridge_name: String,
+    ) -> NetavarkResult<()> {
         // we have to allocate the vecoros here in the top level to avoid
         // "borrow later used" problems
         let (container_addresses, nameservers);
@@ -414,8 +428,12 @@ impl<'a> Bridge<'a> {
             }
         };
 
-        let (sn, spf) =
-            self.get_firewall_conf(container_addresses_ref, nameservers_ref, isolate)?;
+        let (sn, spf) = self.get_firewall_conf(
+            container_addresses_ref,
+            nameservers_ref,
+            isolate,
+            bridge_name,
+        )?;
 
         let tn = TearDownNetwork {
             config: sn,

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -28,4 +28,5 @@ pub const DEFAULT_METRIC: u32 = 100;
 
 pub const NO_CONTAINER_INTERFACE_ERROR: &str = "no container interface name given";
 
+/// make sure this is the same rootful default as used in podman.
 pub const DEFAULT_CONFIG_DIR: &str = "/run/containers/networks";

--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -27,3 +27,5 @@ pub const OPTION_VRF: &str = "vrf";
 pub const DEFAULT_METRIC: u32 = 100;
 
 pub const NO_CONTAINER_INTERFACE_ERROR: &str = "no container interface name given";
+
+pub const DEFAULT_CONFIG_DIR: &str = "/run/containers/networks";

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -27,6 +27,8 @@ pub struct DriverInfo<'a> {
     pub per_network_opts: &'a PerNetworkOptions,
     pub port_mappings: &'a Option<Vec<PortMapping>>,
     pub dns_port: u16,
+    pub config_dir: &'a str,
+    pub rootless: bool,
 }
 
 pub trait NetworkDriver {

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -13,8 +13,10 @@ pub struct TeardownPortForward<'a> {
 /// SetupNetwork contains options for setting up a container
 #[derive(Debug)]
 pub struct SetupNetwork {
-    /// network object
-    pub net: types::Network,
+    /// subnets used for this network
+    pub subnets: Option<Vec<ipnet::IpNet>>,
+    /// bridge interface name
+    pub bridge_name: String,
     /// hash id for the network
     pub network_hash_name: String,
     /// isolation determines whether the network can communicate with others outside of its interface

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -19,12 +19,13 @@ pub struct SetupNetwork {
     pub network_hash_name: String,
     /// isolation determines whether the network can communicate with others outside of its interface
     pub isolation: IsolateOption,
+    /// port used for the dns server
+    pub dns_port: u16,
 }
 
 #[derive(Debug)]
 pub struct TearDownNetwork {
     pub config: SetupNetwork,
-    pub dns_port: u16,
     pub complete_teardown: bool,
 }
 

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -115,7 +115,7 @@ pub struct PerNetworkOptions {
 }
 
 /// PortMapping is one or more ports that will be mapped into the container.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PortMapping {
     /// ContainerPort is the port number that will be exposed from the
     /// container.


### PR DESCRIPTION
Add a new service command which listens on for the firewalld reload dbus event and then re-adds all firewall rules back.
The unit file is written so that it is only started and stopped with firewalld so it never runs unless needed. The new unit is called netavark-firewalld-reload.service.
Tests have been added to ensure it is working as expected.

This required more changes that I would have liked but it is important to only write the minimal firewall config to disk to not waste memory as the config dir is on tmpfs.

Fixes https://issues.redhat.com/browse/RHEL-3079