### PR TITLE
firewalld-reload: prevent race which could leak fw rules

### DIFF
--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -455,6 +455,7 @@ impl<'a> Bridge<'a> {
         };
 
         if !self.info.rootless {
+            // IMPORTANT: This must happen before we actually teardown rules.
             remove_fw_config(
                 self.info.config_dir,
                 &self.info.network.id,


### PR DESCRIPTION
There is a small possibility that the reload service could add fw rules after the container was teardown and thus leak them forever.

Consider this case if both processes run in parallel:

| netavark fw reload service  |  netavark teardown |
|-----------------------------|--------------------|
| read fw config              |                    |
|                             | remove fw config   |
|                             | remove fw rules    |
| add fw rules                |                    |

In order to prevent the race, this commit adds a lock file to ensure that it is not possible to add/remove fw configs while the reload service is doing it's thing.