### PR TITLE
use OsString/Path over String for file paths

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsString;
+
 use crate::error::{NetavarkError, NetavarkResult};
 
 pub mod dhcp_proxy;
@@ -7,7 +9,7 @@ pub mod teardown;
 pub mod update;
 pub mod version;
 
-fn get_config_dir(dir: Option<String>, cmd: &str) -> NetavarkResult<String> {
+fn get_config_dir(dir: Option<OsString>, cmd: &str) -> NetavarkResult<OsString> {
     dir.ok_or_else(|| {
         NetavarkError::msg(format!(
             "--config not specified but required for netavark {}",

--- a/src/firewall/state.rs
+++ b/src/firewall/state.rs
@@ -68,7 +68,7 @@ fn remove_file_ignore_enoent<P: AsRef<Path>>(path: P) -> io::Result<()> {
     }
 }
 
-fn firewall_config_dir(config_dir: &str) -> PathBuf {
+fn firewall_config_dir(config_dir: &Path) -> PathBuf {
     Path::new(config_dir).join(FIREWALL_DIR)
 }
 
@@ -78,7 +78,7 @@ fn firewall_config_dir(config_dir: &str) -> PathBuf {
 /// As a special case when network_id and container_id is empty it will return
 /// the paths for the directories instead which are used to walk the dir for all configs.
 fn get_file_paths(
-    config_dir: &str,
+    config_dir: &Path,
     network_id: &str,
     container_id: &str,
     create_dirs: bool,
@@ -126,7 +126,7 @@ fn get_file_paths(
 /// This should be caller after firewall setup to allow the firewalld reload
 /// service to read the configs later and readd the rules.
 pub fn write_fw_config(
-    config_dir: &str,
+    config_dir: &Path,
     network_id: &str,
     container_id: &str,
     fw_driver: &str,
@@ -168,7 +168,7 @@ pub fn write_fw_config(
 /// On firewall teardown remove the specific config files again so the
 /// firewalld reload service does not keep using them.
 pub fn remove_fw_config(
-    config_dir: &str,
+    config_dir: &Path,
     network_id: &str,
     container_id: &str,
     complete_teardown: bool,
@@ -206,7 +206,7 @@ pub struct FirewallConfig {
 }
 
 /// Read all firewall configs files from the dir.
-pub fn read_fw_config(config_dir: &str) -> NetavarkResult<Option<FirewallConfig>> {
+pub fn read_fw_config(config_dir: &Path) -> NetavarkResult<Option<FirewallConfig>> {
     let paths = get_file_paths(config_dir, "", "", false)?;
 
     // now it is possible the firewall-reload is started before any containers were started so we just
@@ -262,7 +262,7 @@ mod tests {
         let driver = "iptables";
 
         let tmpdir = Builder::new().prefix("netavark-tests").tempdir().unwrap();
-        let config_dir = tmpdir.path().to_str().unwrap();
+        let config_dir = tmpdir.path();
 
         let net_conf = SetupNetwork {
             subnets: Some(vec!["10.0.0.0/24".parse().unwrap()]),
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn test_read_fw_config_empty() {
         let tmpdir = Builder::new().prefix("netavark-tests").tempdir().unwrap();
-        let config_dir = tmpdir.path().to_str().unwrap();
+        let config_dir = tmpdir.path();
 
         let res = read_fw_config(config_dir).expect("no read_fw_config error");
         assert!(res.is_none(), "no firewall config should be given");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsString;
+
 use clap::{Parser, Subcommand};
 
 use netavark::commands::dhcp_proxy;
@@ -12,19 +14,19 @@ use netavark::commands::version;
 struct Opts {
     /// Instead of reading from STDIN, read the configuration to be applied from the given file.
     #[clap(short, long)]
-    file: Option<String>,
+    file: Option<OsString>,
     /// config directory for aardvark, usually path to a tmpfs.
     #[clap(short, long)]
-    config: Option<String>,
+    config: Option<OsString>,
     /// Tells if current netavark invocation is for rootless container.
     #[clap(short, long)]
     rootless: Option<bool>,
     #[clap(short, long)]
     /// Path to the aardvark-dns binary.
-    aardvark_binary: Option<String>,
+    aardvark_binary: Option<OsString>,
     /// Path to netavark plugin directories, can be set multiple times to specify more than one directory.
     #[clap(long, long = "plugin-directory")]
-    plugin_directories: Option<Vec<String>>,
+    plugin_directories: Option<Vec<OsString>>,
     /// Netavark trig command
     #[clap(subcommand)]
     subcmd: SubCommand,
@@ -56,7 +58,7 @@ fn main() {
     let rootless = opts.rootless.unwrap_or(false);
     let aardvark_bin = opts
         .aardvark_binary
-        .unwrap_or_else(|| String::from("/usr/libexec/podman/aardvark-dns"));
+        .unwrap_or_else(|| OsString::from("/usr/libexec/podman/aardvark-dns"));
     let result = match opts.subcmd {
         SubCommand::Setup(setup) => setup.exec(
             opts.file,

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -4,7 +4,7 @@ use crate::{
     firewall::FirewallDriver,
 };
 
-use std::{net::IpAddr, os::fd::BorrowedFd, path::Path};
+use std::{ffi::OsString, net::IpAddr, os::fd::BorrowedFd, path::Path};
 
 use super::{
     bridge::Bridge,
@@ -27,7 +27,7 @@ pub struct DriverInfo<'a> {
     pub per_network_opts: &'a PerNetworkOptions,
     pub port_mappings: &'a Option<Vec<PortMapping>>,
     pub dns_port: u16,
-    pub config_dir: &'a str,
+    pub config_dir: &'a Path,
     pub rootless: bool,
 }
 
@@ -51,7 +51,7 @@ pub trait NetworkDriver {
 
 pub fn get_network_driver<'a>(
     info: DriverInfo<'a>,
-    plugins_directories: &Option<Vec<String>>,
+    plugins_directories: &Option<Vec<OsString>>,
 ) -> NetavarkResult<Box<dyn NetworkDriver + 'a>> {
     match info.network.driver.as_str() {
         constants::DRIVER_BRIDGE => Ok(Box::new(Bridge::new(info))),

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,6 +1,7 @@
 pub mod types;
 pub mod validation;
 use std::{
+    ffi::OsString,
     fs::File,
     io::{self, BufReader},
 };
@@ -20,11 +21,11 @@ pub mod plugin;
 pub mod vlan;
 
 impl types::NetworkOptions {
-    pub fn load(path: Option<String>) -> NetavarkResult<types::NetworkOptions> {
+    pub fn load(path: Option<OsString>) -> NetavarkResult<types::NetworkOptions> {
         wrap!(Self::load_inner(path), "failed to load network options")
     }
 
-    fn load_inner(path: Option<String>) -> Result<types::NetworkOptions, io::Error> {
+    fn load_inner(path: Option<OsString>) -> Result<types::NetworkOptions, io::Error> {
         let opts = match path {
             Some(path) => serde_json::from_reader(BufReader::new(File::open(path)?)),
             None => serde_json::from_reader(io::stdin()),

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -2,13 +2,15 @@
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+
     use netavark::network;
     #[test]
     // Test setup options loader
     fn test_setup_opts_load() {
-        match network::types::NetworkOptions::load(Some(
-            "src/test/config/setupopts.test.json".to_owned(),
-        )) {
+        match network::types::NetworkOptions::load(Some(OsString::from(
+            "src/test/config/setupopts.test.json",
+        ))) {
             Ok(_) => {}
             Err(e) => panic!("{}", e),
         }
@@ -17,9 +19,9 @@ mod tests {
     // Test if we can deserialize values correctly
     #[test]
     fn test_setup_opts_assert() {
-        match network::types::NetworkOptions::load(Some(
-            "src/test/config/setupopts.test.json".to_owned(),
-        )) {
+        match network::types::NetworkOptions::load(Some(OsString::from(
+            "src/test/config/setupopts.test.json",
+        ))) {
             Ok(setupopts) => {
                 assert_eq!(setupopts.container_name, "testcontainer")
             }
@@ -31,9 +33,9 @@ mod tests {
     // Try mutating deserialized struct
     #[test]
     fn test_setup_opts_mutability() {
-        match network::types::NetworkOptions::load(Some(
-            "src/test/config/setupopts.test.json".to_owned(),
-        )) {
+        match network::types::NetworkOptions::load(Some(OsString::from(
+            "src/test/config/setupopts.test.json",
+        ))) {
             Ok(mut setupopts) => {
                 assert_eq!(setupopts.container_name, "testcontainer");
                 setupopts.container_name = "mutatedcontainername".to_string();

--- a/test/001-basic.bats
+++ b/test/001-basic.bats
@@ -26,3 +26,10 @@ load helpers
     expected_rc=1 run_netavark -f /test/1 setup $(get_container_netns_path)
     assert_json ".error" "failed to load network options: IO error: No such file or directory (os error 2)" "Config file does not exists"
 }
+
+@test "netavark - check non utf-8 paths" {
+    # do not use run_netavark here as it sets --config
+    run_helper $NETAVARK --config $'/tmp/\xff.test' version
+    json="$output"
+    assert_json "$json" ".version" =~ "^1\.[0-9]+\.[0-9]+(-rc[0-9]|-dev)?" "correct version"
+}


### PR DESCRIPTION
Rust String type has a pretty well documented difference to most string types in many other languages. A rust string must be valid utf-8. However linux itself does not care about the char encoding in paths, it is simply a non zero byte array. This means that technically netavark will not accept all valid paths. While it unlikely that anyone is using non utf-8 paths in the real world it is still a non great to deny that.

Rust actually offers the OsString/OsStr types that do not enforce the utf-8 requirement. And there is also PathBuf/Path types that futher abstract file paths. So to fix this just use these types instead.

See the added test which checks for it, without this patch we would see a `error: invalid UTF-8 was detected in one or more arguments` message.