### PR TITLE
test: fix syntax problem in helpers.bash

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -407,6 +407,7 @@ function test_port_fw() {
     local container_port=""
     local range=1
     local connect_ip=""
+    local firewalld_reload=false
 
     # parse arguments
     while [[ "$#" -gt 0 ]]; do


### PR DESCRIPTION
firewalld_reload var needs to be defined.
This fixes the superfluous error message:
`helpers.bash: line 541: [: =: unary operator expected` which can be seen in the logs on failures.

Fixes b5d7510039 ("firewalld-reload: add integration tests")