### PR TITLE
aardvark: show error if process is in wrong netns

### DIFF
--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -127,11 +127,42 @@ impl Aardvark {
         Ok(())
     }
 
+    fn check_netns(&self, pid: pid_t) -> Result<()> {
+        let cur_ns = fs::read_link("/proc/self/ns/net")?;
+        let aardvark_ns = fs::read_link(format!("/proc/{pid}/ns/net"))?;
+
+        if aardvark_ns != cur_ns {
+            // netns does not match, this means dns will not work.
+            // see https://github.com/containers/podman/issues/20396 for how that might happen
+            // We do not not really what the problem in the aardvark-dns config files so we
+            // cannot really self heal here and must ask the user to fix it.
+            // I am not sure if this should be a hard error??
+            log::error!(
+                "aardvark-dns runs in a different netns, dns will not work for this container. To resolve please stop all containers, kill the aardvark-dns process, remove the {} directory and then start the containers again",
+                self.config.display()
+            );
+        }
+
+        Ok(())
+    }
+
     pub fn notify(&self, start: bool) -> NetavarkResult<()> {
         match self.get_aardvark_pid() {
             Ok(pid) => {
                 match signal::kill(Pid::from_raw(pid), Signal::SIGHUP) {
-                    Ok(_) => return Ok(()),
+                    Ok(_) => match self.check_netns(pid) {
+                        Ok(_) => return Ok(()),
+                        Err(e) => {
+                            // If the error is ENOENT it means the process must have died in
+                            // the meantime so drop down below to start a new server process.
+                            if e.kind() != std::io::ErrorKind::NotFound {
+                                return Err(NetavarkError::wrap(
+                                    "check aardvark-dns netns",
+                                    e.into(),
+                                ));
+                            }
+                        }
+                    },
                     Err(err) => {
                         // ESRCH == process does not exists
                         // start new sever below in that case and not error


### PR DESCRIPTION
In the rootless netns case it is possible that aardvark-dns kept running
to an improper teardown (root cause unclear). Next time a new rootless
netns is created it means that aardvark-dns runs in the old wrong one
and no dns will work.

Technically it is possible for us to just kill it and start a new one
but if there are other old containers running based on that netns they
would loos dns as well. There is really no good way to fix this by
ourself as we do not know if other containers are still up and running.

So instead log a error with instructions on how to resolve the situation.

Fixes https://github.com/containers/podman/issues/20396