### PR TITLE
Use tonic::transport::Uri instead of HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,7 +1346,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
  "ipnet",
  "iptables",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ futures-channel="0.3.29"
 futures-core = "0.3.29"
 futures-util = "0.3.29"
 nispor = "1.2.15"
-http = "0.2.11"
 tower = { version = "0.4" }
 
 [build-dependencies]

--- a/src/dhcp_proxy/lib.rs
+++ b/src/dhcp_proxy/lib.rs
@@ -6,14 +6,13 @@ use std::convert::TryFrom;
 use std::error::Error;
 
 use g_rpc::netavark_proxy_client::NetavarkProxyClient;
-use http::Uri;
 use log::debug;
 use std::fs::File;
 use std::net::AddrParseError;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 use tokio::net::UnixStream;
-use tonic::transport::{Channel, Endpoint};
+use tonic::transport::{Channel, Endpoint, Uri};
 use tonic::Request;
 use tower::service_fn;
 


### PR DESCRIPTION
With http-1.0.0, the use of HTTP::Uri is no longer valid for when a tonic::transport::Uri is required.