### PR TITLE
perf-netavark: fix missing --config + add fw driver arg

### DIFF
--- a/perf-netavark.sh
+++ b/perf-netavark.sh
@@ -7,9 +7,11 @@ trap cleanup EXIT
 
 function cleanup() {
     kill -9 $netnspid
+    rm -rf $TMP_CONFIG
 }
 
+TMP_CONFIG=$(mktemp -d)
 unshare -n sleep 100 &
 netnspid=$!
 
-unshare -n perf stat $NETAVARK -f ./test/testfiles/simplebridge.json setup /proc/$netnspid/ns/net
+unshare -n perf stat $NETAVARK -f ./test/testfiles/simplebridge.json --config $TMP_CONFIG setup /proc/$netnspid/ns/net

--- a/perf-netavark.sh
+++ b/perf-netavark.sh
@@ -14,4 +14,9 @@ TMP_CONFIG=$(mktemp -d)
 unshare -n sleep 100 &
 netnspid=$!
 
+# first arg is the fw driver
+if [ -n "$1" ]; then
+    export NETAVARK_FW="$1"
+fi
+
 unshare -n perf stat $NETAVARK -f ./test/testfiles/simplebridge.json --config $TMP_CONFIG setup /proc/$netnspid/ns/net


### PR DESCRIPTION
Fix the missing required --config arg for netavark and make the first argument of the script the fw driver. This allows quickly testing some basic performance of the fw driver.