### PR TITLE
Finalize firewalld port forwarding support

### DIFF
--- a/docs/netavark-firewalld.7.md
+++ b/docs/netavark-firewalld.7.md
@@ -31,9 +31,9 @@ When it is enabled (set to `yes`), port forwarding with root Podman will become 
 Attempting to start a container or pod with the `-p` or `-P` options will return errors.
 When StrictForwardPorts is enabled, all port forwarding must be done through firewalld using the firewall-cmd tool.
 This ensures that containers cannot allow traffic through the firewall without administrator intervention.
-Please note that rootless Podman is unaffected by this setting, and will function as it always has.
+Please note that rootless Podman is unaffected by this setting and will function as it always has.
 
-Instead, containers should be started without forwarded ports specified, and preferably with static IPs.
+Instead, containers should be started without forwarded ports specified and preferably with static IPs.
 
 To forward a port externally, the following command should be run, substituting the desired host and container port numbers, protocol, and the container's IP.
 ```

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -560,6 +560,10 @@ fw_driver=iptables
     test_port_fw ip=6 proto=udp hostip="fd65:8371:648b:0c06::1"
 }
 
+@test "$fw_driver - port forwarding with localhost - tcp" {
+    test_port_fw hostip="127.0.0.1"
+}
+
 # Test that port forwarding works with strict Reverse Path Forwarding enabled on the host
 @test "$fw_driver - port forwarding with two networks and RPF - tcp" {
     # First, enable strict RPF on host/container ns.

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -6,6 +6,7 @@
 load helpers
 
 fw_driver=firewalld
+export NETAVARK_FW=firewalld
 
 function setup() {
     basic_setup
@@ -13,7 +14,6 @@ function setup() {
 }
 
 @test "check firewalld driver is in use" {
-    skip "TODO: Firewalld driver swapped with iptables until firewalld 1.1.0"
     RUST_LOG=netavark=info run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json setup $(get_container_netns_path)
     assert "${lines[0]}" "==" "[INFO  netavark::firewall] Using firewalld firewall driver" "firewalld driver is in use"
 }
@@ -156,11 +156,10 @@ function setup() {
 }
 
 @test "$fw_driver - dual stack dns with alt port" {
-    skip "FIXME (#846): firewalld 2.0 broken port redirect"
     # get a random port directly to avoid low ports e.g. 53 would not create iptables
     dns_port=$((RANDOM+10000))
 
-    NETAVARK_FW=firewalld NETAVARK_DNS_PORT="$dns_port" \
+    NETAVARK_DNS_PORT="$dns_port" \
         run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
         setup $(get_container_netns_path)
 
@@ -190,7 +189,7 @@ function setup() {
     run_in_container_netns dig +short "somename.dns.podman" @fd10:88:a::1
     assert "${lines[0]}" =~ "10.89.3.2" "ipv6 dns resolution works"
 
-    NETAVARK_FW=firewalld NETAVARK_DNS_PORT="$dns_port" \
+    NETAVARK_DNS_PORT="$dns_port" \
         run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
         teardown $(get_container_netns_path)
 
@@ -212,117 +211,171 @@ function setup() {
 }
 
 @test "$fw_driver - port forwarding ipv4 - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw
 }
 
 @test "$fw_driver - port forwarding ipv6 - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw ip=6
 }
 
 @test "$fw_driver - port forwarding dualstack - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw ip=dual
 }
 
 @test "$fw_driver - port forwarding ipv4 - udp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw proto=udp
 }
 
 @test "$fw_driver - port forwarding ipv6 - udp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw ip=6 proto=udp
 }
 
 @test "$fw_driver - port forwarding dualstack - udp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw ip=dual proto=udp
 }
 
 @test "$fw_driver - port forwarding ipv4 - sctp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     setup_sctp_kernel_module
     test_port_fw proto=sctp
 }
 
 @test "$fw_driver - port forwarding ipv6 - sctp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     setup_sctp_kernel_module
     test_port_fw ip=6 proto=sctp
 }
 
 @test "$fw_driver - port forwarding dualstack - sctp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     setup_sctp_kernel_module
     test_port_fw ip=dual proto=sctp
 }
 
 @test "$fw_driver - port range forwarding ipv4 - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw range=3
 }
 
 @test "$fw_driver - port range forwarding ipv6 - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw ip=6 range=3
 }
 
 @test "$fw_driver - port range forwarding ipv4 - udp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw proto=udp range=3
 }
 
 @test "$fw_driver - port range forwarding ipv6 - udp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw ip=6 proto=udp range=3
 }
 
 @test "$fw_driver - port range forwarding dual - udp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw ip=dual proto=udp range=3
 }
 
 @test "$fw_driver - port range forwarding dual - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     test_port_fw ip=dual proto=tcp range=3
 }
 
 
 @test "$fw_driver - port forwarding with hostip ipv4 - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "172.16.0.1/24"
     test_port_fw hostip="172.16.0.1"
 }
 
 @test "$fw_driver - port forwarding with hostip ipv4 dual stack - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "172.16.0.1/24"
     test_port_fw ip=dual hostip="172.16.0.1"
 }
 
 @test "$fw_driver - port forwarding with hostip ipv6 - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
     test_port_fw ip=6 hostip="fd65:8371:648b:0c06::1"
 }
 
 @test "$fw_driver - port forwarding with hostip ipv6 dual stack - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
     test_port_fw ip=dual hostip="fd65:8371:648b:0c06::1"
 }
 
 @test "$fw_driver - port forwarding with hostip ipv4 - udp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "172.16.0.1/24"
     test_port_fw proto=udp hostip="172.16.0.1"
 }
 
 @test "$fw_driver - port forwarding with hostip ipv6 - udp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
     test_port_fw ip=6 proto=udp hostip="fd65:8371:648b:0c06::1"
 }
 
 @test "$fw_driver - port forwarding with wildcard hostip ipv4 - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "172.16.0.1/24"
     test_port_fw hostip="0.0.0.0" connectip="172.16.0.1"
 }
 
 @test "$fw_driver - port forwarding with wildcard hostip ipv4 dual stack - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "172.16.0.1/24"
     test_port_fw ip=dual hostip="0.0.0.0" connectip="172.16.0.1"
 }
 
 @test "$fw_driver - port forwarding with wildcard hostip ipv6 - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
     test_port_fw ip=6 hostip="::" connectip="fd65:8371:648b:0c06::1"
 }
 
 @test "$fw_driver - port forwarding with wildcard hostip ipv6 dual stack - tcp" {
+    skip "test requires firewalld same-machine port forwarding for non-localhost IP"
+
     add_dummy_interface_on_host dummy0 "fd65:8371:648b:0c06::1/64"
     test_port_fw ip=dual hostip="::" connectip="fd65:8371:648b:0c06::1"
+}
+
+@test "$fw_driver - port forwarding with localhost - tcp" {
+    test_port_fw hostip="127.0.0.1"
 }
 
 @test "netavark error - invalid host_ip in port mappings" {

--- a/test/250-bridge-nftables.bats
+++ b/test/250-bridge-nftables.bats
@@ -473,6 +473,10 @@ export NETAVARK_FW=nftables
     test_port_fw ip=6 proto=udp hostip="fd65:8371:648b:0c06::1"
 }
 
+@test "$fw_driver - port forwarding with localhost - tcp" {
+    test_port_fw hostip="127.0.0.1"
+}
+
 @test "bridge ipam none" {
            read -r -d '\0' config <<EOF
 {


### PR DESCRIPTION
There are two major changes here.

Firstly, this adds proper support for port forwarding from localhost via a new policy accepting traffic from HOST. This is the last bit we were missing from the original port-forwarding implementation.

Secondly, this fixes a bug where we generated incorrect rules when port-forwarding from a single IP. Instead of doing standard port-forwarding rules, those need rich rules. This was reported as #881.

There are also some small code cleanups in how we handle setting up and tearing down port forwarding. It's still rather ugly, but at least a little better than it was before.

Fixes #881