### PR TITLE
Bump nftables-rs to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,8 +1456,7 @@ dependencies = [
 [[package]]
 name = "nftables"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10abe0d631f93f30c3600ecb4ddd21561bcc6bac1837db11cda9c1c922207e7"
+source = "git+https://github.com/namib-project/nftables-rs.git?rev=1b0c60b#1b0c60ba287cbfc65546d86fbf07d6f26dbeba24"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ sha2 = "0.10.8"
 netlink-packet-utils = "0.5.2"
 netlink-packet-route = "0.18.1"
 netlink-packet-core = "0.7.0"
-nftables = "0.2.4"
+nftables = { git = "https://github.com/namib-project/nftables-rs.git", rev = "1b0c60b" }
 fs2 = "0.4.3"
 netlink-sys = "0.8.5"
 tokio = { version = "1.35", features = ["rt", "rt-multi-thread", "signal", "fs"] }


### PR DESCRIPTION
Instead of vendoring by tag (~ a year old), grab the latest commit. This gets us a number of schema changes that are necessary to safely decode all possible JSON generated by nftables.

Solved an issue I ran into during demos today.