### PR TITLE
Add support for isolation to the nftables driver

### DIFF
--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -272,7 +272,7 @@ pub fn get_network_chains<'a>(
     );
     netavark_isolation_chain_3.create = true;
 
-    if let IsolateOption::Nomal | IsolateOption::Strict = isolation {
+    if let IsolateOption::Normal | IsolateOption::Strict = isolation {
         debug!("Add extra isolate rules");
         // NETAVARK_ISOLATION_1
         let mut netavark_isolation_chain_1 = VarkChain::new(
@@ -305,7 +305,7 @@ pub fn get_network_chains<'a>(
             td_policy: Some(TeardownPolicy::OnComplete),
         });
 
-        // NETAVARK_ISOLATION_2 -i bridge_name ! -o bridge_name -j DROP
+        // NETAVARK_ISOLATION_2 -o bridge_name -j DROP
         netavark_isolation_chain_2.build_rule(VarkRule {
             rule: format!("-o {} -j {}", interface_name, "DROP"),
             position: Some(ind),

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -826,7 +826,7 @@ fn get_isolate_option(opts: &Option<HashMap<String, String>>) -> NetavarkResult<
     // return isolate option value "false" if unknown value or no value passed
     Ok(match isolate.as_str() {
         ISOLATE_OPTION_STRICT => IsolateOption::Strict,
-        ISOLATE_OPTION_TRUE => IsolateOption::Nomal,
+        ISOLATE_OPTION_TRUE => IsolateOption::Normal,
         ISOLATE_OPTION_FALSE => IsolateOption::Never,
         _ => IsolateOption::Never,
     })

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -114,6 +114,6 @@ pub struct IPAMAddresses {
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub enum IsolateOption {
     Strict,
-    Nomal,
+    Normal,
     Never,
 }

--- a/test/testfiles/isolate1.json
+++ b/test/testfiles/isolate1.json
@@ -27,11 +27,11 @@
                 {
                     "subnet": "fd90::/64",
                     "gateway": "fd90::1"
-               }
+                }
             ],
             "options": {
                 "isolate": "true"
-             }
+            }
         }
     }
 }


### PR DESCRIPTION
Replicates the current iptables approach (3 isolation chains, with support for strict and normal isolation, or no isolation at all). No significant changes from iptables implementation.