### PR TITLE
Fix impossible dep on aardvark-dns 1.10.1

### DIFF
--- a/rpm/netavark.spec
+++ b/rpm/netavark.spec
@@ -41,8 +41,11 @@ Source1: %{url}/releases/download/v%{version}/%{name}-v%{version}-vendor.tar.gz
 BuildRequires: cargo
 BuildRequires: %{_bindir}/go-md2man
 # aardvark-dns and %%{name} are usually released in sync
-Recommends: aardvark-dns >= %{version}-1
-Requires: (aardvark-dns >= %{version}-1 if fedora-release-identity-server)
+# but netavark 1.10.1 came with aardvark-dns 1.10.0
+#Recommends: aardvark-dns >= %{version}-1
+#Requires: (aardvark-dns >= %{version}-1 if fedora-release-identity-server)
+Recommends: aardvark-dns >= 1.10.0-1
+Requires: (aardvark-dns >= 1.10.0-1 if fedora-release-identity-server)
 Provides: container-network-stack = 2
 BuildRequires: make
 BuildRequires: protobuf-c


### PR DESCRIPTION
netavark 1.10.1 was released alongside aardvark 1.10.0. This tied dependency is impossible to satisfy at present for netavark 1.10.1.