### PR TITLE
[CI:BUILD] Packit/rpm: fix aardvark-dns handling

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -49,7 +49,10 @@ jobs:
     dist_git_branches:
       - fedora-all
 
-  - job: bodhi_update
-    trigger: commit
-    dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically
+        # NOTE: Bodhi update tasks are disabled to allow netavark and aardvark-dns X.Y
+        # builds in a single manual bodhi update. Leaving this commented out
+        # but not deleted so it's not forgotten.
+        #- job: bodhi_update
+        #trigger: commit
+        #dist_git_branches:
+        #- fedora-branched # rawhide updates are created automatically

--- a/rpm/netavark.spec
+++ b/rpm/netavark.spec
@@ -19,10 +19,15 @@
 %global debug_package %{nil}
 %endif
 
+# Minimum X.Y dep for aardvark-dns
+%define major_minor %((v=%{version}; echo ${v%.*}))
+
 Name: netavark
 # Set a different Epoch for copr builds
 %if %{defined copr_username}
 Epoch: 102
+%else
+Epoch: 0
 %endif
 Version: 0
 Release: %autorelease
@@ -41,8 +46,8 @@ Source1: %{url}/releases/download/v%{version}/%{name}-v%{version}-vendor.tar.gz
 BuildRequires: cargo
 BuildRequires: %{_bindir}/go-md2man
 # aardvark-dns and %%{name} are usually released in sync
-Recommends: aardvark-dns >= %{version}-1
-Requires: (aardvark-dns >= %{version}-1 if fedora-release-identity-server)
+Recommends: aardvark-dns >= %{epoch}:%{major_minor}
+Requires: (aardvark-dns >=  %{epoch}:%{major_minor} if fedora-release-identity-server)
 Provides: container-network-stack = 2
 BuildRequires: make
 BuildRequires: protobuf-c


### PR DESCRIPTION
Bodhi tasks are disabled in Packit config to allow manual submission of a single bodhi update containing netavark and aardvark-dns X.Y builds.

The netavark rpm will now depend on the minimum aardvark-dns X.Y build available to also account for patch releases. Ref: https://github.com/containers/netavark/issues/907#issuecomment-1914504620

Resolves: #907