### PR TITLE
ignore Read-only file system error on sysctl set

### DIFF
--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -282,7 +282,18 @@ impl CoreUtils {
             }
             Err(e) => return Err(e),
         }
-        ctl.set_value_string(val)
+        let result = ctl.set_value_string(val);
+        // if we have a read only /proc we ignore it as well
+        match result {
+            Ok(_) => result,
+            Err(SysctlError::IoError(e)) => {
+                if e.raw_os_error() == Some(libc::EROFS) {
+                    return Ok(String::from(""));
+                }
+                return Err(e.into());
+            },
+            Err(err) => return Err(err),
+        }
     }
 }
 
@@ -432,9 +443,6 @@ pub fn disable_ipv6_autoconf(if_name: &str) -> NetavarkResult<()> {
                 // if the sysctl is not found we likely run on a system without ipv6
                 // just ignore that case
             }
-
-            // if we have a read only /proc we ignore it as well
-            SysctlError::IoError(ref e) if e.raw_os_error() == Some(libc::EROFS) => {}
 
             _ => {
                 return Err(NetavarkError::wrap(


### PR DESCRIPTION
fixes https://github.com/containers/netavark/issues/825

Needed for running podman in a kubernetes pod. I am investigating if we can not set Proc to unmasked and get away with enough podman operations.