### PR TITLE
[CI:BUILD] rpm: Update Rust macro usage

### DIFF
--- a/rpm/netavark.spec
+++ b/rpm/netavark.spec
@@ -90,19 +90,20 @@ Its features include:
 # dependencies directly from the network.
 %if !%{defined copr_username}
 tar fx %{SOURCE1}
-mkdir -p .cargo
-
-cat >.cargo/config << EOF
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"
-EOF
+%if 0%{?fedora} || 0%{?rhel} >= 10
+%cargo_prep -v vendor
+%else
+%cargo_prep -V 1
+%endif
 %endif
 
 %build
 NETAVARK_DEFAULT_FW=%{default_fw} %{__make} CARGO="%{__cargo}" build
+%if (0%{?fedora} || 0%{?rhel} >= 10) && !%{defined copr_username}
+%cargo_license_summary
+%{cargo_license} > LICENSE.dependencies
+%cargo_vendor_manifest
+%endif
 
 cd docs
 %{__make}
@@ -120,6 +121,10 @@ cd docs
 
 %files
 %license LICENSE
+%if (0%{?fedora} || 0%{?rhel} >= 10) && !%{defined copr_username}
+%license LICENSE.dependencies
+%license cargo-vendor.txt
+%endif
 %dir %{_libexecdir}/podman
 %{_libexecdir}/podman/%{name}*
 %{_mandir}/man1/%{name}.1*


### PR DESCRIPTION
The rust-toolset macros in RHEL 10 are now compatible with Fedora's in terms of handling vendoring and automatic generation of license information and bundled provides.

[NO NEW TESTS NEEDED]