### PR TITLE
v1.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "netavark"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netavark"
-version = "1.10.2"
+version = "1.10.3"
 edition = "2021"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## v1.10.3
+* Fixed a bug where the netavark update command could sometimes incorrectly start a new Aardvark DNS server instead of restarting the existing server
+
 ## v1.10.2
 * Fixed a bug where netavark update could sometimes fail
 


### PR DESCRIPTION
Fixed a bug where the netavark update command could sometimes incorrectly start a new Aardvark DNS server instead of restarting the existing server