### PR TITLE
update to nftables 0.4 and only read netavark table rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "nftables"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d11bb5c74ea03d97b6eaed2a30a81657d9884152c661d28d44b4d22616b652"
+checksum = "e689b44b33fc8c2894b6f609701f785a0c1816b7fcf43d05797bd25a513028d1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2086,15 +2086,15 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ sha2 = "0.10.8"
 netlink-packet-utils = "0.5.2"
 netlink-packet-route = "0.19.0"
 netlink-packet-core = "0.7.0"
-nftables = "0.3"
+nftables = "0.4"
 fs2 = "0.4.3"
 netlink-sys = "0.8.5"
 tokio = { version = "1.37", features = ["rt", "rt-multi-thread", "signal", "fs"] }

--- a/src/firewall/nft.rs
+++ b/src/firewall/nft.rs
@@ -381,10 +381,10 @@ impl firewall::FirewallDriver for Nftables {
                         get_subnet_match(&subnet, "saddr", stmt::Operator::EQ),
                         stmt::Statement::Match(stmt::Match {
                             left: expr::Expression::Named(expr::NamedExpression::Payload(
-                                expr::Payload {
+                                expr::Payload::PayloadField(expr::PayloadField {
                                     protocol: "udp".to_string(),
                                     field: "dport".to_string(),
-                                },
+                                }),
                             )),
                             right: expr::Expression::Number(53),
                             op: stmt::Operator::EQ,
@@ -888,10 +888,12 @@ fn ip_to_payload(addr: &IpAddr, field: &str) -> expr::Expression {
         IpAddr::V6(_) => "ip6".to_string(),
     };
 
-    expr::Expression::Named(expr::NamedExpression::Payload(expr::Payload {
-        protocol: proto,
-        field: field.to_string(),
-    }))
+    expr::Expression::Named(expr::NamedExpression::Payload(expr::Payload::PayloadField(
+        expr::PayloadField {
+            protocol: proto,
+            field: field.to_string(),
+        },
+    )))
 }
 
 /// Get a statement to match the given subnet.
@@ -916,20 +918,24 @@ fn subnet_to_payload(net: &IpNet, field: &str) -> expr::Expression {
         IpNet::V6(_) => "ip6".to_string(),
     };
 
-    expr::Expression::Named(expr::NamedExpression::Payload(expr::Payload {
-        protocol: proto,
-        field: field.to_string(),
-    }))
+    expr::Expression::Named(expr::NamedExpression::Payload(expr::Payload::PayloadField(
+        expr::PayloadField {
+            protocol: proto,
+            field: field.to_string(),
+        },
+    )))
 }
 
 /// Get a condition to match destination port/ports based on a given PortMapping.
 /// Properly handles port ranges, protocol, etc.
 fn get_dport_cond(port: &PortMapping) -> stmt::Statement {
     stmt::Statement::Match(stmt::Match {
-        left: expr::Expression::Named(expr::NamedExpression::Payload(expr::Payload {
-            protocol: port.protocol.clone(),
-            field: "dport".to_string(),
-        })),
+        left: expr::Expression::Named(expr::NamedExpression::Payload(expr::Payload::PayloadField(
+            expr::PayloadField {
+                protocol: port.protocol.clone(),
+                field: "dport".to_string(),
+            },
+        ))),
         right: if port.range > 1 {
             // Ranges are a vector with a length of 2.
             // First value start, second value end.
@@ -989,10 +995,12 @@ fn get_dnat_port_rules(
             statements.push(stmt.clone());
         }
         statements.push(stmt::Statement::Match(stmt::Match {
-            left: expr::Expression::Named(expr::NamedExpression::Payload(expr::Payload {
-                protocol: port.protocol.clone(),
-                field: "dport".to_string(),
-            })),
+            left: expr::Expression::Named(expr::NamedExpression::Payload(
+                expr::Payload::PayloadField(expr::PayloadField {
+                    protocol: port.protocol.clone(),
+                    field: "dport".to_string(),
+                }),
+            )),
             right: expr::Expression::Number(host_port),
             op: stmt::Operator::EQ,
         }));
@@ -1118,10 +1126,12 @@ fn make_dns_dnat_rule(dns_ip: &IpAddr, dns_port: u16) -> schema::NfListObject {
         vec![
             get_ip_match(dns_ip, "daddr", stmt::Operator::EQ),
             stmt::Statement::Match(stmt::Match {
-                left: expr::Expression::Named(expr::NamedExpression::Payload(expr::Payload {
-                    protocol: "udp".to_string(),
-                    field: "dport".to_string(),
-                })),
+                left: expr::Expression::Named(expr::NamedExpression::Payload(
+                    expr::Payload::PayloadField(expr::PayloadField {
+                        protocol: "udp".to_string(),
+                        field: "dport".to_string(),
+                    }),
+                )),
                 right: expr::Expression::Number(53),
                 op: stmt::Operator::EQ,
             }),


### PR DESCRIPTION
This contains some breaking changes to the payload type[1] so fix them.

[1] https://github.com/namib-project/nftables-rs/commit/0deaf7d86429b79b857a25f3cd1fb7fdeef8b056


nftables: only dump netavark table rules

This makes things easier as we the lib no longer needs to parse
unrelated rules, we only need to touch/care about the netavark table.

One big issue is that the rust nftables lib is not feature complete and
all rules that it doesn't undersatnd cause the json deserialization to
fail hard and thus easily break netavark. With this fix we only dump our
rules and because we the rules via this lib we should never encounter
unspported rules and thus it should always work.

I assume this also results in a nice speed up if there are many rules in
other tables on the host as they will never be processed by the paring
logic.

Unfortunately this implementation has one big issue, nft will fail when
the table does not exists. This is normal on the first run after boot of
course. To fix this we need to add some special error handling to read
the stderr and we get the ENOENT error message on stderr so we know when
this is the case and can ignore silently.

Fixes https://github.com/containers/netavark/issues/942