### PR TITLE
fix port forward with strict RPF and multi networks

### DIFF
--- a/test/250-bridge-nftables.bats
+++ b/test/250-bridge-nftables.bats
@@ -696,6 +696,8 @@ EOF
     # when the sysctl value is already set correctly we should not error
     run_in_host_netns sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
     run_in_container_netns sh -c "echo 1 > /proc/sys/net/ipv4/conf/default/arp_notify"
+    run_in_host_netns sh -c "echo 2 > /proc/sys/net/ipv4/conf/default/rp_filter"
+    run_in_container_netns sh -c "echo 2 > /proc/sys/net/ipv4/conf/default/rp_filter"
     run_in_host_netns mount -t proc -o ro,nosuid,nodev,noexec proc /proc
 
     run_netavark --file ${TESTSDIR}/testfiles/simplebridge.json setup $(get_container_netns_path)

--- a/test/testfiles/two-networks.json
+++ b/test/testfiles/two-networks.json
@@ -3,7 +3,7 @@
     "container_name": "heuristic_archimedes",
     "port_mappings": [
         {
-          "host_ip": "127.0.0.1",
+          "host_ip": "",
           "container_port": 8080,
           "host_port": 8080,
           "range": 1,


### PR DESCRIPTION
As it turns out our routing setup doesn't play nice with strict Reverse Path Forwarding. The issue is that the incoming packages are routed in via one bridge but may be routed out from the container via another bridge and thus get dropped by strict filtering. The fix is simple, set the filter to loose mode.

From the sysctl doc:
  If using asymmetric routing or other complicated routing,
  then loose mode is recommended.

This applies to us so it seems like the proper fix. Added tests to ensure it works.

Fixes https://issues.redhat.com/browse/RHEL-32500