### PR TITLE
renovate: stop rebasing PRs automatically

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
 
         podman run -it \
             -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
-            docker.io/renovate/renovate:latest \
+            ghcr.io/renovatebot/renovate:latest \
             renovate-config-validator
      3. Commit.
 
@@ -41,10 +41,6 @@
     // https://github.com/containers/automation/blob/main/renovate/defaults.json5
     "github>containers/automation//renovate/defaults.json5"
   ],
-
-  // Permit automatic rebasing when base-branch changes by more than
-  // one commit.
-  "rebaseWhen": "behind-base-branch",
 
   /*************************************************
    *** Repository-specific configuration options ***


### PR DESCRIPTION
This is not really helpful, as it makes it impossible to merge many PRs in a row. The risk of conflicts is rather low IMO so we should not require this by default. We can still rebase manually via the button if needed.