### PR TITLE
Add suffix to Aardvark internal network filenames

### DIFF
--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -57,6 +57,7 @@ impl Teardown {
                     container_ips_v6: Vec::new(),
                     container_names: Vec::new(),
                     container_dns_servers: &None,
+                    is_internal: network.internal,
                 });
             }
         }

--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -29,6 +29,7 @@ pub struct AardvarkEntry<'a> {
     pub container_ips_v6: Vec<Ipv6Addr>,
     pub container_names: Vec<String>,
     pub container_dns_servers: &'a Option<Vec<IpAddr>>,
+    pub is_internal: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -220,7 +221,12 @@ impl Aardvark {
         }
 
         for entry in &entries {
-            let path = Path::new(&self.config).join(entry.network_name);
+            let mut path = Path::new(&self.config).join(entry.network_name);
+            if entry.is_internal {
+                let new_path = Path::new(&self.config).join(entry.network_name.to_owned() + "%int");
+                let _ = std::fs::rename(&path, &new_path);
+                path = new_path;
+            }
 
             let file = match OpenOptions::new().write(true).create_new(true).open(&path) {
                 Ok(mut f) => {
@@ -325,7 +331,11 @@ impl Aardvark {
     }
 
     pub fn delete_entry(&self, container_id: &str, network_name: &str) -> Result<()> {
-        let path = Path::new(&self.config).join(network_name);
+        let mut path = Path::new(&self.config).join(network_name);
+        if !path.exists() {
+            path = Path::new(&self.config).join(network_name.to_owned() + "%int");
+        }
+
         let file_content = fs::read_to_string(&path)?;
         let lines: Vec<&str> = file_content.split_terminator('\n').collect();
 

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -203,6 +203,7 @@ impl driver::NetworkDriver for Bridge<'_> {
                 container_ips_v6: ipv6,
                 container_names: names,
                 container_dns_servers: self.info.container_dns_servers,
+                is_internal: self.info.network.internal,
             })
         } else {
             // If --dns-enable=false and --dns was set then return following DNS servers


### PR DESCRIPTION
Use the %int suffix for internal network files passed to AV so we can properly trigger DNS handling (or, more accurately, lack of DNS handling) over there. Also, to handle version migrations, if there is a previous file for the network named without the suffix, delete that.

This will unblock [1].

[1] https://github.com/containers/aardvark-dns/pull/447