### PR TITLE
CI VMs: bump to new versions with tmpfs /tmp

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ env:
     CARGO_TARGET_DIR: "$CIRRUS_WORKING_DIR/targets"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
-    IMAGE_SUFFIX: "c20240102t155643z-f39f38d13"
+    IMAGE_SUFFIX: "c20240411t124913z-f39f38d13"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
     AARDVARK_DNS_BRANCH: "main"
     AARDVARK_DNS_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_DNS_BRANCH}"


### PR DESCRIPTION
For the last long time, Fedora CI VMs have had a disk /tmp. Real-world setups typically have tmpfs /tmp. This switches to CI VMs that reflect the real world.

See https://github.com/containers/automation_images/pull/340

**THIS WILL FAIL CI!** Because https://github.com/containers/netavark/pull/948 (nc bug). I'm just seeing here if there are any other failures.