### PR TITLE
DO NOT MERGE: test ncat 7.95

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ env:
     CARGO_TARGET_DIR: "$CIRRUS_WORKING_DIR/targets"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
-    IMAGE_SUFFIX: "c20240102t155643z-f39f38d13"
+    IMAGE_SUFFIX: "c20240501t194928z-f40f39d13"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
     AARDVARK_DNS_BRANCH: "main"
     AARDVARK_DNS_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_DNS_BRANCH}"


### PR DESCRIPTION
Chris has a new-vm PR in progress[1] and I noticed that nmap-ncat is up from 7.94 to .95. Let's see if the nasty 7.94 bug is fixed.

 [1] https://github.com/containers/automation_images/pull/349