### PR TITLE
[skip-ci] Packit: enable c10s downstream sync

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,8 +2,17 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-specfile_path: rpm/netavark.spec
+downstream_package_name: netavark
 upstream_tag_template: v{version}
+
+packages:
+  netavark-fedora:
+    pkg_tool: fedpkg
+    specfile_path: rpm/netavark.spec
+  netavark-centos:
+    pkg_tool: centpkg
+    specfile_path: rpm/netavark.spec
+
 
 srpm_build_deps:
   - cargo
@@ -13,17 +22,40 @@ srpm_build_deps:
 jobs:
   - job: copr_build
     trigger: pull_request
-    notifications:
+    packages: [netavark-fedora]
+    notifications: &copr_build_failure_notification
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
-    enable_net: true
     targets:
-      - fedora-all-x86_64
-      - fedora-all-aarch64
-      - centos-stream+epel-next-9-x86_64
-      - centos-stream+epel-next-9-aarch64
-    additional_repos:
-      - "copr://rhcontainerbot/podman-next"
+      fedora-all-x86_64: {}
+      fedora-all-aarch64: {}
+      fedora-eln-x86_64:
+        additional_repos:
+          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
+      fedora-eln-aarch64:
+        additional_repos:
+          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/aarch64/"
+    enable_net: true
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [netavark-centos]
+    notifications: *copr_build_failure_notification
+    targets:
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+      - centos-stream-10-x86_64
+      - centos-stream-10-aarch64
+    enable_net: true
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [netavark-centos]
+    notifications: *copr_build_failure_notification
+    targets:
+      - epel-9-x86_64
+      - epel-9-aarch64
+    enable_net: true
 
   # Run on commit to main branch
   - job: copr_build
@@ -36,11 +68,21 @@ jobs:
     project: podman-next
     enable_net: true
 
+  # Sync to Fedora
   - job: propose_downstream
     trigger: release
+    packages: [netavark-fedora]
     update_release: false
     dist_git_branches:
       - fedora-all
+
+  # Sync to CentOS Stream
+  - job: propose_downstream
+    trigger: release
+    packages: [netavark-centos]
+    update_release: false
+    dist_git_branches:
+      - c10s
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
This commit will enable downstream syncing to CentOS Stream 10. The centos maintainer will need to manually run `packit propose-downstream` and `centpkg build` until better centos integration is in place.

This commit also builds both rhel9 and centos9 copr rpms so we can check for things like differences in rust compiler.