### PR TITLE
[skip-ci] Packit: distinct `-rhel` packages value

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,7 +12,8 @@ packages:
   netavark-centos:
     pkg_tool: centpkg
     specfile_path: rpm/netavark.spec
-
+  netavark-rhel:
+    specfile_path: rpm/netavark.spec
 
 srpm_build_deps:
   - cargo
@@ -50,7 +51,7 @@ jobs:
 
   - job: copr_build
     trigger: pull_request
-    packages: [netavark-centos]
+    packages: [netavark-rhel]
     notifications: *copr_build_failure_notification
     targets:
       - epel-9-x86_64


### PR DESCRIPTION
Include a distinct value for the packages key for rhel copr_build jobs to avoid packit status reporting issues.