### PR TITLE
Add conditional compilation of default firewall driver

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -63,4 +63,18 @@ fn main() {
         Err(_) => "".to_string(),
     };
     println!("cargo:rustc-env=GIT_COMMIT={commit}");
+
+    // Handle default firewall driver.
+    // Allowed values "nftables" and "iptables".
+    let fwdriver = match env::var("NETAVARK_DEFAULT_FW")
+        .unwrap_or("iptables".to_string())
+        .as_str()
+    {
+        "nftables" => "nftables",
+        "iptables" => "iptables",
+        "none" => "none",
+        inv => panic!("Invalid default firewall driver {}", inv),
+    };
+    println!("cargo:rustc-cfg=default_fw=\"{}\"", fwdriver);
+    println!("cargo:rustc-env=DEFAULT_FW={fwdriver}");
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -11,6 +11,7 @@ struct Info {
     commit: &'static str,
     build_time: &'static str,
     target: &'static str,
+    default_fw_driver: &'static str,
 }
 
 impl Version {
@@ -20,6 +21,7 @@ impl Version {
             commit: env!("GIT_COMMIT"),
             build_time: env!("BUILD_TIMESTAMP"),
             target: env!("BUILD_TARGET"),
+            default_fw_driver: env!("DEFAULT_FW"),
         };
 
         let out = serde_json::to_string_pretty(&info)?;

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -71,9 +71,7 @@ fn get_firewall_impl(driver_name: Option<String>) -> NetavarkResult<FirewallImpl
         }
     }
 
-    // Until firewalld 1.1.0 with support for self-port forwarding lands:
-    // Just use iptables
-    Ok(FirewallImpl::Iptables)
+    get_default_fw_impl()
 
     // Is firewalld running?
     // let conn = match Connection::system() {
@@ -90,6 +88,21 @@ fn get_firewall_impl(driver_name: Option<String>) -> NetavarkResult<FirewallImpl
     //     Ok(_) => FirewallImpl::Firewalld(conn),
     //     Err(_) => FirewallImpl::Iptables,
     // }
+}
+
+#[cfg(default_fw = "nftables")]
+fn get_default_fw_impl() -> NetavarkResult<FirewallImpl> {
+    Ok(FirewallImpl::Nftables)
+}
+
+#[cfg(default_fw = "iptables")]
+fn get_default_fw_impl() -> NetavarkResult<FirewallImpl> {
+    Ok(FirewallImpl::Iptables)
+}
+
+#[cfg(default_fw = "none")]
+fn get_default_fw_impl() -> NetavarkResult<FirewallImpl> {
+    Ok(FirewallImpl::Fwnone)
 }
 
 /// Get the preferred firewall implementation for the current system


### PR DESCRIPTION
The NETAVARK_DEFAULT_FW environment variable controls the default firewall driver that will be used by the compiled Netavark. Currently supported values are "iptables" (the default, if the environment variable is unset), "nftables", and "none" (we'll add "firewalld" as a supported value once that driver is done).

Unsupported values result in a panic/failure to build.