### PR TITLE
[skip-ci] Packit: do not create dup jobs on podman-next

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -61,6 +61,7 @@ jobs:
   # Run on commit to main branch
   - job: copr_build
     trigger: commit
+    packages: [netavark-fedora]
     notifications:
       failure_comment:
         message: "podman-next COPR build failed. @containers/packit-build please check."


### PR DESCRIPTION
If the packages key isn't specified, packit will trigger copr jobs for all of `netavark-fedora`, `netavark-centos` and `netavark-rhel`.