### PR TITLE
Fix Epoch so upgrade path is preserved from Fedora/RHEL.

### DIFF
--- a/rpm/netavark.spec
+++ b/rpm/netavark.spec
@@ -28,7 +28,7 @@ Name: netavark
 %if %{defined copr_username}
 Epoch: 102
 %else
-Epoch: 0
+Epoch: 2
 %endif
 Version: 0
 Release: %autorelease


### PR DESCRIPTION
The Epoch in spec file needs to be bumped to preserve upgrade path in c10s.