### PR TITLE
aardvark-dns: trim whitespaces from error text

### DIFF
--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -143,7 +143,7 @@ impl Aardvark {
 
         Err(std::io::Error::new(
             std::io::ErrorKind::Other,
-            format!("aardvark-dns failed to start: {}", msg),
+            format!("aardvark-dns failed to start: {}", msg.trim()),
         ))
     }
 


### PR DESCRIPTION
Noticed this while testing my aardvark-dns changes. As we capture the full stderr it includes the final newline from the error text which will then be returned like this to podman. However because all podman always adds a newline to its error output on the cli it resulted in two newlines being printed. Not a bug deal but still unnecessary and confusing.