### PR TITLE
Change nv cargo categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 description = "A container network stack"
 homepage = "https://github.com/containers/netavark"
 repository = "https://github.com/containers/netavark"
-categories = ["containers", "networking", "podman"]
+categories = ["virtualization"]
 exclude = ["/.cirrus.yml", "/.github/*", "/hack/*"]
 build = "build.rs"
 


### PR DESCRIPTION
To publish our crate, we must use official categories.  In this case, "virtualization" specifically calls out containers and seems appropriate.

Upstream: https://github.com/rust-lang/crates.io/pull/8930