### PR TITLE
silence new rust 1.80 warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -75,6 +75,7 @@ fn main() {
         "none" => "none",
         inv => panic!("Invalid default firewall driver {}", inv),
     };
+    println!("cargo:rustc-check-cfg=cfg(default_fw, values(\"nftables\", \"iptables\", \"none\"))");
     println!("cargo:rustc-cfg=default_fw=\"{}\"", fwdriver);
     println!("cargo:rustc-env=DEFAULT_FW={fwdriver}");
 }

--- a/src/dhcp_proxy/cache.rs
+++ b/src/dhcp_proxy/cache.rs
@@ -43,7 +43,7 @@ impl<W: Write + Clear> LeaseCache<W> {
     /// # Arguments
     ///
     /// * `writer`: any type that can has the Write and Clear trait implemented. In production this
-    /// is a file. In development/testing this is a Cursor of bytes
+    ///   is a file. In development/testing this is a Cursor of bytes
     ///
     /// returns: Result<LeaseCache<W>, Error>
     ///

--- a/src/dhcp_proxy/lib.rs
+++ b/src/dhcp_proxy/lib.rs
@@ -40,10 +40,7 @@ pub mod g_rpc {
     impl From<DhcpV4Lease> for Lease {
         fn from(l: DhcpV4Lease) -> Lease {
             // Since these fields are optional as per mozim. Match them first and then set them
-            let domain_name = match l.domain_name {
-                None => String::from(""),
-                Some(l) => l,
-            };
+            let domain_name = l.domain_name.unwrap_or_default();
             let mtu = l.mtu.unwrap_or(0) as u32;
 
             Lease {


### PR DESCRIPTION
A new lint check was added[1] that makes sure all cfg values are checked. As such we must tell the compiler which values are valid so it doesn't flag them as unexpected.

[1] https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#cargorustc-check-cfg-for-buildrsbuild-script