### PR TITLE
chore: remove superfluous formatters from debug stmt

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -47,7 +47,7 @@ impl Setup {
                 return Err(NetavarkError::wrap("invalid namespace path", e));
             }
         }
-        debug!("{:?}", "Setting up...");
+        debug!("Setting up...");
         let network_options = network::types::NetworkOptions::load(input_file)?;
 
         let firewall_driver = match firewall::get_supported_firewall_driver(firewall_driver) {
@@ -166,7 +166,7 @@ impl Setup {
         debug!("{:#?}", response);
         let response_json = serde_json::to_string(&response)?;
         println!("{response_json}");
-        debug!("{:?}", "Setup complete");
+        debug!("Setup complete");
         Ok(())
     }
 }

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -37,7 +37,7 @@ impl Teardown {
         plugin_directories: Option<Vec<OsString>>,
         rootless: bool,
     ) -> NetavarkResult<()> {
-        debug!("{:?}", "Tearing down..");
+        debug!("Tearing down..");
         let network_options = network::types::NetworkOptions::load(input_file)?;
 
         let mut error_list = NetavarkErrorList::new();
@@ -129,7 +129,7 @@ impl Teardown {
             return Err(NetavarkError::List(error_list));
         }
 
-        debug!("{:?}", "Teardown complete");
+        debug!("Teardown complete");
         Ok(())
     }
 }

--- a/src/dhcp_proxy_client/commands/setup.rs
+++ b/src/dhcp_proxy_client/commands/setup.rs
@@ -10,7 +10,7 @@ pub struct Setup {}
 
 impl Setup {
     pub async fn exec(&self, p: &str, config: NetworkConfig) -> Result<Lease, NetavarkError> {
-        debug!("{:?}", "Setting up...");
+        debug!("Setting up...");
         debug!("input: {:#?}", serde_json::to_string_pretty(&config));
 
         config.clone().get_lease(p).await

--- a/src/network/validation.rs
+++ b/src/network/validation.rs
@@ -3,7 +3,7 @@ use log::debug;
 use std::fs::File;
 
 pub fn ns_checks(file: &str) -> NetavarkResult<()> {
-    debug!("{:?}", "Validating network namespace...");
+    debug!("Validating network namespace...");
     // TODO check for FS_MAGIC
     let _ = File::open(file)?.metadata()?;
     Ok(())


### PR DESCRIPTION
Following debug lines don't need any formatters hence removing them.