### PR TITLE
[skip-ci] Packit: add sidetag to release with aardvark-dns

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -88,13 +88,14 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    sidetag_group: netavark-releases
     dist_git_branches:
       - fedora-all
 
-        # NOTE: Bodhi update tasks are disabled to allow netavark and aardvark-dns X.Y
-        # builds in a single manual bodhi update. Leaving this commented out
-        # but not deleted so it's not forgotten.
-        #- job: bodhi_update
-        #trigger: commit
-        #dist_git_branches:
-        #- fedora-branched # rawhide updates are created automatically
+  - job: bodhi_update
+    trigger: koji_build
+    sidetag_group: netavark-releases
+    dependencies:
+      - aardvark-dns
+    dist_git_branches:
+      - fedora-all


### PR DESCRIPTION
Packit now supports Fedora sidetags to ship multiple package updates in a single bodhi.
Ref: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages

The targets for bodhi update should be `fedora-all` and not
fedora-branched as the update is with builds from a sidetag and not the
default tag.
