### PR TITLE
nft: remove port forwarding rules correctly

### DIFF
--- a/src/firewall/nft.rs
+++ b/src/firewall/nft.rs
@@ -12,7 +12,7 @@ use nftables::schema;
 use nftables::stmt;
 use nftables::types;
 use std::collections::HashSet;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 
 const TABLENAME: &str = "netavark";
 
@@ -36,6 +36,8 @@ const DNATPRIO: i32 = -100;
 const SRCNATPRIO: i32 = 100;
 /// The filter priority for chains
 const FILTERPRIO: i32 = 0;
+
+const IPV4_LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
 pub struct Nftables {}
 
@@ -1110,7 +1112,7 @@ fn get_dnat_rules_for_addr_family(
                 // Container dnat chain: ip saddr 127.0.0.1 ip daddr <host IP> <proto> dport <port(s)> jump SETMARKCHAIN
                 let mut localhost_jump_statements: Vec<stmt::Statement> = Vec::new();
                 localhost_jump_statements.push(get_ip_match(
-                    &("127.0.0.1".parse()?),
+                    &IPV4_LOCALHOST,
                     "saddr",
                     stmt::Operator::EQ,
                 ));

--- a/src/firewall/nft.rs
+++ b/src/firewall/nft.rs
@@ -1122,9 +1122,12 @@ fn get_dnat_rules_for_addr_family(
                 rules.push(make_rule(&subnet_dnat_chain, localhost_jump_statements));
             }
 
-            for rule in get_dnat_port_rules(&subnet_dnat_chain, port, &ip, &daddr_cond) {
-                rules.push(rule);
-            }
+            rules.append(&mut get_dnat_port_rules(
+                &subnet_dnat_chain,
+                port,
+                &ip,
+                &daddr_cond,
+            ));
         }
     }
 

--- a/test/testfiles/bridge-port-tcp-udp.json
+++ b/test/testfiles/bridge-port-tcp-udp.json
@@ -1,0 +1,52 @@
+{
+    "container_id": "f922ffdda5718b26ea585a500d5ad05191da5461b06d6f62e4d1f66ca901a253",
+    "container_name": "sharp_gould",
+    "port_mappings": [
+        {
+            "host_ip": "192.168.188.25",
+            "container_port": 8080,
+            "host_port": 8080,
+            "range": 1,
+            "protocol": "tcp"
+        },
+        {
+            "host_ip": "192.168.188.25",
+            "container_port": 8080,
+            "host_port": 8080,
+            "range": 1,
+            "protocol": "udp"
+        }
+    ],
+    "networks": {
+        "podman": {
+            "static_ips": [
+                "10.88.0.14"
+            ],
+            "aliases": [
+                "f922ffdda571"
+            ],
+            "interface_name": "eth0"
+        }
+    },
+    "network_info": {
+        "podman": {
+            "name": "podman",
+            "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
+            "driver": "bridge",
+            "network_interface": "podman0",
+            "created": "2024-09-05T15:00:04.45111926+02:00",
+            "subnets": [
+                {
+                    "subnet": "10.88.0.0/16",
+                    "gateway": "10.88.0.1"
+                }
+            ],
+            "ipv6_enabled": false,
+            "internal": false,
+            "dns_enabled": false,
+            "ipam_options": {
+                "driver": "host-local"
+            }
+        }
+    }
+}


### PR DESCRIPTION

The problem with these match statements to check the rules that they are
hard to keep track of and match 1 to 1 to the rules we generate on
setup. This approach here generates the same rules as setup and uses this
to compare the existing rules against.

Fixes #1068