### PR TITLE
iptables/nftables: add dns dnat rule first

### DIFF
--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -525,13 +525,15 @@ pub fn get_port_forwarding_chains<'a>(
             }
             netavark_hostport_dn_chain.create = true;
             for proto in ["udp", "tcp"] {
-                netavark_hostport_dn_chain.build_rule(VarkRule::new(
-                    format!(
+                netavark_hostport_dn_chain.build_rule(VarkRule {
+                    rule: format!(
                         "-j {} -d {} -p {} --dport {} --to-destination {}:{}",
                         DNAT, dns_ip, proto, 53, ip_value, pfwd.dns_port
                     ),
-                    Some(TeardownPolicy::OnComplete),
-                ));
+                    // rule should be first otherwise another container might hijack all 53 traffic to itself
+                    position: Some(1),
+                    td_policy: Some(TeardownPolicy::OnComplete),
+                });
             }
         }
     }

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -319,11 +319,11 @@ fw_driver=iptables
 
     # check iptables
     run_in_host_netns iptables -t nat -S NETAVARK-HOSTPORT-DNAT
-    assert "${lines[1]}" == "-A NETAVARK-HOSTPORT-DNAT -d 10.89.3.1/32 -p udp -m udp --dport 53 -j DNAT --to-destination 10.89.3.1:$dns_port" "ipv4 dns forward rule"
-    assert "${lines[2]}" == "-A NETAVARK-HOSTPORT-DNAT -d 10.89.3.1/32 -p tcp -m tcp --dport 53 -j DNAT --to-destination 10.89.3.1:$dns_port" "ipv4 dns tcp forward rule"
+    assert "${lines[2]}" == "-A NETAVARK-HOSTPORT-DNAT -d 10.89.3.1/32 -p udp -m udp --dport 53 -j DNAT --to-destination 10.89.3.1:$dns_port" "ipv4 dns forward rule"
+    assert "${lines[1]}" == "-A NETAVARK-HOSTPORT-DNAT -d 10.89.3.1/32 -p tcp -m tcp --dport 53 -j DNAT --to-destination 10.89.3.1:$dns_port" "ipv4 dns tcp forward rule"
     run_in_host_netns ip6tables -t nat -S NETAVARK-HOSTPORT-DNAT
-    assert "${lines[1]}" == "-A NETAVARK-HOSTPORT-DNAT -d fd10:88:a::1/128 -p udp -m udp --dport 53 -j DNAT --to-destination [fd10:88:a::1]:$dns_port" "ipv6 dns forward rule"
-    assert "${lines[2]}" == "-A NETAVARK-HOSTPORT-DNAT -d fd10:88:a::1/128 -p tcp -m tcp --dport 53 -j DNAT --to-destination [fd10:88:a::1]:$dns_port" "ipv6 dns tcp forward rule"
+    assert "${lines[2]}" == "-A NETAVARK-HOSTPORT-DNAT -d fd10:88:a::1/128 -p udp -m udp --dport 53 -j DNAT --to-destination [fd10:88:a::1]:$dns_port" "ipv6 dns forward rule"
+    assert "${lines[1]}" == "-A NETAVARK-HOSTPORT-DNAT -d fd10:88:a::1/128 -p tcp -m tcp --dport 53 -j DNAT --to-destination [fd10:88:a::1]:$dns_port" "ipv6 dns tcp forward rule"
 
     # check aardvark config and running
     run_helper cat "$NETAVARK_TMPDIR/config/aardvark-dns/podman1"

--- a/test/250-bridge-nftables.bats
+++ b/test/250-bridge-nftables.bats
@@ -317,7 +317,8 @@ export NETAVARK_FW=nftables
 
     # check nftables
     run_in_host_netns nft list chain inet netavark NETAVARK-HOSTPORT-DNAT
-    assert "${lines[2]}" =~ "ip daddr 10.89.3.1 meta l4proto \{ tcp, udp \} th dport 53 dnat ip to 10.89.3.1:$dns_port" "DNS forward rule"
+    assert "${lines[2]}" =~ "ip6 daddr fd10:88:a::1 meta l4proto \{ tcp, udp \} th dport 53 dnat ip6 to \[fd10:88:a::1\]:$dns_port" "DNS forward rule ip6"
+    assert "${lines[3]}" =~ "ip daddr 10.89.3.1 meta l4proto \{ tcp, udp \} th dport 53 dnat ip to 10.89.3.1:$dns_port" "DNS forward rule ip4"
 
     # check aardvark config and running
     run_helper cat "$NETAVARK_TMPDIR/config/aardvark-dns/podman1"


### PR DESCRIPTION


When a container has port 53 forwarded as well we also add dnst rules
for it. This means depending on the order the container dns traffic
might go to another container not aardvark-dns breaking container name
resolution.

The fix to make sure to insert the rule always first.

Fixes https://github.com/containers/netavark/issues/1079