### PR TITLE
rust 1.81 lint fixes and remove NOP dhcp test

### DIFF
--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -193,7 +193,7 @@ impl CoreUtils {
 
     pub fn decode_address_from_hex(input: &str) -> Result<Vec<u8>, std::io::Error> {
         let bytes: Result<Vec<u8>, _> = input
-            .split(|c| c == ':' || c == '-')
+            .split([':', '-'])
             .map(|b| u8::from_str_radix(b, 16))
             .collect();
 

--- a/src/network/vlan.rs
+++ b/src/network/vlan.rs
@@ -336,7 +336,7 @@ fn setup(
                     netns
                         .set_link_name(link.header.index, if_name.to_string())
                         .wrap(format!("rename tmp {kind_data} interface"))
-                        .map_err(|err| {
+                        .inspect_err(|_| {
                             // If there is an error here most likely the name in the netns is already used,
                             // make sure to delete the tmp interface.
                             if let Err(err) = netns.del_link(netlink::LinkID::ID(link.header.index))
@@ -346,7 +346,6 @@ fn setup(
                                     kind_data, tmp_name, err
                                 );
                             };
-                            err
                         })?;
 
                     // successful run, break out of loop

--- a/test-dhcp/001-basic.bats
+++ b/test-dhcp/001-basic.bats
@@ -5,7 +5,10 @@
 
 load helpers
 
-@test "simple example" {
-
+# One might think this is a NOP and does nothing, so do I. But apparently
+# something really weird is going with that in CI. If we delete this file
+# the basic setup test will fail in CI. No idea why and I tried for to
+# long to make any sense of this.
+@test "NOP setup" {
+    :
 }
-


### PR DESCRIPTION
Stuff needed for CI image update but that seems to have other issues that need to debugged so I just submit the fixes alone https://github.com/containers/netavark/pull/1081