### PR TITLE
[skip-ci] Packit: Remove epel targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,8 +12,6 @@ packages:
   netavark-centos:
     pkg_tool: centpkg
     specfile_path: rpm/netavark.spec
-  netavark-rhel:
-    specfile_path: rpm/netavark.spec
 
 srpm_build_deps:
   - cargo
@@ -47,15 +45,6 @@ jobs:
       - centos-stream-9-aarch64
       - centos-stream-10-x86_64
       - centos-stream-10-aarch64
-    enable_net: true
-
-  - job: copr_build
-    trigger: pull_request
-    packages: [netavark-rhel]
-    notifications: *copr_build_failure_notification
-    targets:
-      - epel-9-x86_64
-      - epel-9-aarch64
     enable_net: true
 
   # Run on commit to main branch


### PR DESCRIPTION
EPEL targets, which are essentially RHEL + EPEL repos, often contain very old builds of rust, golang and other important tools leading to a lot more failures compared to centos stream.