### PR TITLE
[skip-ci] RPM: cleanup changelog conditionals

### DIFF
--- a/rpm/netavark.spec
+++ b/rpm/netavark.spec
@@ -138,12 +138,4 @@ cd docs
 %{_unitdir}/%{name}-firewalld-reload.service
 
 %changelog
-%if %{defined autochangelog}
 %autochangelog
-%else
-# NOTE: This changelog will be visible on CentOS 8 Stream builds
-# Other envs are capable of handling autochangelog
-* Fri Jun 16 2023 RH Container Bot <rhcontainerbot@fedoraproject.org>
-- Placeholder changelog for envs that are not autochangelog-ready
-- Contact upstream if you need to report an issue with the build.
-%endif


### PR DESCRIPTION
rpmautospec is now present on all active Fedora and CentOS Stream envs so we don't need such changelog manipulation anymore.