### PR TITLE
generate protobuf in OUT_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ targets/
 netavark.1
 vendor/
 .idea/*
-src/proto-build/netavark_proxy.rs
 contrib/systemd/*/*.service
 .vscode*

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 fn main() {
@@ -32,8 +32,7 @@ fn main() {
         .type_attribute(
             "netavark_proxy.NetworkConfig",
             "#[derive(serde::Serialize)]",
-        )
-        .out_dir(PathBuf::from("src/proto-build"));
+        );
 
     builder
         .compile_protos(&[Path::new("src/proto/proxy.proto")], &[Path::new("proto")])

--- a/src/dhcp_proxy/lib.rs
+++ b/src/dhcp_proxy/lib.rs
@@ -19,7 +19,7 @@ use tower::service_fn;
 
 #[allow(clippy::unwrap_used)]
 pub mod g_rpc {
-    include!("../proto-build/netavark_proxy.rs");
+    include!(concat!(env!("OUT_DIR"), "/netavark_proxy.rs"));
     use crate::dhcp_proxy::lib::VectorConv;
     use crate::dhcp_proxy::types::{CustomErr, ProxyError};
     use mozim::DhcpV4Lease;


### PR DESCRIPTION
We should not create build time generated files under src/, with the latest rust version this seems to cause problems on cargo publish.

Instead just default to the OUT_DIR env that is always set by cargo.

Fixes #1137