### PR TITLE
bridge: support DHCP ipam driver

### DIFF
--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -7,7 +7,7 @@ use netlink_packet_route::link::{
     LinkMessage,
 };
 
-use crate::network::macvlan_dhcp::get_dhcp_lease;
+use crate::network::dhcp::{dhcp_teardown, get_dhcp_lease};
 use crate::{
     dns::aardvark::AardvarkEntry,
     error::{ErrorWrap, NetavarkError, NetavarkErrorList, NetavarkResult},
@@ -315,7 +315,7 @@ impl driver::NetworkDriver for Bridge<'_> {
 
         let mut error_list = NetavarkErrorList::new();
 
-        core_utils::dhcp_teardown(&self.info, netns_sock)?;
+        dhcp_teardown(&self.info, netns_sock)?;
 
         let routes = core_utils::create_route_list(&self.info.network.routes)?;
         for route in routes.iter() {

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -1,5 +1,4 @@
 use crate::error::{ErrorWrap, NetavarkError, NetavarkResult};
-use crate::network::macvlan_dhcp::release_dhcp_lease;
 use crate::network::{constants, internal_types, types};
 use crate::wrap;
 use ipnet::IpNet;
@@ -19,7 +18,7 @@ use std::os::unix::prelude::*;
 use std::str::FromStr;
 use sysctl::{Sysctl, SysctlError};
 
-use super::{driver::DriverInfo, netlink};
+use super::netlink;
 
 use netlink_packet_route::link::LinkAttribute;
 
@@ -448,27 +447,4 @@ pub fn get_mac_address(v: Vec<LinkAttribute>) -> NetavarkResult<String> {
     Err(NetavarkError::msg(
         "failed to get the the container mac address",
     ))
-}
-
-pub fn dhcp_teardown(info: &DriverInfo, sock: &mut netlink::Socket) -> NetavarkResult<()> {
-    let ipam = get_ipam_addresses(info.per_network_opts, info.network)?;
-    let if_name = info.per_network_opts.interface_name.clone();
-
-    // If we are using DHCP, we need to at least call to the proxy so that
-    // the proxy's cache can get updated and the current lease can be released.
-    if ipam.dhcp_enabled {
-        let dev = sock.get_link(netlink::LinkID::Name(if_name)).wrap(format!(
-            "get container interface {}",
-            &info.per_network_opts.interface_name
-        ))?;
-
-        let container_mac_address = get_mac_address(dev.attributes)?;
-        release_dhcp_lease(
-            &info.network.network_interface.clone().unwrap_or_default(),
-            &info.per_network_opts.interface_name,
-            info.netns_path,
-            &container_mac_address,
-        )?
-    }
-    Ok(())
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -13,9 +13,9 @@ use crate::{
 pub mod bridge;
 pub mod constants;
 pub mod core_utils;
+mod dhcp;
 pub mod driver;
 pub mod internal_types;
-mod macvlan_dhcp;
 pub mod netlink;
 pub mod plugin;
 pub mod vlan;

--- a/src/network/vlan.rs
+++ b/src/network/vlan.rs
@@ -7,7 +7,7 @@ use netlink_packet_route::link::{
 };
 use rand::distributions::{Alphanumeric, DistString};
 
-use crate::network::macvlan_dhcp::{get_dhcp_lease, release_dhcp_lease};
+use crate::network::macvlan_dhcp::get_dhcp_lease;
 use crate::{
     dns::aardvark::AardvarkEntry,
     error::{ErrorWrap, NetavarkError, NetavarkResult},
@@ -20,7 +20,7 @@ use super::{
         NO_CONTAINER_INTERFACE_ERROR, OPTION_BCLIM, OPTION_METRIC, OPTION_MODE, OPTION_MTU,
         OPTION_NO_DEFAULT_ROUTE,
     },
-    core_utils::{self, get_ipam_addresses, parse_option, CoreUtils},
+    core_utils::{self, get_ipam_addresses, get_mac_address, parse_option, CoreUtils},
     driver::{self, DriverInfo},
     internal_types::IPAMAddresses,
     netlink::{self, CreateLinkOptions},
@@ -218,33 +218,7 @@ impl driver::NetworkDriver for Vlan<'_> {
         &self,
         netlink_sockets: (&mut netlink::Socket, &mut netlink::Socket),
     ) -> NetavarkResult<()> {
-        let ipam = get_ipam_addresses(self.info.per_network_opts, self.info.network)?;
-        let if_name = self.info.per_network_opts.interface_name.clone();
-
-        // If we are using DHCP macvlan, we need to at least call to the proxy so that
-        // the proxy's cache can get updated and the current lease can be released.
-        if ipam.dhcp_enabled {
-            let dev = netlink_sockets
-                .1
-                .get_link(netlink::LinkID::Name(if_name))
-                .wrap(format!(
-                    "get macvlan interface {}",
-                    &self.info.per_network_opts.interface_name
-                ))?;
-
-            let container_mac_address = get_mac_address(dev.attributes)?;
-            release_dhcp_lease(
-                &self
-                    .info
-                    .network
-                    .network_interface
-                    .clone()
-                    .unwrap_or_default(),
-                &self.info.per_network_opts.interface_name,
-                self.info.netns_path,
-                &container_mac_address,
-            )?
-        }
+        core_utils::dhcp_teardown(&self.info, netlink_sockets.1)?;
 
         let routes = core_utils::create_route_list(&self.info.network.routes)?;
         for route in routes.iter() {
@@ -385,17 +359,6 @@ fn setup(
     }
 
     get_mac_address(dev.attributes)
-}
-
-fn get_mac_address(v: Vec<LinkAttribute>) -> NetavarkResult<String> {
-    for nla in v.into_iter() {
-        if let LinkAttribute::Address(ref addr) = nla {
-            return Ok(CoreUtils::encode_address_to_hex(addr));
-        }
-    }
-    Err(NetavarkError::msg(
-        "failed to get the the container mac address",
-    ))
 }
 
 fn get_default_route_interface(host: &mut netlink::Socket) -> NetavarkResult<String> {

--- a/src/network/vlan.rs
+++ b/src/network/vlan.rs
@@ -7,7 +7,7 @@ use netlink_packet_route::link::{
 };
 use rand::distributions::{Alphanumeric, DistString};
 
-use crate::network::macvlan_dhcp::get_dhcp_lease;
+use crate::network::dhcp::{dhcp_teardown, get_dhcp_lease};
 use crate::{
     dns::aardvark::AardvarkEntry,
     error::{ErrorWrap, NetavarkError, NetavarkResult},
@@ -218,7 +218,7 @@ impl driver::NetworkDriver for Vlan<'_> {
         &self,
         netlink_sockets: (&mut netlink::Socket, &mut netlink::Socket),
     ) -> NetavarkResult<()> {
-        core_utils::dhcp_teardown(&self.info, netlink_sockets.1)?;
+        dhcp_teardown(&self.info, netlink_sockets.1)?;
 
         let routes = core_utils::create_route_list(&self.info.network.routes)?;
         for route in routes.iter() {

--- a/test/620-bridge-mode.bats
+++ b/test/620-bridge-mode.bats
@@ -40,3 +40,7 @@ load helpers
     assert_json "$link_info" '.[].flags[] | select(.=="UP")' == "UP" "Host bridge interface is up"
 }
 
+@test "bridge - managed mode with dhcp" {
+    expected_rc=1 run_netavark --file ${TESTSDIR}/testfiles/bridge-managed-dhcp.json setup $(get_container_netns_path)
+    assert_json ".error" "cannot use dhcp ipam driver without using the option mode=unmanaged" "dhcp error"
+}

--- a/test/testfiles/bridge-managed-dhcp.json
+++ b/test/testfiles/bridge-managed-dhcp.json
@@ -1,0 +1,28 @@
+{
+    "container_id": "6ce776ea58b5",
+    "container_name": "testcontainer",
+    "networks": {
+        "podman": {
+            "interface_name": "eth0",
+            "static_ips": []
+        }
+    },
+    "network_info": {
+        "podman": {
+            "dns_enabled": false,
+            "driver": "bridge",
+            "id": "53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
+            "internal": false,
+            "ipv6_enabled": false,
+            "name": "podman",
+            "network_interface": "podman0",
+            "subnets": [],
+            "options": {
+                "mode": "managed"
+            },
+            "ipam_options": {
+                "driver": "dhcp"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Support DHCP for bridge driver, like macvlan.
Only valid when using the unmanaged bridge mode.


Fixes #868