### PR TITLE
Add handling for firewalld's StrictForwardPorts setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 targets/
 *.swp
 netavark.1
+netavark-firewalld.7
 vendor/
 .idea/*
 contrib/systemd/*/*.service

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,9 +4,12 @@ MANDIR ?= $(DATADIR)/man
 GO ?= go
 GOMD2MAN ?= go-md2man
 
-docs: $(patsubst %.md,%,$(wildcard *.1.md))
+docs: $(patsubst %.md,%,$(wildcard *.[0-9].md))
 
 %.1: %.1.md
+	$(GOMD2MAN) -in $^ -out $@
+
+%.7: %.7.md
 	$(GOMD2MAN) -in $^ -out $@
 
 .PHONY: .install.md2man
@@ -17,6 +20,8 @@ docs: $(patsubst %.md,%,$(wildcard *.1.md))
 install:
 	install -d ${DESTDIR}/${MANDIR}/man1
 	install -m 0644 *.1 ${DESTDIR}/${MANDIR}/man1
+	install -d ${DESTDIR}/${MANDIR}/man7
+	install -m 0644 *.7 ${DESTDIR}/${MANDIR}/man7
 
 .PHONY: clean
 clean:

--- a/docs/netavark-firewalld.7.md
+++ b/docs/netavark-firewalld.7.md
@@ -1,0 +1,90 @@
+% NETAVARK-FIREWALLD 7 Netavark Firewalld Interactions Man Page
+% Matthew Heon
+% January 2025
+
+## Name
+
+netavark-firewalld - description of the interaction of Netavark and firewalld
+
+## Description
+
+Netavark can be used on systems with firewalld enabled without issue.
+When using the default `nftables` or `iptables` firewall drivers, on systems where firewalld is running, firewalld will automatically be configured to allow connectivity to Podman containers.
+All subnets of Podman-managed networks will be automatically added to the `trusted` zone to allow this access.
+
+### Firewalld Driver
+
+There is also a dedicated firewalld driver in Netavark.
+This driver uses the firewalld DBus API to natively interact with firewalld.
+It can be enabled by setting `firewall_driver` to `firewalld` in `containers.conf`.
+The native firewalld driver offers better integration with firewalld, but presently suffers from several limitations.
+It does not support isolation (the `--opt isolate=` option to `podman network create`.
+Connections to ports forwarded by a container on the same host can only be made through the IPv4 localhost IP (`127.0.0.1`).
+Using other IPs on the host will not work, unless the connection comes from a separate host.
+
+### Strict Port Forwarding
+
+Since firewalld version 2.3.0, a new setting, `StrictForwardPorts`, has been added.
+The setting is located in `/etc/firewalld/firewalld.conf` and defaults to `no` (disabled).
+When disabled, port forwarding with Podman works as normal.
+When it is enabled (set to `yes`), port forwarding with root Podman will become nonfunctional.
+Attempting to start a container or pod with the `-p` or `-P` options will return errors.
+When StrictForwardPorts is enabled, all port forwarding must be done through firewalld using the firewall-cmd tool.
+This ensures that containers cannot allow traffic through the firewall without administrator intervention.
+Please note that rootless Podman is unaffected by this setting, and will function as it always has.
+
+Instead, containers should be started without forwarded ports specified, and preferably with static IPs.
+
+To forward a port externally, the following command should be run, substituting the desired host and container port numbers, protocol, and the container's IP.
+```
+# firewall-cmd --permanent --zone {ZONE} --add-forward-port=port={HOST_PORT_NUMBER}:proto={PROTOCOL}:toport={CONTAINER_PORT_NUMBER}:toaddr={CONTAINER_IP}
+```
+
+If you are not sure which zone to use, the `public` zone should always work.
+
+If the container does not have a static IP, it can be found with `podman inspect`:
+```
+# podman inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {CONTAINER_NAME_OR_ID}
+```
+
+Once the container is stopped or removed, the rule must be manually removed with the following command:
+```
+# firewall-cmd --permanent --zone {ZONE} --remove-forward-port=port={HOST_PORT_NUMBER}:proto={PROTOCOL}:toport={CONTAINER_PORT_NUMBER}:toaddr={CONTAINER_IP}
+```
+
+To also allow forwarding via IPv4 localhost (`127.0.0.1`), a firewalld policy must be added, as well as a rich rule for each port requiring localhost forwarding.
+Forwarding via IPv6 localhost is not possible due to kernel limitations.
+
+To add the policies required for IPv4 localhost forwarding, the following commands must be run.
+This is only necessary once per system.
+```
+# firewall-cmd --permanent --new-policy localhostForward
+# firewall-cmd --permanent --policy localhostForward --add-ingress-zone HOST
+# firewall-cmd --permanent --policy localhostForward --add-egress-zone ANY
+```
+
+A further rich rule for each container is required:
+```
+# firewall-cmd --permanent --policy localhostForward --add-rich-rule='rule family=ipv4 destination address=127.0.0.0/8 forward-port port={HOST_PORT_NUMBER} protocol={PROTOCOL} to-port={CONTAINER_PORT_NUMBER} to-addr={CONTAINER_IP}'
+```
+
+These rules must be manually removed when the container is stopped or removed with the following command:
+```
+# firewall-cmd --permanent --policy localhostForward --remove-rich-rule='rule family=ipv4 destination address=127.0.0.0/8 forward-port port={HOST_PORT_NUMBER} protocol={PROTOCOL} to-port={CONTAINER_PORT_NUMBER} to-addr={CONTAINER_IP}'
+```
+
+The associated `localhostForward` policy does not need to be removed.
+
+Please also note that, at present, it is only possible to access forwarded ports of a container on the same host via the IPv4 localhost IP (`127.0.0.1`), and only when the rich rule above has been applied.
+Accessing via an IP that is not `127.0.0.1` from the same host is presently not possible, but we hope to address this with a future firewalld release.
+
+Please note that the firewalld driver presently bypasses this protection, and will still allow traffic through the firewall when `StrictForwardPorts` is enabled without manual forwarding through `firewall-cmd`.
+This may be changed in a future release.
+
+## SEE ALSO
+
+firewalld(1), firewall-cmd(1), firewalld.conf(5), podman(1), containers.conf(5)
+
+## Authors
+
+Matthew Heon <mheon@redhat.com>

--- a/rpm/netavark.spec
+++ b/rpm/netavark.spec
@@ -133,6 +133,7 @@ cd docs
 %dir %{_libexecdir}/podman
 %{_libexecdir}/podman/%{name}*
 %{_mandir}/man1/%{name}.1*
+%{_mandir}/man7/%{name}-firewalld.7*
 %{_unitdir}/%{name}-dhcp-proxy.service
 %{_unitdir}/%{name}-dhcp-proxy.socket
 %{_unitdir}/%{name}-firewalld-reload.service

--- a/src/commands/firewalld_reload.rs
+++ b/src/commands/firewalld_reload.rs
@@ -60,11 +60,16 @@ fn reload_rules_inner(config_dir: &Path) -> NetavarkResult<()> {
     if let Some(conf) = conf {
         let fw_driver = get_supported_firewall_driver(Some(conf.driver))?;
 
+        let dbus_conn = match zbus::blocking::Connection::system() {
+            Ok(c) => Some(c),
+            Err(_) => None,
+        };
+
         for net in conf.net_confs {
-            fw_driver.setup_network(net)?;
+            fw_driver.setup_network(net, &dbus_conn)?;
         }
         for port in &conf.port_confs {
-            fw_driver.setup_port_forward(port.into())?;
+            fw_driver.setup_port_forward(port.into(), &dbus_conn)?;
         }
         log::info!("Successfully reloaded firewall rules");
     }

--- a/src/firewall/fwnone.rs
+++ b/src/firewall/fwnone.rs
@@ -16,7 +16,11 @@ impl firewall::FirewallDriver for Fwnone {
         firewall::NONE
     }
 
-    fn setup_network(&self, _network_setup: SetupNetwork) -> NetavarkResult<()> {
+    fn setup_network(
+        &self,
+        _network_setup: SetupNetwork,
+        _dbus_conn: &Option<zbus::blocking::Connection>,
+    ) -> NetavarkResult<()> {
         Ok(())
     }
 
@@ -26,7 +30,11 @@ impl firewall::FirewallDriver for Fwnone {
         Ok(())
     }
 
-    fn setup_port_forward(&self, _setup_portfw: PortForwardConfig) -> NetavarkResult<()> {
+    fn setup_port_forward(
+        &self,
+        _setup_portfw: PortForwardConfig,
+        _dbus_conn: &Option<zbus::blocking::Connection>,
+    ) -> NetavarkResult<()> {
         Ok(())
     }
 

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -21,12 +21,20 @@ const NONE: &str = "none";
 /// and port mappings.
 pub trait FirewallDriver {
     /// Set up firewall rules for the given network,
-    fn setup_network(&self, network_setup: SetupNetwork) -> NetavarkResult<()>;
+    fn setup_network(
+        &self,
+        network_setup: SetupNetwork,
+        dbus_con: &Option<zbus::blocking::Connection>,
+    ) -> NetavarkResult<()>;
     /// Tear down firewall rules for the given network.
     fn teardown_network(&self, tear: TearDownNetwork) -> NetavarkResult<()>;
 
     /// Set up port-forwarding firewall rules for a given container.
-    fn setup_port_forward(&self, setup_pw: PortForwardConfig) -> NetavarkResult<()>;
+    fn setup_port_forward(
+        &self,
+        setup_pw: PortForwardConfig,
+        dbus_con: &Option<zbus::blocking::Connection>,
+    ) -> NetavarkResult<()>;
     /// Tear down port-forwarding firewall rules for a single container.
     fn teardown_port_forward(&self, teardown_pf: TeardownPortForward) -> NetavarkResult<()>;
 

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -417,7 +417,12 @@ impl<'a> Bridge<'a> {
             )?;
         }
 
-        self.info.firewall.setup_network(sn)?;
+        let system_dbus = match zbus::blocking::Connection::system() {
+            Ok(c) => Some(c),
+            Err(_) => None,
+        };
+
+        self.info.firewall.setup_network(sn, &system_dbus)?;
 
         if spf.port_mappings.is_some() {
             // Need to enable sysctl localnet so that traffic can pass
@@ -432,7 +437,7 @@ impl<'a> Bridge<'a> {
             )?;
         }
 
-        self.info.firewall.setup_port_forward(spf)?;
+        self.info.firewall.setup_port_forward(spf, &system_dbus)?;
         Ok(())
     }
 


### PR DESCRIPTION
This mostly amounts to throwing a sensible error in cases where the setting is enabled and the user has requested ports be forwarded.

There are no tests at present because firewalld 2.3.x is currently restricted to Rawhide, and is required for effective testing.

A manpage has also been added with details on how to work with the StrictForwardPorts setting (as well as some other tidbits on firewalld + Podman integration).