### PR TITLE
[v1.14] Release 1.14.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,7 @@ env:
     AARDVARK_DNS_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_DNS_BRANCH}"
     FEDORA_NETAVARK_AARCH64_AMI: "fedora-netavark-aws-arm64-${IMAGE_SUFFIX}"
     EC2_INST_TYPE: "t4g.xlarge"
+    NETAVARK_UPSTREAM: "1"
 
 
 gcp_credentials: ENCRYPTED[d6efdb7d6d4c61e3831df2193ca6348bb02f26cd931695f69d41930b1965f7dab72a838ca0902f6ed8cde66c7deddae2]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -257,10 +257,8 @@ success_task:
     API_URL_BASE: "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}"
     EXP_BINS: >-
         netavark
-        netavark.debug
         netavark.info
         netavark.aarch64-unknown-linux-gnu
-        netavark.debug.aarch64-unknown-linux-gnu
         netavark.info.aarch64-unknown-linux-gnu
   clone_script: *noop
   bin_cache: *ro_bin_cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "netavark"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netavark"
-version = "1.14.0"
+version = "1.14.1"
 edition = "2021"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
 endif
 
 .PHONY: all
-all: build
+all: build docs
 
 bin:
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ install: $(NV_UNIT_FILES)
 
 .PHONY: uninstall
 uninstall:
+	$(MAKE) -C docs uninstall
 	rm -f $(DESTDIR)$(LIBEXECPODMAN)/netavark
 	rm -f $(PREFIX)/share/man/man1/netavark*.1
 	rm -f ${DESTDIR}${SYSTEMDDIR}/netavark-dhcp-proxy.service

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ uninstall:
 	rm -f $(PREFIX)/share/man/man1/netavark*.1
 	rm -f ${DESTDIR}${SYSTEMDDIR}/netavark-dhcp-proxy.service
 	rm -f ${DESTDIR}${SYSTEMDDIR}/netavark-dhcp-proxy.socket
+	rm -f ${DESTDIR}${SYSTEMDDIR}/netavark-firewalld-reload.service
 
 .PHONY: test
 test: unit integration

--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,10 @@ $(CARGO_TARGET_DIR):
 	mkdir -p $@
 
 .PHONY: build
-build: build_netavark build_proxy_client
-
-.PHONY: build_netavark
-build_netavark: bin $(CARGO_TARGET_DIR)
+build: bin $(CARGO_TARGET_DIR)
 	$(CARGO) build $(release)
 	cp $(CARGO_TARGET_DIR)/$(profile)/netavark bin/netavark$(if $(debug),.debug,)
+	cp $(CARGO_TARGET_DIR)/$(profile)/netavark-dhcp-proxy-client bin/netavark-dhcp-proxy-client$(if $(debug),.debug,)
 
 .PHONY: examples
 examples: bin $(CARGO_TARGET_DIR)
@@ -152,8 +150,3 @@ mock-rpm:
 .PHONY: help
 help:
 	@echo "usage: make $(prog) [debug=1]"
-
-.PHONY: build_proxy_client
-build_proxy_client: bin $(CARGO_TARGET_DIR)
-	$(CARGO) build --bin netavark-dhcp-proxy-client $(release)
-	cp $(CARGO_TARGET_DIR)/$(profile)/netavark-dhcp-proxy-client bin/netavark-dhcp-proxy-client$(if $(debug),.debug,)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ CARGO ?= cargo
 CARGO_TARGET_DIR ?= targets
 export CARGO_TARGET_DIR  # 'cargo' is sensitive to this env. var. value.
 
+SOURCES = src/** Cargo.toml Cargo.lock
+
 ifdef debug
 $(info debug is $(debug))
   # These affect both $(CARGO_TARGET_DIR) layout and contents
@@ -50,10 +52,13 @@ $(CARGO_TARGET_DIR):
 	mkdir -p $@
 
 .PHONY: build
-build: bin $(CARGO_TARGET_DIR)
+build: bin/netavark
+
+bin/netavark: $(SOURCES) bin $(CARGO_TARGET_DIR)
 	$(CARGO) build $(release)
-	cp $(CARGO_TARGET_DIR)/$(profile)/netavark bin/netavark$(if $(debug),.debug,)
-	cp $(CARGO_TARGET_DIR)/$(profile)/netavark-dhcp-proxy-client bin/netavark-dhcp-proxy-client$(if $(debug),.debug,)
+	cp $(CARGO_TARGET_DIR)/$(profile)/netavark bin/netavark
+	cp $(CARGO_TARGET_DIR)/$(profile)/netavark-dhcp-proxy-client bin/netavark-dhcp-proxy-client
+
 
 .PHONY: examples
 examples: bin $(CARGO_TARGET_DIR)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v1.14.1
+
+* Fixed an issue where the Makefile did not install the `netavark-firewalld(7)` man page. ([#1179](https://github.com/containers/netavark/issues/1179))
+* Fixed the detection of Firewalld's StrictForwardPorts property.
+* Upstream tests no longer check for the commit sha in the version output by default so downstream tests on packaged versions without the commit info can pass.
+
 ## v1.14.0
 
 * bridge: Add support for a new option called `mode`. When set to `unmanaged` only the veth pair and ip addresses are setup. The bridge must exist and no firewall or sysctl setting will be configured in this mode. ([#1090](https://github.com/containers/netavark/issues/1090))

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -19,9 +19,9 @@ _run_noarg() {
 _run_build() {
     # Assume we're on a fast VM, compile everything needed by the
     # rest of CI since subsequent tasks may have limited resources.
-    make all debug=1
     make build_unit  # reuses some debug binaries
     make all  # optimized/non-debug binaries
+    make examples # build the examples binaries needed by the integration tests
     # This will get scooped up and become part of the artifact archive.
     # Identify where the binary came from to benefit downstream consumers.
     cat | tee bin/netavark.info << EOF

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,12 +17,17 @@ docs: $(patsubst %.md,%,$(wildcard *.[0-9].md))
 	$(GO) install github.com/cpuguy83/go-md2man/v2@latest
 
 .PHONY: install
-install:
+install: docs
 	install -d ${DESTDIR}/${MANDIR}/man1
 	install -m 0644 *.1 ${DESTDIR}/${MANDIR}/man1
 	install -d ${DESTDIR}/${MANDIR}/man7
 	install -m 0644 *.7 ${DESTDIR}/${MANDIR}/man7
 
+.PHONY: uninstall
+uninstall:
+	rm -f ${DESTDIR}/${MANDIR}/man1/*.1
+	rm -f ${DESTDIR}/${MANDIR}/man7/*.7
+
 .PHONY: clean
 clean:
-	$(RM) *.1
+	$(RM) *.1 *.7

--- a/test/001-basic.bats
+++ b/test/001-basic.bats
@@ -12,7 +12,9 @@ load helpers
     run_netavark version
     json="$output"
     assert_json "$json" ".version" =~ "^1\.[0-9]+\.[0-9]+(-rc[0-9]|-dev)?" "correct version"
-    assert_json "$json" ".commit" =~ "[0-9a-f]{40}" "shows commit sha"
+    if [ -n "$NETAVARK_UPSTREAM" ]; then
+        assert_json "$json" ".commit" =~ "[0-9a-f]{40}" "shows commit sha"
+    fi
     assert_json "$json" ".build_time" =~ "20.*" "show build date"
     assert_json "$json" ".target" =~ ".*" "contains target string"
 }


### PR DESCRIPTION
Release + backports from
https://github.com/containers/netavark/pull/1202
https://github.com/containers/netavark/pull/1191
https://github.com/containers/netavark/pull/1184