### PR TITLE
Add link to c/common contributor's guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to Containers/netavark
+
+We'd love to have you join the community! Learn [here](https://github.com/containers/common/blob/main/CONTRIBUTING.md) how to contribute to the Containers Group Projects.

--- a/README.md
+++ b/README.md
@@ -54,3 +54,5 @@ and [PRs](https://github.com/containers/netavark/pulls) tracking system.
 ## Plugins
 
 Netavark also supports executing external plugins, see [./plugin-API.md](./plugin-API.md).
+
+## [Contributing](./CONTRIBUTING.md)


### PR DESCRIPTION
This PR adds a link to the c/common contributor's guide. 

Fixes: https://issues.redhat.com/browse/RUN-2321

Note: After the merge https://github.com/containers/common/pull/2386, the contributor's guide will contain sections specific to Golang and Rust. 