### PR TITLE
Cargo.lock: fix desync with Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-packet-generic",
- "netlink-packet-utils",
+ "netlink-packet-utils 0.5.2",
  "netlink-proto",
  "netlink-sys",
  "thiserror 1.0.69",
@@ -843,7 +843,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-packet-generic",
- "netlink-packet-utils",
+ "netlink-packet-utils 0.5.2",
  "netlink-proto",
  "thiserror 1.0.69",
 ]
@@ -1403,7 +1403,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-packet-generic",
- "netlink-packet-utils",
+ "netlink-packet-utils 0.5.2",
  "netlink-proto",
  "netlink-sys",
  "thiserror 1.0.69",
@@ -1436,7 +1436,7 @@ dependencies = [
  "mozim",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
+ "netlink-packet-utils 0.6.0",
  "netlink-sys",
  "nftables",
  "nispor",
@@ -1467,7 +1467,7 @@ checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 dependencies = [
  "anyhow",
  "byteorder",
- "netlink-packet-utils",
+ "netlink-packet-utils 0.5.2",
 ]
 
 [[package]]
@@ -1479,7 +1479,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "netlink-packet-core",
- "netlink-packet-utils",
+ "netlink-packet-utils 0.5.2",
 ]
 
 [[package]]
@@ -1494,7 +1494,7 @@ dependencies = [
  "libc",
  "log",
  "netlink-packet-core",
- "netlink-packet-utils",
+ "netlink-packet-utils 0.5.2",
 ]
 
 [[package]]
@@ -1507,6 +1507,17 @@ dependencies = [
  "byteorder",
  "paste",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3176f18d11a1ae46053e59ec89d46ba318ae1343615bd3f8c908bfc84edae35c"
+dependencies = [
+ "byteorder",
+ "pastey",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1646,6 +1657,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8cb46bdc156b1c90460339ae6bfd45ba0394e5effbaa640badb4987fdc261"
 
 [[package]]
 name = "percent-encoding"
@@ -1934,7 +1951,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
+ "netlink-packet-utils 0.5.2",
  "netlink-proto",
  "netlink-sys",
  "nix 0.29.0",
@@ -2807,7 +2824,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-packet-generic",
- "netlink-packet-utils",
+ "netlink-packet-utils 0.5.2",
  "netlink-proto",
  "netlink-sys",
  "thiserror 1.0.69",


### PR DESCRIPTION
Somehow renovate created a borken PR by not updating Cargo.lock but it still passed CI. It is not clear what happened but this needs investigation, anyhow for the time being fix the unclean tree by committing the missing Cargo.lock changes.

Fixes: 84ec7510 ("fix(deps): update rust crate netlink-packet-utils to 0.6.0")