### PR TITLE
.github: check_cirrus_cron work around github bug

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     # N/B: This should correspond to a period slightly after
     # the last job finishes running.  See job defs. at:
-    # https://cirrus-ci.com/settings/repository/5138144844840960
+    # https://cirrus-ci.com/settings/repository/5268168076689408
     - cron:  '03 03 * * 1-5'
   # Debug: Allow triggering job manually in github-actions WebUI
   workflow_dispatch: {}
@@ -17,4 +17,9 @@ jobs:
   # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
   call_cron_failures:
     uses: containers/podman/.github/workflows/check_cirrus_cron.yml@main
-    secrets: inherit
+    secrets:
+      SECRET_CIRRUS_API_KEY: ${{secrets.SECRET_CIRRUS_API_KEY}}
+      ACTION_MAIL_SERVER: ${{secrets.ACTION_MAIL_SERVER}}
+      ACTION_MAIL_USERNAME: ${{secrets.ACTION_MAIL_USERNAME}}
+      ACTION_MAIL_PASSWORD: ${{secrets.ACTION_MAIL_PASSWORD}}
+      ACTION_MAIL_SENDER: ${{secrets.ACTION_MAIL_SENDER}}


### PR DESCRIPTION
So I wondered why our email workflow only reported things for podman...

It seems the secrets: inherit is broken and no longer working, I see all jobs on all repos failing with:

Error when evaluating 'secrets'. .github/workflows/check_cirrus_cron.yml (Line: 19, Col: 11): Secret SECRET_CIRRUS_API_KEY is required, but not provided while calling.

This makes no sense to me I doubled checked the names, nothing changed on our side and it is consistent for all projects. Interestingly this same thing passed on March 10 and 11 (on all repos) but failed before and after this as well.

Per[1] we are not alone, anyway let's try to get this working again even if it means more duplication.

[1] actions/runner#2709