### PR TITLE
Makefile: correctly set SOURCES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CARGO ?= cargo
 CARGO_TARGET_DIR ?= targets
 export CARGO_TARGET_DIR  # 'cargo' is sensitive to this env. var. value.
 
-SOURCES = src/** Cargo.toml Cargo.lock
+SOURCES = $(shell find src/ -type f) Cargo.toml Cargo.lock Makefile
 
 ifdef debug
 $(info debug is $(debug))


### PR DESCRIPTION
Use find to list all source files recursively, the ** doesn't actually seem to work correctly in all cases. It requires the use the the globstar shell option which may or may not be set.

While at it also add Makefile so we rebuild if the Makefile is changed, e.g. when adding new flags to cargo.

Fixes: a08bb557fd ("Makefile: do not rebuild if nothing changed")