### PR TITLE
aardvark: handle names more safely

### DIFF
--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -58,17 +58,25 @@ impl Teardown {
         let mut aardvark_entries = Vec::new();
         for (key, network) in &network_options.network_info {
             if network.dns_enabled && network.driver == DRIVER_BRIDGE {
-                aardvark_entries.push(AardvarkEntry {
-                    network_name: key,
-                    network_gateways: Vec::new(),
-                    network_dns_servers: &None,
-                    container_id: &network_options.container_id,
-                    container_ips_v4: Vec::new(),
-                    container_ips_v6: Vec::new(),
-                    container_names: Vec::new(),
-                    container_dns_servers: &None,
-                    is_internal: network.internal,
-                });
+                match network_options.container_id.as_str().try_into() {
+                    Ok(id) => {
+                        aardvark_entries.push(AardvarkEntry {
+                            network_name: key,
+                            network_gateways: Vec::new(),
+                            network_dns_servers: &None,
+                            container_id: id,
+                            container_ips_v4: Vec::new(),
+                            container_ips_v6: Vec::new(),
+                            container_names: Vec::new(),
+                            container_dns_servers: &None,
+                            is_internal: network.internal,
+                        });
+                    }
+                    Err(err) => log::warn!(
+                        "invalid container id {}: {err}",
+                        network_options.container_id
+                    ),
+                }
             }
         }
 

--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -27,7 +27,7 @@ pub struct AardvarkEntry<'a> {
     pub container_id: &'a str,
     pub container_ips_v4: Vec<Ipv4Addr>,
     pub container_ips_v6: Vec<Ipv6Addr>,
-    pub container_names: Vec<String>,
+    pub container_names: Vec<&'a str>,
     pub container_dns_servers: &'a Option<Vec<IpAddr>>,
     pub is_internal: bool,
 }

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -239,9 +239,18 @@ impl driver::NetworkDriver for Bridge<'_> {
                     }
                 }
             }
-            let mut names = vec![self.info.container_name.to_string()];
+
+            // get size so we can preallocate the vector which is more efficient
+            let len = match &self.info.per_network_opts.aliases {
+                Some(n) => n.len() + 1,
+                None => 1,
+            };
+            let mut names = Vec::with_capacity(len);
+            names.push(self.info.container_name.as_str());
             if let Some(n) = &self.info.per_network_opts.aliases {
-                names.extend(n.clone());
+                for name in n {
+                    names.push(name);
+                }
             }
 
             let gw = data

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -7,6 +7,7 @@ use netlink_packet_route::link::{
     LinkMessage,
 };
 
+use crate::dns::aardvark::SafeString;
 use crate::network::dhcp::{dhcp_teardown, get_dhcp_lease};
 use crate::{
     dns::aardvark::AardvarkEntry,
@@ -246,10 +247,10 @@ impl driver::NetworkDriver for Bridge<'_> {
                 None => 1,
             };
             let mut names = Vec::with_capacity(len);
-            names.push(self.info.container_name.as_str());
-            if let Some(n) = &self.info.per_network_opts.aliases {
-                for name in n {
-                    names.push(name);
+            maybe_add_alias(&mut names, self.info.container_name);
+            if let Some(aliases) = &self.info.per_network_opts.aliases {
+                for name in aliases {
+                    maybe_add_alias(&mut names, name);
                 }
             }
 
@@ -260,17 +261,23 @@ impl driver::NetworkDriver for Bridge<'_> {
                 .map(|ipnet| ipnet.addr())
                 .collect();
 
-            Some(AardvarkEntry {
-                network_name: &self.info.network.name,
-                container_id: self.info.container_id,
-                network_gateways: gw,
-                network_dns_servers: &self.info.network.network_dns_servers,
-                container_ips_v4: ipv4,
-                container_ips_v6: ipv6,
-                container_names: names,
-                container_dns_servers: self.info.container_dns_servers,
-                is_internal: self.info.network.internal,
-            })
+            match self.info.container_id.as_str().try_into() {
+                Ok(id) => Some(AardvarkEntry {
+                    network_name: &self.info.network.name,
+                    container_id: id,
+                    network_gateways: gw,
+                    network_dns_servers: &self.info.network.network_dns_servers,
+                    container_ips_v4: ipv4,
+                    container_ips_v6: ipv6,
+                    container_names: names,
+                    container_dns_servers: self.info.container_dns_servers,
+                    is_internal: self.info.network.internal,
+                }),
+                Err(err) => {
+                    log::warn!("invalid container id {}: {err}", &self.info.container_id);
+                    None
+                }
+            }
         } else {
             // If --dns-enable=false and --dns was set then return following DNS servers
             // in status_block so podman can use these and populate resolv.conf
@@ -1003,5 +1010,15 @@ fn get_bridge_mode_from_string(mode: Option<&str>) -> NetavarkResult<BridgeMode>
         Some(name) => Err(NetavarkError::msg(format!(
             "invalid bridge mode \"{name}\""
         ))),
+    }
+}
+
+fn maybe_add_alias<'a>(names: &mut Vec<SafeString<'a>>, name: &'a str) {
+    match name.try_into() {
+        Ok(name) => names.push(name),
+        Err(err) => log::warn!(
+            "invalid network alias {:?}: {err}, ignoring this name",
+            name
+        ),
     }
 }

--- a/test/testfiles/dns-invalid-names.json
+++ b/test/testfiles/dns-invalid-names.json
@@ -1,0 +1,38 @@
+{
+  "container_id": "f031bf33eecba75d0d84952337b1ceef6a239eb8e94b48aee0993d0791345325",
+  "container_name": "somename",
+  "networks": {
+    "podman1": {
+      "static_ips": [
+        "10.89.3.2"
+      ],
+      "aliases": [
+        "valid",
+        "space 1",
+        "comma,1",
+        "newline\n2"
+      ],
+      "interface_name": "eth0"
+    }
+  },
+  "network_info": {
+    "podman1": {
+      "name": "podman1",
+      "id": "ec79dd0cad82083c8ac5cc23e9542e4ddea813dff60d68258d36e84f6393b63b",
+      "driver": "bridge",
+      "network_interface": "podman1",
+      "subnets": [
+        {
+          "subnet": "10.89.3.0/24",
+          "gateway": "10.89.3.1"
+        }
+      ],
+      "ipv6_enabled": false,
+      "internal": false,
+      "dns_enabled": true,
+      "ipam_options": {
+        "driver": "host-local"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Since we write space, command and newline separated file these
characters have a special meaning when parsing the file. Any such
character inside the strings can break the parser. We need checks to
disallow these characters.

While it would have been easy to add a check at the time we write the
file there we could not really make a good decision on what to do with
the value. As such I create a newtype which wraps the string but it can
only be constructed via the TryFrom trait. That is enough to gurantee
that any caller must have called the validation code.

Note that we only print a warning and ignore such invalid value, a hard
error might cause compatibility issues as per the issue some automated
tooling generates such names.

Fixes: https://github.com/containers/netavark/issues/1019
Fixes: https://github.com/containers/podman/issues/25927