### PR TITLE
minor dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,7 +1431,7 @@ dependencies = [
  "log",
  "mozim",
  "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-route 0.23.0",
  "netlink-sys",
  "nftables",
  "nix 0.30.1",
@@ -1479,6 +1479,21 @@ name = "netlink-packet-route"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0800eae8638a299eaa67476e1c6b6692922273e0f7939fd188fc861c837b9cd2"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1933,7 +1948,7 @@ dependencies = [
  "futures",
  "log",
  "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-route 0.22.0",
  "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,7 +1434,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-sys",
  "nftables",
- "nix 0.29.0",
+ "nix 0.30.1",
  "once_cell",
  "prost",
  "rand 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,7 +1434,6 @@ dependencies = [
  "netlink-packet-route",
  "netlink-sys",
  "nftables",
- "nispor",
  "nix 0.29.0",
  "once_cell",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ zbus = { version = "5.7.1" }
 nix = { version = "0.30.1", features = ["sched", "signal", "user"] }
 rand = "0.9.1"
 sha2 = "0.10.9"
-netlink-packet-route = "0.22.0"
+netlink-packet-route = "0.23.0"
 netlink-packet-core = "0.7.0"
 netlink-sys = "0.8.7"
 nftables = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ prost = "0.13.5"
 futures-channel = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
-nispor = "1.2.23"
 tower = { version = "0.5.2", features = ["util"] }
 hyper-util = "0.1.12"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 sysctl = "0.6.0"
 zbus = { version = "5.7.1" }
-nix = { version = "0.29.0", features = ["sched", "signal", "user"] }
+nix = { version = "0.30.1", features = ["sched", "signal", "user"] }
 rand = "0.9.1"
 sha2 = "0.10.9"
 netlink-packet-route = "0.22.0"


### PR DESCRIPTION
remove unused nispor from Cargo.toml

update nix to v0.30.1

update netlink-packet-route to v0.23.0

## Summary by Sourcery

Refresh project dependencies by bumping nix and netlink-packet-route versions and eliminating the unused nispor crate.

Build:
- Upgrade nix crate to v0.30.1 with existing features
- Update netlink-packet-route crate to v0.23.0
- Remove unused nispor dependency