### PR TITLE
Revert "remove search domain from response"

### DIFF
--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -17,7 +17,7 @@ use crate::{
         iptables::MAX_HASH_SIZE,
         state::{remove_fw_config, write_fw_config},
     },
-    network::{core_utils::disable_ipv6_autoconf, types},
+    network::{constants, core_utils::disable_ipv6_autoconf, types},
 };
 
 use super::{
@@ -227,6 +227,11 @@ impl driver::NetworkDriver for Bridge<'_> {
             let _ = response
                 .dns_server_ips
                 .insert(data.ipam.nameservers.clone());
+            // Note: this is being added so podman setup is backward compatible with the design
+            // which we had with dnsname/dnsmasq.
+            let _ = response
+                .dns_search_domains
+                .insert(vec![constants::PODMAN_DEFAULT_SEARCH_DOMAIN.to_string()]);
 
             let mut ipv4 = Vec::new();
             let mut ipv6 = Vec::new();

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -316,8 +316,6 @@ fw_driver=iptables
 
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
         setup $(get_container_netns_path)
-    config="$output"
-    assert_json "$config" ".podman1.dns_search_domains" == "[]" "empty search domains"
 
     # check iptables
     run_in_host_netns iptables -t nat -S NETAVARK-HOSTPORT-DNAT

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -162,8 +162,6 @@ function setup() {
     NETAVARK_DNS_PORT="$dns_port" \
         run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
         setup $(get_container_netns_path)
-    config="$output"
-    assert_json "$config" ".podman1.dns_search_domains" == "[]" "empty search domains"
 
     # check iptables
     # firewall-cmd --list-rich-rules does not guarantee order, use sort

--- a/test/250-bridge-nftables.bats
+++ b/test/250-bridge-nftables.bats
@@ -314,8 +314,6 @@ export NETAVARK_FW=nftables
 
     NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/dualstack-bridge.json \
         setup $(get_container_netns_path)
-    config="$output"
-    assert_json "$config" ".podman1.dns_search_domains" == "[]" "empty search domains"
 
     # check nftables
     run_in_host_netns nft list chain inet netavark NETAVARK-HOSTPORT-DNAT


### PR DESCRIPTION
This reverts commit 9035c677338a62a21ab58698527e9756ce1de842. The commit broke the name lookup for podman containers when other host search domains are defined that respond to the same name.

Fixes: containers/podman#26198