### PR TITLE
release v1.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "netavark"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netavark"
-version = "1.15.0"
+version = "1.15.1"
 edition = "2021"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v1.15.1
+
+* Fixed a regression that caused container name lookups to get the wrong ip address when the host's search domain responded for the same name. ([containers/podman#26198](https://github.com/containers/podman/issues/26198))
+
 ## v1.15.0
 
 * Fixed an issue where invalid dns names that included a space would cause aardvark-dns to crash. Instead such names are now ignored and generate a warning. ([#1019](https://github.com/containers/netavark/issues/1019))


### PR DESCRIPTION
Note I accidentally pushed the backport commit https://github.com/containers/netavark/commit/ad51a4aff61d071d391738037c53b344a1435a11 directly to the upstream branch that is why it is not show in the diff here

## Summary by Sourcery

Release v1.15.1 with a version bump and updated release notes, including a fix for DNS name lookup regression.

Bug Fixes:
- Fix regression where container name lookups returned the wrong IP when the host's search domain responded for the same name.

Documentation:
- Add release notes for v1.15.1 describing the DNS lookup regression fix.

Chores:
- Bump package version to 1.15.1 and update Cargo.lock.