### PR TITLE
update nix to v0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
  "netlink-packet-route 0.23.0",
  "netlink-sys",
  "nftables",
- "nix 0.29.0",
+ "nix 0.30.1",
  "once_cell",
  "prost",
  "rand 0.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4.27"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 zbus = { version = "5.7.1" }
-nix = { version = "0.29.0", features = ["sched", "signal", "user"] }
+nix = { version = "0.30.1", features = ["sched", "signal", "user"] }
 rand = "0.9.1"
 sha2 = "0.10.9"
 netlink-packet-route = "0.23.0"


### PR DESCRIPTION
Because the renovate PR doesn't create the proper lockfile diff https://github.com/containers/netavark/pull/1265

## Summary by Sourcery

Enhancements:
- Update nix dependency to v0.30.1 and regenerate Cargo.lock