### PR TITLE
release v1.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,9 +487,9 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "dhcproto"
-version = "0.9.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcee045385d5f7819022821f41209b9945d17550760b0b2349aaef4ecfa14bc3"
+checksum = "f6794294f2c4665aae452e950c2803a1e487c5672dc8448f0bfa3f52ff67e270"
 dependencies = [
  "dhcproto-macros",
  "hex",
@@ -1221,7 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b627935a2f5d654613bea2bcd677cc760b03ecf224ced0f1970c0d174813b9"
 dependencies = [
  "lazy_static",
- "nix 0.29.0",
+ "nix",
  "regex",
 ]
 
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "mozim"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610e34113d007c3588631f879854c14fbf291f3ab7853b833220f7cbf6ece8ad"
+checksum = "8232b853f83a0c76331d934627aeec172e9d5f2c82d1f9e7f86caa0df72cb304"
 dependencies = [
  "byteorder",
  "dhcproto",
@@ -1382,7 +1382,7 @@ dependencies = [
  "libc",
  "log",
  "nispor",
- "nix 0.27.1",
+ "nix",
  "rand 0.8.5",
 ]
 
@@ -1435,7 +1435,7 @@ dependencies = [
  "netlink-sys",
  "nftables",
  "nispor",
- "nix 0.29.0",
+ "nix",
  "once_cell",
  "prost",
  "rand 0.9.1",
@@ -1560,17 +1560,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "wl-nl80211",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -1926,7 +1915,7 @@ dependencies = [
  "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.29.0",
+ "nix",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -2927,7 +2916,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix 0.29.0",
+ "nix",
  "ordered-stream",
  "serde",
  "serde_repr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "netavark"
-version = "1.15.1"
+version = "1.15.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netavark"
-version = "1.15.1"
+version = "1.15.2"
 edition = "2021"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ fs2 = "0.4.3"
 tokio = { version = "1.45.0", features = ["rt", "rt-multi-thread", "signal", "fs"] }
 tokio-stream = { version = "0.1.17", features = ["net"] }
 tonic = "0.13.1"
-mozim = "0.2.5"
+mozim = "0.2.6"
 prost = "0.13.5"
 futures-channel = "0.3.31"
 futures-core = "0.3.31"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## v1.15.2
+
+* Fixed a bug that caused a thread leak in the dhcp-proxy for each started container. ([#811](https://github.com/containers/netavark/issues/811))
+* Fixed a bug which printed bogus errors when the dhcp-proxy was run with an activity timeout of 0. ([#1262](https://github.com/containers/netavark/issues/1262))
+
 ## v1.15.1
 
 * Fixed a regression that caused container name lookups to get the wrong ip address when the host's search domain responded for the same name. ([containers/podman#26198](https://github.com/containers/podman/issues/26198))


### PR DESCRIPTION
So we can get the thread leak fix out to users.

## Summary by Sourcery

Release v1.15.2: fix thread leak in the DHCP proxy, suppress bogus errors when activity timeout is zero, and make inactivity timeout optional.

Bug Fixes:
- Fix a thread leak in the DHCP proxy for each started container
- Suppress bogus errors when the DHCP proxy is run with an activity timeout of zero

Enhancements:
- Make the DHCP proxy inactivity timeout channel optional and disable related tasks when timeout is set to zero

Documentation:
- Add v1.15.2 release notes

Chores:
- Bump package version to v1.15.2
- Update mozim dependency to 0.2.6