### PR TITLE
fix new rust 1.88 lint errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -72,9 +72,9 @@ fn main() {
         "nftables" => "nftables",
         "iptables" => "iptables",
         "none" => "none",
-        inv => panic!("Invalid default firewall driver {}", inv),
+        inv => panic!("Invalid default firewall driver {inv}"),
     };
     println!("cargo:rustc-check-cfg=cfg(default_fw, values(\"nftables\", \"iptables\", \"none\"))");
-    println!("cargo:rustc-cfg=default_fw=\"{}\"", fwdriver);
+    println!("cargo:rustc-cfg=default_fw=\"{fwdriver}\"");
     println!("cargo:rustc-env=DEFAULT_FW={fwdriver}");
 }

--- a/src/commands/dhcp_proxy.rs
+++ b/src/commands/dhcp_proxy.rs
@@ -69,13 +69,13 @@ impl<W: Write + Clear> NetavarkProxyService<W> {
             let locked_sender = match sender_clone.lock() {
                 Ok(v) => v,
                 Err(e) => {
-                    log::error!("{}", e);
+                    log::error!("{e}");
                     return;
                 }
             };
             match locked_sender.try_send(1) {
                 Ok(..) => {}
-                Err(e) => log::error!("{}", e),
+                Err(e) => log::error!("{e}"),
             }
         }
     }
@@ -214,7 +214,7 @@ async fn handle_signal(uds_path: PathBuf) {
             }
         }
         if let Err(e) = fs::remove_file(uds_path) {
-            error!("Could not close uds socket: {}", e);
+            error!("Could not close uds socket: {e}");
         }
 
         std::process::exit(0x0100);
@@ -266,7 +266,7 @@ pub async fn serve(opts: Opts) -> NetavarkResult<()> {
     let fq_cache_path = get_cache_fqname(optional_run_dir);
     let file = match File::create(&fq_cache_path) {
         Ok(file) => {
-            debug!("Successfully created leases file: {:?}", fq_cache_path);
+            debug!("Successfully created leases file: {fq_cache_path:?}");
             file
         }
         Err(e) => {
@@ -387,7 +387,7 @@ fn is_catch_empty<W: Write + Clear>(current_cache: Arc<Mutex<LeaseCache<W>>>) ->
             v.is_empty()
         }
         Err(e) => {
-            log::error!("{}", e);
+            log::error!("{e}");
             false
         }
     }

--- a/src/commands/firewalld_reload.rs
+++ b/src/commands/firewalld_reload.rs
@@ -26,7 +26,7 @@ pub fn listen(config_dir: Option<OsString>) -> NetavarkResult<()> {
             .as_deref()
             .unwrap_or(OsStr::new(constants::DEFAULT_CONFIG_DIR)),
     );
-    log::debug!("looking for firewall configs in {:?}", config_dir);
+    log::debug!("looking for firewall configs in {config_dir:?}");
 
     let conn = Connection::system()?;
     let proxy = FirewallDDbusProxyBlocking::builder(&conn)
@@ -43,7 +43,7 @@ pub fn listen(config_dir: Option<OsString>) -> NetavarkResult<()> {
 
     // This loops forever until the process is killed or there is some dbus error.
     for _ in proxy.0.receive_signal(SIGNAL_NAME)? {
-        log::debug!("got firewalld {} signal", SIGNAL_NAME);
+        log::debug!("got firewalld {SIGNAL_NAME} signal");
         reload_rules(config_dir, &conn_option);
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,8 +12,7 @@ pub mod version;
 fn get_config_dir(dir: Option<OsString>, cmd: &str) -> NetavarkResult<OsString> {
     dir.ok_or_else(|| {
         NetavarkError::msg(format!(
-            "--config not specified but required for netavark {}",
-            cmd
+            "--config not specified but required for netavark {cmd}"
         ))
     })
 }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -152,7 +152,7 @@ impl Setup {
                 );
             }
         }
-        debug!("{:#?}", response);
+        debug!("{response:#?}");
         let response_json = serde_json::to_string(&response)?;
         println!("{response_json}");
         debug!("Setup complete");

--- a/src/dhcp_proxy/cache.rs
+++ b/src/dhcp_proxy/cache.rs
@@ -64,7 +64,7 @@ impl<W: Write + Clear> LeaseCache<W> {
     /// returns: Result<(), Error>
     ///
     pub fn add_lease(&mut self, mac_addr: &str, lease: &NetavarkLease) -> Result<(), io::Error> {
-        debug!("add lease: {:?}", mac_addr);
+        debug!("add lease: {mac_addr:?}");
         // Update cache memory with new lease
         let cache = &mut self.mem;
         cache.insert(mac_addr.to_string(), vec![lease.clone()]);
@@ -95,7 +95,7 @@ impl<W: Write + Clear> LeaseCache<W> {
     ///
     /// * `mac_addr`: Mac address of the container
     pub fn remove_lease(&mut self, mac_addr: &str) -> Result<Lease, io::Error> {
-        debug!("remove lease: {:?}", mac_addr);
+        debug!("remove lease: {mac_addr:?}");
         let mem = &mut self.mem;
         // Check and see if the lease exists, if not create an empty one
         let lease = match mem.get(mac_addr) {
@@ -150,10 +150,7 @@ impl<W: Write + Clear> LeaseCache<W> {
                 writer.flush()
             }
             Err(e) => {
-                error!(
-                    "Could not clear the writer. Not updating lease information: {:?}",
-                    e
-                );
+                error!("Could not clear the writer. Not updating lease information: {e:?}");
                 Ok(())
             }
         }

--- a/src/dhcp_proxy/ip.rs
+++ b/src/dhcp_proxy/ip.rs
@@ -84,7 +84,7 @@ fn test_handle_gws() {
 // IPV4 implementation
 impl Address<Ipv4Addr> for MacVLAN {
     fn new(l: &NetavarkLease, interface: &str) -> Result<MacVLAN, ProxyError> {
-        debug!("new ipv4 macvlan for {}", interface);
+        debug!("new ipv4 macvlan for {interface}");
         let address = match IpAddr::from_str(&l.yiaddr) {
             Ok(a) => a,
             Err(e) => {
@@ -94,7 +94,7 @@ impl Address<Ipv4Addr> for MacVLAN {
         let gateways = match handle_gws(l.gateways.clone(), &l.subnet_mask) {
             Ok(g) => g,
             Err(e) => {
-                return Err(ProxyError::new(format!("bad gateways: {}", e)));
+                return Err(ProxyError::new(format!("bad gateways: {e}")));
             }
         };
         let prefix_length = match get_prefix_length_v4(&l.subnet_mask) {
@@ -135,7 +135,7 @@ impl Address<Ipv4Addr> for MacVLAN {
 // setup takes the DHCP lease and some additional information and
 // applies the TCP/IP information to the namespace.
 pub fn setup(lease: &NetavarkLease, interface: &str, ns_path: &str) -> Result<(), ProxyError> {
-    debug!("setting up {}", interface);
+    debug!("setting up {interface}");
     let vlan = MacVLAN::new(lease, interface)?;
     let (_, mut netns) = core_utils::open_netlink_sockets(ns_path)?;
     vlan.add_ip(&mut netns.netlink)?;

--- a/src/dhcp_proxy/proxy_conf.rs
+++ b/src/dhcp_proxy/proxy_conf.rs
@@ -119,7 +119,6 @@ mod conf_tests {
     ///
     /// The following stanzas of code should be attributed to https://github.com/vmx/temp-env
     ///
-
     /// The previous value is restored when the closure completes or panics, before unwinding the
     /// panic.
     ///

--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -135,7 +135,7 @@ impl Aardvark {
             OsStr::new("run"),
         ]);
 
-        log::debug!("start aardvark-dns: {:?}", aardvark_args);
+        log::debug!("start aardvark-dns: {aardvark_args:?}");
 
         // After https://github.com/containers/aardvark-dns/pull/148 this command
         // will block till aardvark-dns's parent process returns back and let

--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -147,7 +147,7 @@ impl firewall::FirewallDriver for FirewallD {
 
         if let Some(subnets) = tear.config.subnets {
             for subnet in subnets {
-                debug!("Removing subnet {} from zone {}", subnet, ZONENAME);
+                debug!("Removing subnet {subnet} from zone {ZONENAME}");
                 let _ = self.conn.call_method(
                     Some("org.fedoraproject.FirewallD1"),
                     "/org/fedoraproject/FirewallD1",
@@ -208,7 +208,7 @@ impl firewall::FirewallDriver for FirewallD {
                     if port.host_ip == "127.0.0.1" {
                         if let Some(v4) = setup_portfw.container_ip_v4 {
                             let rule = get_localhost_pf_rich_rule(port, &v4);
-                            debug!("Adding localhost pf rule: {}", rule);
+                            debug!("Adding localhost pf rule: {rule}");
                             localhost_rich_rules.append(Value::new(rule))?;
                         }
                         continue;
@@ -247,7 +247,7 @@ impl firewall::FirewallDriver for FirewallD {
                             port_forwarding_rules
                                 .append(Value::new(make_port_tuple(port, &v4.to_string())))?;
                             let localhost_rule = get_localhost_pf_rich_rule(port, &v4);
-                            debug!("Adding localhost pf rule: {}", localhost_rule);
+                            debug!("Adding localhost pf rule: {localhost_rule}");
                             localhost_rich_rules.append(Value::new(localhost_rule))?;
                         }
                     }
@@ -430,13 +430,13 @@ impl firewall::FirewallDriver for FirewallD {
                         };
                         let mut is_match = false;
                         if let Some(v4) = &ipv4 {
-                            debug!("Checking firewalld IP {} against our IP {}", port_ip, v4);
+                            debug!("Checking firewalld IP {port_ip} against our IP {v4}");
                             if *v4 == port_ip {
                                 is_match = true;
                             }
                         }
                         if let Some(v6) = &ipv6 {
-                            debug!("Checking firewalld IP {} against our IP {}", port_ip, v6);
+                            debug!("Checking firewalld IP {port_ip} against our IP {v6}");
                             if *v6 == port_ip {
                                 is_match = true;
                             }
@@ -508,14 +508,14 @@ impl firewall::FirewallDriver for FirewallD {
 
                         // Remove any rule using our IPv4 or IPv6 as daddr.
                         if let Some(v4) = &ipv4 {
-                            let daddr = format!("to-addr=\"{}\"", v4);
-                            debug!("Checking if {} contains string {}", old_rule, daddr);
+                            let daddr = format!("to-addr=\"{v4}\"");
+                            debug!("Checking if {old_rule} contains string {daddr}");
                             if old_rule.to_string().contains(&daddr) {
                                 is_match = true;
                             }
                         }
                         if let Some(v6) = &ipv6 {
-                            let daddr = format!("to-addr=\"{}\"", v6);
+                            let daddr = format!("to-addr=\"{v6}\"");
                             if old_rule.to_string().contains(&daddr) {
                                 is_match = true;
                             }
@@ -572,8 +572,8 @@ impl firewall::FirewallDriver for FirewallD {
                         // Remove any rule using our IPv4 as daddr.
                         // We don't do IPv6 localhost forwarding.
                         if let Some(v4) = &ipv4 {
-                            let daddr = format!("to-addr=\"{}\"", v4);
-                            debug!("Checking if {} contains string {}", old_rule, daddr);
+                            let daddr = format!("to-addr=\"{v4}\"");
+                            debug!("Checking if {old_rule} contains string {daddr}");
                             if old_rule.to_string().contains(&daddr) {
                                 is_match = true;
                             }
@@ -623,7 +623,7 @@ impl firewall::FirewallDriver for FirewallD {
 
 /// Create a firewalld zone to hold all our interfaces.
 fn create_zone_if_not_exist(conn: &Connection, zone_name: &str) -> NetavarkResult<bool> {
-    debug!("Creating firewall zone {}", zone_name);
+    debug!("Creating firewall zone {zone_name}");
 
     // First, double-check if the zone exists in the running config.
     let zones_msg = conn.call_method(
@@ -701,11 +701,11 @@ pub fn add_source_subnets_to_zone(
             "Error decoding DBus message for zone of subnet"
         )?;
         if zone_string == zone_name {
-            debug!("Subnet {} already exists in zone {}", net, zone_name);
+            debug!("Subnet {net} already exists in zone {zone_name}");
             return Ok(());
         }
 
-        debug!("Adding subnet {} to zone {} as source", net, zone_name);
+        debug!("Adding subnet {net} to zone {zone_name} as source");
 
         let _ = conn.call_method(
             Some("org.fedoraproject.FirewallD1"),
@@ -730,8 +730,7 @@ fn add_policy_if_not_exist(
     priority: Option<i16>,
 ) -> NetavarkResult<bool> {
     debug!(
-        "Adding firewalld policy {} (ingress zone {}, egress zone {})",
-        policy_name, ingress_zone_name, egress_zone_name
+        "Adding firewalld policy {policy_name} (ingress zone {ingress_zone_name}, egress zone {egress_zone_name})"
     );
 
     // Does policy exist in running policies?
@@ -829,7 +828,7 @@ fn make_port_tuple(port: &PortMapping, addr: &str) -> (String, String, String, S
             port.container_port.to_string(),
             addr.to_string(),
         );
-        debug!("Port is {:?}", to_return);
+        debug!("Port is {to_return:?}");
         to_return
     }
 }
@@ -882,10 +881,7 @@ fn update_policy_config(
         Ok(_) => {}
         Err(e) => {
             return Err(NetavarkError::wrap(
-                format!(
-                    "Failed to update firewalld policy {} port forwarding rules",
-                    policy_name
-                ),
+                format!("Failed to update firewalld policy {policy_name} port forwarding rules"),
                 e.into(),
             ))
         }
@@ -964,7 +960,7 @@ fn get_pf_rich_rule(
     ctr_port: &str,
     ctr_ip: &str,
 ) -> String {
-    format!("rule family=\"{}\" destination address=\"{}\" forward-port port=\"{}\" protocol=\"{}\" to-port=\"{}\" to-addr=\"{}\"", ip_family, host_ip, host_port, protocol, ctr_port, ctr_ip)
+    format!("rule family=\"{ip_family}\" destination address=\"{host_ip}\" forward-port port=\"{host_port}\" protocol=\"{protocol}\" to-port=\"{ctr_port}\" to-addr=\"{ctr_ip}\"")
 }
 
 /// Check if firewalld is running.
@@ -993,14 +989,11 @@ pub fn add_firewalld_if_possible(dbus_conn: &Option<Connection>, net: &ipnet::Ip
     if !is_firewalld_running(conn) {
         return;
     }
-    debug!("Adding firewalld rules for network {}", net);
+    debug!("Adding firewalld rules for network {net}");
 
     match add_source_subnets_to_zone(conn, "trusted", &[*net]) {
         Ok(_) => {}
-        Err(e) => warn!(
-            "Error adding subnet {} from firewalld trusted zone: {}",
-            net, e
-        ),
+        Err(e) => warn!("Error adding subnet {net} from firewalld trusted zone: {e}"),
     }
 }
 
@@ -1016,7 +1009,7 @@ pub fn rm_firewalld_if_possible(net: &ipnet::IpNet) {
     if !is_firewalld_running(&conn) {
         return;
     }
-    debug!("Removing firewalld rules for IPs {}", net);
+    debug!("Removing firewalld rules for IPs {net}");
     match conn.call_method(
         Some("org.fedoraproject.FirewallD1"),
         "/org/fedoraproject/FirewallD1",
@@ -1025,10 +1018,7 @@ pub fn rm_firewalld_if_possible(net: &ipnet::IpNet) {
         &("trusted", net.to_string()),
     ) {
         Ok(_) => {}
-        Err(e) => warn!(
-            "Error removing subnet {} from firewalld trusted zone: {}",
-            net, e
-        ),
+        Err(e) => warn!("Error removing subnet {net} from firewalld trusted zone: {e}"),
     };
 }
 
@@ -1057,15 +1047,12 @@ pub fn is_firewalld_strict_forward_enabled(dbus_con: &Option<Connection>) -> boo
                 Ok(v) => match v.downcast::<String>() {
                     Ok(s) => s,
                     Err(e) => {
-                        warn!(
-                            "couldn't downcast StrictForwardPorts value to string: {}",
-                            e
-                        );
+                        warn!("couldn't downcast StrictForwardPorts value to string: {e}");
                         return false;
                     }
                 },
                 Err(e) => {
-                    warn!("couldn't retrieve StrictForwardPorts property: {}", e);
+                    warn!("couldn't retrieve StrictForwardPorts property: {e}");
                     return false;
                 }
             };
@@ -1073,10 +1060,7 @@ pub fn is_firewalld_strict_forward_enabled(dbus_con: &Option<Connection>) -> boo
                 "yes" => true,
                 "no" => false,
                 other => {
-                    warn!(
-                        "unexpected value from StrictForwardPorts property: {}",
-                        other
-                    );
+                    warn!("unexpected value from StrictForwardPorts property: {other}");
                     false
                 }
             }

--- a/src/firewall/nft.rs
+++ b/src/firewall/nft.rs
@@ -807,9 +807,9 @@ fn get_subnet_chain_name(subnet: IpNet, net_id: &str, dnat: bool) -> Cow<str> {
     };
 
     if dnat {
-        Cow::Owned(format!("nv_{}_{}_dnat", net_id_clean, subnet_clean))
+        Cow::Owned(format!("nv_{net_id_clean}_{subnet_clean}_dnat"))
     } else {
-        Cow::Owned(format!("nv_{}_{}", net_id_clean, subnet_clean))
+        Cow::Owned(format!("nv_{net_id_clean}_{subnet_clean}"))
     }
 }
 
@@ -1243,7 +1243,7 @@ fn get_matching_rules_in_chain<'a, F: Fn(&schema::Rule) -> bool>(
                     }
 
                     if rule_match(r) {
-                        log::debug!("Matched {:?}", r);
+                        log::debug!("Matched {r:?}");
                         rules.push(r.clone());
                     }
                 }
@@ -1263,7 +1263,7 @@ fn get_chain<'a>(base_rules: &schema::Nftables<'a>, chain: &str) -> Option<schem
             schema::NfObject::ListObject(obj) => match obj {
                 schema::NfListObject::Chain(c) => {
                     if c.name == *chain {
-                        log::debug!("Found chain {}", chain);
+                        log::debug!("Found chain {chain}");
                         return Some(c.clone());
                     }
                 }

--- a/src/firewall/varktables/helpers.rs
+++ b/src/firewall/varktables/helpers.rs
@@ -87,30 +87,21 @@ pub fn remove_if_rule_exists(
 }
 
 fn debug_chain_create(table: &str, chain: &str) {
-    debug!("chain {} created on table {}", chain, table);
+    debug!("chain {chain} created on table {table}");
 }
 
 fn debug_chain_exists(table: &str, chain: &str) {
-    debug!("chain {} exists on table {}", chain, table);
+    debug!("chain {chain} exists on table {table}");
 }
 
 pub fn debug_rule_create(table: &str, chain: &str, rule: String) {
-    debug!(
-        "rule {} created on table {} and chain {}",
-        rule, table, chain
-    );
+    debug!("rule {rule} created on table {table} and chain {chain}");
 }
 
 fn debug_rule_exists(table: &str, chain: &str, rule: String) {
-    debug!(
-        "rule {} exists on table {} and chain {}",
-        rule, table, chain
-    );
+    debug!("rule {rule} exists on table {table} and chain {chain}");
 }
 
 fn debug_rule_no_exists(table: &str, chain: &str, rule: String) {
-    debug!(
-        "no rule {} exists on table {} and chain {}",
-        rule, table, chain
-    );
+    debug!("no rule {rule} exists on table {table} and chain {chain}");
 }

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -347,7 +347,7 @@ pub fn get_network_chains<'a>(
     chains.push(netavark_isolation_chain_3);
 
     forward_chain.build_rule(VarkRule {
-        rule: format!("{} {}", NETAVARK_FIREWALL_RULE_BUILDER, NETAVARK_FORWARD),
+        rule: format!("{NETAVARK_FIREWALL_RULE_BUILDER} {NETAVARK_FORWARD}"),
         position: Some(ind),
         td_policy: Some(TeardownPolicy::Never),
     });
@@ -360,7 +360,7 @@ pub fn get_network_chains<'a>(
 
     // Add NETAVARK_INPUT chain to INPUT chain
     input_chain.build_rule(VarkRule {
-        rule: format!("{} {}", NETAVARK_FIREWALL_RULE_BUILDER, NETAVARK_INPUT),
+        rule: format!("{NETAVARK_FIREWALL_RULE_BUILDER} {NETAVARK_INPUT}"),
         position: Some(1),
         td_policy: Some(TeardownPolicy::Never),
     });
@@ -375,10 +375,7 @@ pub fn get_network_chains<'a>(
     // to gateway when using bridge network with internal dns.
     for proto in ["udp", "tcp"] {
         netavark_input_chain.build_rule(VarkRule::new(
-            format!(
-                "-p {} -s {} --dport {} -j {}",
-                proto, network, dns_port, ACCEPT
-            ),
+            format!("-p {proto} -s {network} --dport {dns_port} -j {ACCEPT}"),
             Some(TeardownPolicy::OnComplete),
         ));
     }

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -485,7 +485,7 @@ impl<'a> Bridge<'a> {
             None => {
                 let isolate = get_isolate_option(&self.info.network.options).unwrap_or_else(|e| {
                     // just log we still try to do as much as possible for cleanup
-                    error!("failed to parse {} option: {}", OPTION_ISOLATE, e);
+                    error!("failed to parse {OPTION_ISOLATE} option: {e}");
                     IsolateOption::Never
                 });
 
@@ -494,7 +494,7 @@ impl<'a> Bridge<'a> {
                         Ok(i) => (i.container_addresses, i.nameservers),
                         Err(e) => {
                             // just log we still try to do as much as possible for cleanup
-                            error!("failed to parse ipam options: {}", e);
+                            error!("failed to parse ipam options: {e}");
                             (Vec::new(), Vec::new())
                         }
                     };
@@ -944,8 +944,7 @@ fn check_link_is_vrf(msg: LinkMessage, vrf_name: &str) -> NetavarkResult<LinkMes
                         return Ok(msg);
                     } else {
                         return Err(NetavarkError::Message(format!(
-                            "vrf {} already exists but is a {:?} interface",
-                            vrf_name, kind
+                            "vrf {vrf_name} already exists but is a {kind:?} interface"
                         )));
                     }
                 }
@@ -953,8 +952,7 @@ fn check_link_is_vrf(msg: LinkMessage, vrf_name: &str) -> NetavarkResult<LinkMes
         }
     }
     Err(NetavarkError::Message(format!(
-        "could not determine namespace link kind for vrf {}",
-        vrf_name
+        "could not determine namespace link kind for vrf {vrf_name}"
     )))
 }
 
@@ -981,7 +979,7 @@ fn remove_link(
     // no connected interfaces on that bridge we can remove it
     if links.is_empty() {
         if let BridgeMode::Managed = mode {
-            log::info!("removing bridge {}", br_name);
+            log::info!("removing bridge {br_name}");
             host.del_link(netlink::LinkID::ID(br.header.index))
                 .wrap(format!("failed to delete bridge {container_veth_name}"))?;
             return Ok(true);
@@ -1015,9 +1013,6 @@ fn get_bridge_mode_from_string(mode: Option<&str>) -> NetavarkResult<BridgeMode>
 fn maybe_add_alias<'a>(names: &mut Vec<SafeString<'a>>, name: &'a str) {
     match name.try_into() {
         Ok(name) => names.push(name),
-        Err(err) => log::warn!(
-            "invalid network alias {:?}: {err}, ignoring this name",
-            name
-        ),
+        Err(err) => log::warn!("invalid network alias {name:?}: {err}, ignoring this name"),
     }
 }

--- a/src/network/netlink.rs
+++ b/src/network/netlink.rs
@@ -337,7 +337,7 @@ impl Socket {
 
     pub fn add_route(&mut self, route: &Route) -> NetavarkResult<()> {
         let msg = Self::create_route_msg(route);
-        info!("Adding route {}", route);
+        info!("Adding route {route}");
 
         let result = self
             .make_netlink_request(RouteNetlinkMessage::NewRoute(msg), NLM_F_ACK | NLM_F_CREATE)?;
@@ -348,7 +348,7 @@ impl Socket {
 
     pub fn del_route(&mut self, route: &Route) -> NetavarkResult<()> {
         let msg = Self::create_route_msg(route);
-        info!("Deleting route {}", route);
+        info!("Deleting route {route}");
 
         let result = self.make_netlink_request(RouteNetlinkMessage::DelRoute(msg), NLM_F_ACK)?;
         expect_netlink_result!(result, 0);
@@ -486,7 +486,7 @@ impl Socket {
         packet.finalize();
 
         packet.serialize(&mut self.buffer[..]);
-        trace!("send netlink packet: {:?}", packet);
+        trace!("send netlink packet: {packet:?}");
 
         self.socket.send(&self.buffer[..packet.buffer_len()], 0)?;
         Ok(())
@@ -511,7 +511,7 @@ impl Socket {
                             "failed to deserialize netlink message: {e}",
                         ))
                     })?;
-                trace!("read netlink packet: {:?}", rx_packet);
+                trace!("read netlink packet: {rx_packet:?}");
 
                 if rx_packet.header.sequence_number != self.sequence_number {
                     return Err(NetavarkError::msg(format!(

--- a/src/network/sysctl.rs
+++ b/src/network/sysctl.rs
@@ -21,7 +21,7 @@ fn _apply_sysctl_value(ns_value: impl AsRef<str>, val: impl AsRef<str>) -> Resul
     path.push_str(ns_value);
     let val = val.as_ref();
 
-    log::debug!("Setting sysctl value for {} to {}", ns_value, val);
+    log::debug!("Setting sysctl value for {ns_value} to {val}");
 
     let mut f = File::open(&path)?;
     let mut buf = String::with_capacity(1);

--- a/src/network/vlan.rs
+++ b/src/network/vlan.rs
@@ -318,10 +318,7 @@ fn setup(
                             // make sure to delete the tmp interface.
                             if let Err(err) = netns.del_link(netlink::LinkID::ID(link.header.index))
                             {
-                                error!(
-                                    "failed to delete tmp {} link {}: {}",
-                                    kind_data, tmp_name, err
-                                );
+                                error!("failed to delete tmp {kind_data} link {tmp_name}: {err}");
                             };
                         })?;
 


### PR DESCRIPTION
Just some slight formatting for the format!() macros. I migrated them using cargo clippy --fix.

Also one complain about a empty line in a doc comment.

## Summary by Sourcery

Fix Rust 1.88 lint warnings by migrating all formatting and logging macros to use the newer brace-based style and cleaning up a stray blank doc-comment line.

Enhancements:
- Refactor all `format!`, `debug!`, `info!`, `warn!`, and `error!` macros to use `{variable}` style formatting instead of positional `{}` placeholders

Documentation:
- Remove an empty line from a doc comment to satisfy lint rules