### PR TITLE
Set bridge MTU to match default route.

### DIFF
--- a/test/640-bridge-mtu.bats
+++ b/test/640-bridge-mtu.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# bridge driver tests with explicit modes
+#
+
+load helpers
+
+function check_iface_mtu() {
+    local host_or_container=$1
+    local iface=$2
+    local mtu=$3
+
+    if [ "$host_or_container" = "host" ]; then
+        run_in_host_netns ip -j --details link show "$iface"
+    else
+        run_in_container_netns ip -j --details link show "$iface"
+    fi
+    assert_json "$output" ".[].mtu" "=="  "$mtu" "$iface MTU matches $mtu"
+}
+
+function check_mtu() {
+    local mtu=$1
+    check_iface_mtu container eth0 "$mtu"
+    check_iface_mtu host veth0 "$mtu"
+    check_iface_mtu host podman0 "$mtu"
+}
+
+
+function add_default_route() {
+    run_in_host_netns ip link add default_route type dummy
+    run_in_host_netns ip link set default_route mtu 9000
+    run_in_host_netns ip addr add 192.168.0.0/24 dev default_route
+    run_in_host_netns ip link set default_route up
+    run_in_host_netns ip route add default via 192.168.0.0
+}
+
+function add_bridge() {
+    run_in_host_netns ip link add podman0 type bridge
+    run_in_host_netns ip link set podman0 mtu 9001
+    run_in_host_netns ip link set up podman0
+}
+
+@test "bridge - mtu from default route" {
+    add_default_route
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-managed.json setup $(get_container_netns_path)
+    check_mtu 9000
+}
+
+@test "bridge - mtu from existing bridge" {
+    add_bridge
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-managed.json setup $(get_container_netns_path)
+    check_mtu 9001
+}
+
+@test "bridge - mtu from config with default route" {
+    add_default_route
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-mtu.json setup $(get_container_netns_path)
+    check_mtu 9002
+}
+
+@test "bridge - mtu from config with existing bridge" {
+    add_bridge
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-mtu.json setup $(get_container_netns_path)
+    check_iface_mtu container eth0 9002
+    check_iface_mtu host veth0 9002
+    # The existing bridge MTU should not be overriden.
+    check_iface_mtu host podman0 9001
+}

--- a/test/testfiles/bridge-mtu.json
+++ b/test/testfiles/bridge-mtu.json
@@ -1,0 +1,35 @@
+{
+  "container_id": "6ce776ea58b5",
+  "container_name": "testcontainer",
+  "networks": {
+    "podman1": {
+      "static_ips": [
+        "10.88.0.2"
+      ],
+      "interface_name": "eth0"
+    }
+  },
+  "network_info": {
+    "podman1": {
+      "name": "podman0",
+      "id": "ed82e3a703682a9c09629d3cf45c1f1e7da5b32aeff3faf82837ef4d005356e6",
+      "driver": "bridge",
+      "network_interface": "podman0",
+      "subnets": [
+        {
+          "gateway": "10.88.0.1",
+          "subnet": "10.88.0.0/16"
+        }
+      ],
+      "ipv6_enabled": true,
+      "internal": false,
+      "dns_enabled": false,
+      "ipam_options": {
+        "driver": "host-local"
+      },
+      "options": {
+        "mtu": "9002"
+      }
+    }
+  }
+}


### PR DESCRIPTION
When creating a custom network, netavark previously used the default Linux bridge MTU (1500), which undermined performance optimization strategy of using a large MTU (65520) for improved TCP throughput.

This patch ensures that when the user does not explicitly set an MTU, podman attempts to derive a more suitable MTU from the system's default route interface, preserving intended performance benefits.

Also moved get_default_route_interface into core_utils for reuse across modules.

Fixes: https://github.com/containers/podman/issues/23883
Fixes: https://github.com/containers/podman/issues/20009

## Summary by Sourcery

Set bridge MTU to match the system’s default route interface MTU when the user does not specify one, preserving high-throughput network performance and moving shared utilities into core_utils

Bug Fixes:
- Fixes #23883 by avoiding the 1500-byte default bridge MTU

Enhancements:
- Derive and apply the default route interface’s MTU for bridge and veth setups when no explicit MTU is provided
- Expand validate_bridge_link to return both the interface index and its MTU
- Propagate the computed MTU into veth pair creation