### PR TITLE
test: Introduce NCATOPTS variable to specify ncat options

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -5,6 +5,10 @@ NETAVARK=${NETAVARK:-./bin/netavark}
 
 TESTSDIR=${TESTSDIR:-$(dirname ${BASH_SOURCE})}
 
+# ncat 7.96 changed default behaviour
+# https://nmap.org/changelog.html#7.96
+NCATOPTS="$NCATOPTS"
+
 # export RUST_BACKTRACE so that we get a helpful stack trace
 export RUST_BACKTRACE=full
 
@@ -623,7 +627,7 @@ function run_nc_test() {
     local connect_ip=$4
     local host_port=$5
 
-    local nc_common_args=""
+    local nc_common_args="$NCATOPTS"
     exec {stdin}<>/dev/null
 
     case $proto in


### PR DESCRIPTION
test: Introduce NCATOPTS variable to specify ncat options

ncat 7.96 changed default behaviour and we may need to specify some options.

https://nmap.org/changelog.html#7.96

## Summary by Sourcery

Introduce NCATOPTS environment variable in test helpers to override ncat options and apply it to run_nc_test, addressing changed default behavior in ncat 7.96.

New Features:
- Add NCATOPTS environment variable for specifying ncat options in tests

Enhancements:
- Use NCATOPTS in run_nc_test to pass custom options to ncat