### PR TITLE
Introduce our own test helper instead of using ncat.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(linux)']
+runner = 'unshare -rn'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,15 @@ tier = "2"
 name = "netavark"
 path = "src/main.rs"
 
+
+# Only used for testing, do not ship to end users.
 [[bin]]
 name = "netavark-dhcp-proxy-client"
 path = "src/dhcp_proxy_client/client.rs"
+
+[[bin]]
+name = "netavark-connection-tester"
+path = "src/test/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
@@ -37,7 +43,7 @@ log = "0.4.27"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 zbus = { version = "5.9.0" }
-nix = { version = "0.30.1", features = ["sched", "signal", "user"] }
+nix = { version = "0.30.1", features = ["net", "sched", "signal", "socket", "user"] }
 rand = "0.9.2"
 sha2 = "0.10.9"
 netlink-packet-route = "0.23.0"

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ bin/netavark: $(SOURCES) bin $(CARGO_TARGET_DIR)
 	$(CARGO) build $(release)
 	cp $(CARGO_TARGET_DIR)/$(profile)/netavark bin/netavark
 	cp $(CARGO_TARGET_DIR)/$(profile)/netavark-dhcp-proxy-client bin/netavark-dhcp-proxy-client
+	cp $(CARGO_TARGET_DIR)/$(profile)/netavark-connection-tester bin/netavark-connection-tester
 
 
 .PHONY: examples

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -259,8 +259,7 @@ pub fn join_netns<Fd: AsFd>(fd: Fd) -> NetavarkResult<()> {
 
 /// safe way to join the namespace and join back to the host after the task is done
 /// This first arg should be the hostns fd, the second is the container ns fd.
-/// The third is the result variable name and the last the closure that should be
-/// executed in the ns.
+/// The third and last the closure that should be executed in the ns.
 #[macro_export]
 macro_rules! exec_netns {
     ($host:expr, $netns:expr, $exec:expr) => {{

--- a/src/test/main.rs
+++ b/src/test/main.rs
@@ -1,0 +1,181 @@
+//! Test program only, unsupported outside of our test suite.
+use std::{
+    io::Read,
+    os::fd::{AsRawFd, OwnedFd},
+};
+
+use netavark::exec_netns;
+use netavark::network::core_utils::join_netns;
+use nix::sys::socket;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args();
+    _ = args.next(); // skip argv0
+
+    let mut i = 0;
+    let mut netns = String::new();
+    let mut connect = String::new();
+    let mut listen = String::new();
+
+    let mut sock_type = socket::SockType::Stream;
+    let mut protocol = socket::SockProtocol::Tcp;
+
+    for arg in args {
+        match arg.as_str() {
+            "--tcp" => {
+                protocol = socket::SockProtocol::Tcp;
+                sock_type = socket::SockType::Stream;
+            }
+            "--udp" => {
+                protocol = socket::SockProtocol::Udp;
+                sock_type = socket::SockType::Datagram;
+            }
+            "--sctp" => {
+                protocol = socket::SockProtocol::Sctp;
+                sock_type = socket::SockType::Stream;
+            }
+            _ => {
+                match i {
+                    0 => netns = arg,
+                    1 => connect = arg,
+                    2 => listen = arg,
+                    _ => {
+                        eprintln!("To many arguments\nUsage: NETNS CONNECT_ADDRESS LISTEN_PORT");
+                        std::process::exit(1)
+                    }
+                };
+                i += 1;
+            }
+        }
+    }
+
+    let hostns = std::fs::File::open("/proc/self/ns/net").expect("open host netns");
+    let containerns = std::fs::File::open(netns).expect("open netns");
+
+    let connect_addr: std::net::SocketAddr =
+        connect.parse().expect("failed to parse connect address");
+
+    let listen_port: u16 = listen.parse().expect("parse listne port");
+
+    let (address_family, listen_addr) = match connect_addr {
+        std::net::SocketAddr::V4(_) => (
+            socket::AddressFamily::Inet,
+            std::net::SocketAddr::V4(std::net::SocketAddrV4::new(
+                std::net::Ipv4Addr::UNSPECIFIED,
+                listen_port,
+            )),
+        ),
+        std::net::SocketAddr::V6(_) => (
+            socket::AddressFamily::Inet6,
+            std::net::SocketAddr::V6(std::net::SocketAddrV6::new(
+                std::net::Ipv6Addr::UNSPECIFIED,
+                listen_port,
+                0,
+                0,
+            )),
+        ),
+    };
+
+    // create socket in namespace
+    let listen_sock = exec_netns!(&hostns, &containerns, {
+        let listen_sock = socket::socket(
+            address_family,
+            sock_type,
+            socket::SockFlag::empty(),
+            Some(protocol),
+        )
+        .expect("listen socket");
+
+        socket::bind(
+            listen_sock.as_raw_fd(),
+            &socket::SockaddrStorage::from(listen_addr),
+        )
+        .expect("bind listen socket");
+
+        listen_sock
+    });
+
+    let connect_sock = socket::socket(
+        address_family,
+        sock_type,
+        socket::SockFlag::empty(),
+        Some(protocol),
+    )
+    .expect("connect socket");
+
+    let mut send_buf = Vec::new();
+    std::io::stdin()
+        .read_to_end(&mut send_buf)
+        .expect("read stdin");
+
+    match sock_type {
+        socket::SockType::Stream => stream_test(listen_sock, connect_sock, connect_addr, &send_buf),
+        socket::SockType::Datagram => {
+            datagram_test(listen_sock, connect_sock, connect_addr, &send_buf)
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+fn stream_test(
+    listen_sock: OwnedFd,
+    connect_sock: OwnedFd,
+    connect_addr: std::net::SocketAddr,
+    buf: &[u8],
+) {
+    socket::listen(&listen_sock, socket::Backlog::new(5).unwrap()).expect("listen on socket");
+
+    socket::connect(
+        connect_sock.as_raw_fd(),
+        &socket::SockaddrStorage::from(connect_addr),
+    )
+    .expect("connect to remote socket");
+
+    let conn = socket::accept4(listen_sock.as_raw_fd(), socket::SockFlag::empty())
+        .expect("accept connection");
+
+    let peer_addr = socket::getpeername::<socket::SockaddrStorage>(conn).expect("getpeername");
+    println!("Peer address: {peer_addr}");
+
+    socket::send(connect_sock.as_raw_fd(), buf, socket::MsgFlags::empty()).expect("send msg");
+
+    let mut read_buf = vec![0; buf.len()];
+
+    let len = socket::recv(conn, &mut read_buf, socket::MsgFlags::empty()).expect("recv msg");
+
+    println!(
+        "Message: {}",
+        std::str::from_utf8(&read_buf[..len]).expect("parse msg")
+    );
+}
+
+fn datagram_test(
+    listen_sock: OwnedFd,
+    connect_sock: OwnedFd,
+    connect_addr: std::net::SocketAddr,
+    buf: &[u8],
+) {
+    socket::sendto(
+        connect_sock.as_raw_fd(),
+        buf,
+        &socket::SockaddrStorage::from(connect_addr),
+        socket::MsgFlags::empty(),
+    )
+    .expect("sendto msg");
+
+    let mut read_buf = vec![0; buf.len()];
+
+    let (len, peer_addr) =
+        socket::recvfrom::<socket::SockaddrStorage>(listen_sock.as_raw_fd(), &mut read_buf)
+            .expect("recvfrom msg");
+
+    let peer_addr = peer_addr.expect("no peer address");
+    println!("Peer address: {peer_addr}");
+
+    println!(
+        "Message: {}",
+        std::str::from_utf8(&read_buf[..len]).expect("parse msg")
+    );
+}

--- a/test/100-bridge-iptables.bats
+++ b/test/100-bridge-iptables.bats
@@ -590,7 +590,7 @@ fw_driver=iptables
     assert "2" "rp_filter eth1 interface"
 
     # Important: Use the "host" ip here and not localhost or bridge ip.
-    run_nc_test "0" "tcp" 8080 "10.0.0.1" 8080
+    run_connection_test "0" "tcp" 8080 "10.0.0.1" 8080
 }
 
 @test "bridge ipam none" {

--- a/test/README.md
+++ b/test/README.md
@@ -14,4 +14,3 @@ The tests need root privileges to create network namespaces, so you either have 
 - iptables
 - firewalld
 - dbus-daemon
-- ncat (NMAP)


### PR DESCRIPTION
Use this to replace ncat. ncat is flaky and harder to use and with
the latest version it seems they broke us in a way that makes the flags
we use incompatible[1].

As a nice benefit this makes the test code itself simpler and faster as
we get rid of the is port bound polling/sleeps.

[1] https://github.com/containers/netavark/pull/1282

Fixes: https://github.com/containers/netavark/issues/1076

## Summary by Sourcery

Introduce a custom test helper binary to replace flaky ncat-based tests, simplifying connection checks and removing port polling logic

New Features:
- Add netavark-connection-tester binary for streamlined namespace connection testing

Enhancements:
- Replace run_nc_test with run_connection_test and remove ncat and port-polling logic from bash helpers
- Fix exec_netns macro documentation

Build:
- Add netavark-connection-tester to Cargo.toml and Makefile, update nix features, and configure .cargo/config.toml runner

Documentation:
- Remove ncat requirement from test README

Tests:
- Update Bats scripts and helpers to use the new connection tester instead of ncat