### PR TITLE
add nftables reload command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ use crate::error::{NetavarkError, NetavarkResult};
 
 pub mod dhcp_proxy;
 pub mod firewalld_reload;
+pub mod nftables_reload;
 pub mod setup;
 pub mod teardown;
 pub mod update;

--- a/src/commands/nftables_reload.rs
+++ b/src/commands/nftables_reload.rs
@@ -1,0 +1,36 @@
+use crate::{
+    error::NetavarkResult,
+    firewall::{get_supported_firewall_driver, state::read_fw_config},
+    network::constants,
+};
+use std::{
+    ffi::{OsStr, OsString},
+    path::Path,
+};
+
+pub fn reload_nftables(config_dir: Option<OsString>) -> NetavarkResult<()> {
+    let config_dir = Path::new(
+        config_dir
+            .as_deref()
+            .unwrap_or(OsStr::new(constants::DEFAULT_CONFIG_DIR)),
+    );
+    log::debug!("Reloading nftables rules from {:?}", config_dir);
+
+    let conf = read_fw_config(config_dir)?;
+    if let Some(conf) = conf {
+        let fw_driver = get_supported_firewall_driver(Some(conf.driver))?;
+
+        for net in conf.net_confs {
+            fw_driver.setup_network(net, &None)?;
+        }
+
+        for port in &conf.port_confs {
+            fw_driver.setup_port_forward(port.into(), &None)?;
+        }
+
+        log::info!("nftables rules reloaded successfully");
+    } else {
+        log::debug!("No configs found, nothing to reload");
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 
 use netavark::commands::dhcp_proxy;
 use netavark::commands::firewalld_reload;
+use netavark::commands::nftables_reload;
 use netavark::commands::setup;
 use netavark::commands::teardown;
 use netavark::commands::update;
@@ -51,6 +52,9 @@ enum SubCommand {
     /// Listen for the firewalld reload event and reload fw rules
     #[command(name = "firewalld-reload")]
     FirewallDReload,
+    /// Reload netavark nftables firewall rules
+    #[command(name = "nftables-reload")]
+    NftablesReload,
 }
 
 fn main() {
@@ -84,6 +88,7 @@ fn main() {
         SubCommand::Version(version) => version.exec(),
         SubCommand::DHCPProxy(proxy) => dhcp_proxy::serve(proxy),
         SubCommand::FirewallDReload => firewalld_reload::listen(config),
+        SubCommand::NftablesReload => nftables_reload::reload_nftables(config),
     };
 
     match result {


### PR DESCRIPTION
I added a one-shot command that restores the nftables rules and exits. I initially created a separate systemd service that runs when nftables is restarted, which works on restart but not on reload. To make it respond to reloads as well, we would need to listen to netlink events, but that requires extra capabilities and complexity. however this "one shot" command can be manually hooked into `nftables.service` by adding
```
ExecStart=netavark nftables-reload
ExecReload=netavark nftables-reload
```
Fixes [#1258](https://github.com/containers/netavark/issues/1258)

## Summary by Sourcery

New Features:
- Introduce nftables-reload subcommand for one-shot restoration of nftables rules