### PR TITLE
fix new lint warnings on rust 1.89

### DIFF
--- a/src/firewall/nft.rs
+++ b/src/firewall/nft.rs
@@ -791,7 +791,7 @@ fn delete_port_rules<'a>(
 }
 
 /// Convert a subnet into a chain name.
-fn get_subnet_chain_name(subnet: IpNet, net_id: &str, dnat: bool) -> Cow<str> {
+fn get_subnet_chain_name(subnet: IpNet, net_id: &str, dnat: bool) -> Cow<'_, str> {
     // nftables is very lenient around chain name lengths.
     // So let's use the full IP to be unambiguous.
     // Replace . and : with _, and / with _nm (netmask), to remove special characters.
@@ -815,7 +815,7 @@ fn get_subnet_chain_name(subnet: IpNet, net_id: &str, dnat: bool) -> Cow<str> {
 
 /// Get a statement to match the given destination bridge.
 /// Always matches using ==.
-fn get_dest_bridge_match(bridge: &str) -> stmt::Statement {
+fn get_dest_bridge_match(bridge: &str) -> stmt::Statement<'_> {
     stmt::Statement::Match(stmt::Match {
         left: expr::Expression::Named(expr::NamedExpression::Meta(expr::Meta {
             key: expr::MetaKey::Oifname,
@@ -883,7 +883,7 @@ fn subnet_to_payload<'a>(net: &IpNet, field: &'a str) -> expr::Expression<'a> {
 
 /// Get a condition to match destination port/ports based on a given PortMapping.
 /// Properly handles port ranges, protocol, etc.
-fn get_dport_cond(port: &PortMapping) -> stmt::Statement {
+fn get_dport_cond(port: &PortMapping) -> stmt::Statement<'_> {
     stmt::Statement::Match(stmt::Match {
         left: expr::Expression::Named(expr::NamedExpression::Payload(expr::Payload::PayloadField(
             expr::PayloadField {
@@ -1089,7 +1089,7 @@ fn get_dnat_rules_for_addr_family<'a>(
 }
 
 /// Make a DNAT rule to allow DNS traffic to a DNS server on a non-standard port (53 -> actual port).
-fn make_dns_dnat_rule(dns_ip: &IpAddr, dns_port: u16) -> schema::NfListObject {
+fn make_dns_dnat_rule(dns_ip: &IpAddr, dns_port: u16) -> schema::NfListObject<'_> {
     let rule = schema::Rule {
         family: types::NfFamily::INet,
         table: Cow::Borrowed(TABLENAME),
@@ -1156,7 +1156,7 @@ fn make_complex_chain(
     chain_type: types::NfChainType,
     hook: types::NfHook,
     priority: i32,
-) -> schema::NfListObject {
+) -> schema::NfListObject<'_> {
     schema::NfListObject::Chain(schema::Chain {
         family: types::NfFamily::INet,
         table: Cow::Borrowed(TABLENAME),

--- a/src/firewall/varktables/types.rs
+++ b/src/firewall/varktables/types.rs
@@ -88,7 +88,7 @@ impl VarkChain<'_> {
         table: String,
         chain_name: String,
         td_policy: Option<TeardownPolicy>,
-    ) -> VarkChain {
+    ) -> VarkChain<'_> {
         VarkChain {
             driver,
             chain_name,

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -148,7 +148,7 @@ impl driver::NetworkDriver for Bridge<'_> {
     fn setup(
         &self,
         netlink_sockets: (&mut netlink::Socket, &mut netlink::Socket),
-    ) -> NetavarkResult<(StatusBlock, Option<AardvarkEntry>)> {
+    ) -> NetavarkResult<(StatusBlock, Option<AardvarkEntry<'_>>)> {
         let data = match &self.data {
             Some(d) => d,
             None => return Err(NetavarkError::msg("must call validate() before setup()")),

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -39,7 +39,7 @@ pub trait NetworkDriver {
     fn setup(
         &self,
         netlink_sockets: (&mut netlink::Socket, &mut netlink::Socket),
-    ) -> NetavarkResult<(StatusBlock, Option<AardvarkEntry>)>;
+    ) -> NetavarkResult<(StatusBlock, Option<AardvarkEntry<'_>>)>;
     /// teardown the network interfaces/firewall rules for this driver
     fn teardown(
         &self,

--- a/src/network/plugin.rs
+++ b/src/network/plugin.rs
@@ -37,7 +37,7 @@ impl NetworkDriver for PluginDriver<'_> {
     fn setup(
         &self,
         _netlink_sockets: (&mut super::netlink::Socket, &mut super::netlink::Socket),
-    ) -> NetavarkResult<(types::StatusBlock, Option<AardvarkEntry>)> {
+    ) -> NetavarkResult<(types::StatusBlock, Option<AardvarkEntry<'_>>)> {
         let result = self.exec_plugin(true, self.info.netns_path).wrap(format!(
             "plugin {:?} failed",
             &self.path.file_name().unwrap_or_default()

--- a/src/network/vlan.rs
+++ b/src/network/vlan.rs
@@ -146,7 +146,7 @@ impl driver::NetworkDriver for Vlan<'_> {
     fn setup(
         &self,
         netlink_sockets: (&mut netlink::Socket, &mut netlink::Socket),
-    ) -> Result<(StatusBlock, Option<AardvarkEntry>), NetavarkError> {
+    ) -> Result<(StatusBlock, Option<AardvarkEntry<'_>>), NetavarkError> {
         let data = match &self.data {
             Some(d) => d,
             None => return Err(NetavarkError::msg("must call validate() before setup()")),


### PR DESCRIPTION
Only trivial new lifetime elision warning fixes, see https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

## Summary by Sourcery

Add explicit elided lifetimes to various function and return types to address new lifetime elision lint warnings in Rust 1.89

Enhancements:
- Annotate return types with implicit '_' lifetimes in NFT firewall helper functions
- Add elided lifetimes to schema and statement return types
- Update network driver and plugin method signatures to include '_' lifetimes
- Introduce '_' lifetimes to VarkChain and AardvarkEntry types