### PR TITLE
Packit: fetch copr rpm version from Cargo.toml

### DIFF
--- a/.packit-copr-rpm.sh
+++ b/.packit-copr-rpm.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# This script handles any custom processing of the spec file using the `fix-spec-file`
+# action in .packit.yaml. These steps only work on copr builds, not on official
+# Fedora builds.
+
+set -uexo pipefail
+
+PACKAGE=netavark
+SPEC_FILE=rpm/"$PACKAGE".spec
+
+# Get Version from HEAD
+VERSION=$(grep '^version' Cargo.toml | cut -d\" -f2)
+
+# RPM Version can't take "-"
+RPM_VERSION="${VERSION//-/\~}"
+
+# Generate source tarball from HEAD
+git-archive-all -C "$(git rev-parse --show-toplevel)" --prefix="$PACKAGE"-"$VERSION"/ rpm/"$PACKAGE"-"$VERSION".tar.gz
+
+# RPM Spec modifications
+
+# Use the Version from HEAD in rpm spec
+sed -i "s/^Version:.*/Version: $RPM_VERSION/" "$SPEC_FILE"
+
+# Use Packit's supplied variable in the Release field in rpm spec.
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" "$SPEC_FILE"
+
+# Use above generated tarball as Source in rpm spec
+sed -i "s/^Source0:.*.tar.gz/Source0: $PACKAGE-$VERSION.tar.gz/" $SPEC_FILE
+
+# Don't need Source1 for copr builds
+sed -i "/^Source1/d" "$SPEC_FILE"
+
+# Update setup macro to use the correct build dir
+sed -i "s/^%autosetup.*/%autosetup -Sgit -n %{name}-$VERSION/" "$SPEC_FILE"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,8 +15,14 @@ packages:
 
 srpm_build_deps:
   - cargo
+  - git-archive-all
   - make
   - openssl-devel
+
+# https://packit.dev/docs/configuration/actions
+# fix-spec-file only operates on copr builds and doesn't affect official distro builds
+actions:
+  fix-spec-file: "bash .packit-copr-rpm.sh"
 
 jobs:
   - job: copr_build


### PR DESCRIPTION
Current installation of nv from podman-next is failing because it's expecting aardvark-dns >= 102:1.16 while current av on podman-next is only 102:1.15 . From the latest build log, that seems to be because Packit is determining 1.15.0 as the version for av and 1.16.0 as the version for nv.

This commit includes a script to fetch the version directly from Cargo.toml. A similar script will be added to av, thus ensuring both nv and av major.minor versions are in sync for copr rpms as well.

Related: https://github.com/containers/aardvark-dns/pull/625/

## Summary by Sourcery

Ensure Copr RPM packaging uses the Cargo.toml version by adding a Packit fix-spec-file action and script to generate source archives and update the spec file accordingly

Enhancements:
- Add git-archive-all to srpm build dependencies
- Invoke a fix-spec-file action in .packit.yaml to run a custom script during Copr builds
- Introduce .packit-copr-rpm.sh to extract the version from Cargo.toml, generate a source tarball, and patch the RPM spec (Version, Release, Source0, %autosetup) for Copr