### PR TITLE
Revert "[skip-ci] Update actions/download-artifact action to v5"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Display release notes
       run: cat $VERSION-release-notes.md
     - name: Download all artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v4
     - name: Create release
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 9b3e3328f2838fdc34bb92dcf3394cf22f97b85c.

The action is broken as the file layout changed, see #1312.

## Summary by Sourcery

Revert the update of actions/download-artifact action to v5 in the release workflow and restore v4 to address file layout changes that broke artifact downloads.

Bug Fixes:
- Fix broken artifact downloads due to file layout changes with v5 of the download-artifact action.

CI:
- Revert actions/download-artifact action to v4 in the release workflow.