### PR TITLE
refactor(network): Rename netlink module to netlink_route

### DIFF
--- a/examples/host-device-plugin.rs
+++ b/examples/host-device-plugin.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, os::fd::AsFd};
 use netavark::{
     network::{
         core_utils::{open_netlink_sockets, CoreUtils},
-        netlink, types,
+        netlink_route, types,
     },
     new_error,
     plugin::{Info, Plugin, PluginExec, API_VERSION},
@@ -41,7 +41,9 @@ impl Plugin for Exec {
 
         let name = opts.network.network_interface.unwrap_or_default();
 
-        let link = host.netlink.get_link(netlink::LinkID::Name(name.clone()))?;
+        let link = host
+            .netlink
+            .get_link(netlink_route::LinkID::Name(name.clone()))?;
 
         let mut mac_address = String::from("");
         for nla in link.attributes {
@@ -98,7 +100,7 @@ impl Plugin for Exec {
 
         let name = opts.network.network_interface.unwrap_or_default();
 
-        let link = netns.netlink.get_link(netlink::LinkID::Name(name))?;
+        let link = netns.netlink.get_link(netlink_route::LinkID::Name(name))?;
 
         netns
             .netlink

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -4,7 +4,7 @@ use crate::dns::aardvark::Aardvark;
 use crate::error::{NetavarkError, NetavarkResult};
 use crate::firewall;
 use crate::network::driver::{get_network_driver, DriverInfo, NetworkDriver};
-use crate::network::netlink::{self, LinkID};
+use crate::network::netlink_route::{self, LinkID};
 use crate::network::{self};
 use crate::network::{core_utils, types};
 
@@ -160,8 +160,11 @@ impl Setup {
     }
 }
 
-fn teardown_drivers<'a, I>(drivers: I, host: &mut netlink::Socket, netns: &mut netlink::Socket)
-where
+fn teardown_drivers<'a, I>(
+    drivers: I,
+    host: &mut netlink_route::RouteSocket,
+    netns: &mut netlink_route::RouteSocket,
+) where
     I: Iterator<Item = &'a Box<dyn NetworkDriver + 'a>>,
 {
     for driver in drivers {

--- a/src/dhcp_proxy/dhcp_service.rs
+++ b/src/dhcp_proxy/dhcp_service.rs
@@ -7,7 +7,7 @@ use crate::dhcp_proxy::dhcp_service::DhcpServiceErrorKind::{
 use crate::dhcp_proxy::lib::g_rpc::{Lease as NetavarkLease, NetworkConfig};
 use crate::error::{ErrorWrap, NetavarkError, NetavarkResult};
 use crate::network::core_utils;
-use crate::network::netlink::Route;
+use crate::network::netlink_route::Route;
 use crate::wrap;
 use log::debug;
 use mozim::{DhcpV4ClientAsync, DhcpV4Config, DhcpV4Lease as MozimV4Lease};
@@ -234,7 +234,9 @@ fn update_lease_ip(
 
     if new_net != old_net {
         let link = sock
-            .get_link(crate::network::netlink::LinkID::Name(interface.to_string()))
+            .get_link(crate::network::netlink_route::LinkID::Name(
+                interface.to_string(),
+            ))
             .wrap("get interface in netns")?;
         sock.add_addr(link.header.index, &ipnet::IpNet::V4(new_net))
             .wrap("add new addr")?;

--- a/src/network/dhcp.rs
+++ b/src/network/dhcp.rs
@@ -8,7 +8,7 @@ use crate::dhcp_proxy::lib::g_rpc::NetworkConfig;
 use crate::dhcp_proxy::proxy_conf::DEFAULT_UDS_PATH;
 
 use super::driver::DriverInfo;
-use super::{core_utils, netlink};
+use super::{core_utils, netlink_route};
 
 pub type DhcpLeaseInfo = (Vec<NetAddress>, Option<Vec<IpAddr>>, Option<Vec<String>>);
 
@@ -159,17 +159,22 @@ pub fn release_dhcp_lease(
     Ok(())
 }
 
-pub fn dhcp_teardown(info: &DriverInfo, sock: &mut netlink::Socket) -> NetavarkResult<()> {
+pub fn dhcp_teardown(
+    info: &DriverInfo,
+    sock: &mut netlink_route::RouteSocket,
+) -> NetavarkResult<()> {
     let ipam = core_utils::get_ipam_addresses(info.per_network_opts, info.network)?;
     let if_name = info.per_network_opts.interface_name.clone();
 
     // If we are using DHCP, we need to at least call to the proxy so that
     // the proxy's cache can get updated and the current lease can be released.
     if ipam.dhcp_enabled {
-        let dev = sock.get_link(netlink::LinkID::Name(if_name)).wrap(format!(
-            "get container interface {}",
-            &info.per_network_opts.interface_name
-        ))?;
+        let dev = sock
+            .get_link(netlink_route::LinkID::Name(if_name))
+            .wrap(format!(
+                "get container interface {}",
+                &info.per_network_opts.interface_name
+            ))?;
 
         let container_mac_address = core_utils::get_mac_address(dev.attributes)?;
         release_dhcp_lease(

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -8,7 +8,7 @@ use std::{ffi::OsString, net::IpAddr, os::fd::BorrowedFd, path::Path};
 
 use super::{
     bridge::Bridge,
-    constants, netlink,
+    constants, netlink_route,
     plugin::PluginDriver,
     types::{Network, PerNetworkOptions, PortMapping, StatusBlock},
     vlan::Vlan,
@@ -38,12 +38,18 @@ pub trait NetworkDriver {
     /// setup the network interfaces/firewall rules for this driver
     fn setup(
         &self,
-        netlink_sockets: (&mut netlink::Socket, &mut netlink::Socket),
+        netlink_sockets: (
+            &mut netlink_route::RouteSocket,
+            &mut netlink_route::RouteSocket,
+        ),
     ) -> NetavarkResult<(StatusBlock, Option<AardvarkEntry<'_>>)>;
     /// teardown the network interfaces/firewall rules for this driver
     fn teardown(
         &self,
-        netlink_sockets: (&mut netlink::Socket, &mut netlink::Socket),
+        netlink_sockets: (
+            &mut netlink_route::RouteSocket,
+            &mut netlink_route::RouteSocket,
+        ),
     ) -> NetavarkResult<()>;
 
     /// return the network name

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -1,4 +1,4 @@
-use super::netlink;
+use super::netlink_route;
 use crate::network::types;
 use std::net::IpAddr;
 
@@ -103,7 +103,7 @@ pub struct IPAMAddresses {
     // if using macvlan and dhcp, then true
     pub dhcp_enabled: bool,
     pub gateway_addresses: Vec<ipnet::IpNet>,
-    pub routes: Vec<netlink::Route>,
+    pub routes: Vec<netlink_route::Route>,
     pub ipv6_enabled: bool,
     // result for podman
     pub net_addresses: Vec<types::NetAddress>,

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -16,7 +16,7 @@ pub mod core_utils;
 mod dhcp;
 pub mod driver;
 pub mod internal_types;
-pub mod netlink;
+pub mod netlink_route;
 pub mod plugin;
 pub mod sysctl;
 pub mod vlan;

--- a/src/network/netlink_route.rs
+++ b/src/network/netlink_route.rs
@@ -24,7 +24,7 @@ use netlink_packet_route::{
 };
 use netlink_sys::{protocols::NETLINK_ROUTE, SocketAddr};
 
-pub struct Socket {
+pub struct RouteSocket {
     socket: netlink_sys::Socket,
     sequence_number: u32,
     ///  buffer size for reading netlink messages, see NLMSG_GOODSIZE in the kernel
@@ -110,8 +110,8 @@ macro_rules! function {
     }};
 }
 
-impl Socket {
-    pub fn new() -> NetavarkResult<Socket> {
+impl RouteSocket {
+    pub fn new() -> NetavarkResult<RouteSocket> {
         let mut socket = wrap!(netlink_sys::Socket::new(NETLINK_ROUTE), "open")?;
         let addr = &SocketAddr::new(0, 0);
         // Needs to be enabled for dump filtering to work
@@ -119,7 +119,7 @@ impl Socket {
         wrap!(socket.bind(addr), "bind")?;
         wrap!(socket.connect(addr), "connect")?;
 
-        Ok(Socket {
+        Ok(RouteSocket {
             socket,
             sequence_number: 0,
             buffer: [0; 8192],

--- a/src/network/plugin.rs
+++ b/src/network/plugin.rs
@@ -36,7 +36,10 @@ impl NetworkDriver for PluginDriver<'_> {
 
     fn setup(
         &self,
-        _netlink_sockets: (&mut super::netlink::Socket, &mut super::netlink::Socket),
+        _netlink_sockets: (
+            &mut super::netlink_route::RouteSocket,
+            &mut super::netlink_route::RouteSocket,
+        ),
     ) -> NetavarkResult<(types::StatusBlock, Option<AardvarkEntry<'_>>)> {
         let result = self.exec_plugin(true, self.info.netns_path).wrap(format!(
             "plugin {:?} failed",
@@ -49,7 +52,10 @@ impl NetworkDriver for PluginDriver<'_> {
 
     fn teardown(
         &self,
-        _netlink_sockets: (&mut super::netlink::Socket, &mut super::netlink::Socket),
+        _netlink_sockets: (
+            &mut super::netlink_route::RouteSocket,
+            &mut super::netlink_route::RouteSocket,
+        ),
     ) -> NetavarkResult<()> {
         self.exec_plugin(false, self.info.netns_path).wrap(format!(
             "plugin {:?} failed",

--- a/src/test/netlink.rs
+++ b/src/test/netlink.rs
@@ -2,7 +2,7 @@
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
-    use netavark::network::netlink::*;
+    use netavark::network::netlink_route::*;
     use netlink_packet_route::{address, link::InfoKind};
 
     macro_rules! test_setup {
@@ -28,13 +28,16 @@ mod tests {
     #[test]
     fn test_socket_new() {
         test_setup!();
-        assert!(Socket::new().is_ok(), "Netlink Socket::new() should work");
+        assert!(
+            RouteSocket::new().is_ok(),
+            "Netlink Socket::new() should work"
+        );
     }
 
     #[test]
     fn test_add_link() {
         test_setup!();
-        let mut sock = Socket::new().expect("Socket::new()");
+        let mut sock = RouteSocket::new().expect("Socket::new()");
 
         let name = String::from("test1");
         sock.create_link(CreateLinkOptions::new(name.clone(), InfoKind::Dummy))
@@ -49,7 +52,7 @@ mod tests {
     #[test]
     fn test_add_addr() {
         test_setup!();
-        let mut sock = Socket::new().expect("Socket::new()");
+        let mut sock = RouteSocket::new().expect("Socket::new()");
 
         let out = run_command!("ip", "link", "add", "test1", "type", "dummy");
         eprintln!("{}", String::from_utf8(out.stderr).unwrap());
@@ -72,7 +75,7 @@ mod tests {
     #[test]
     fn test_del_addr() {
         test_setup!();
-        let mut sock = Socket::new().expect("Socket::new()");
+        let mut sock = RouteSocket::new().expect("Socket::new()");
 
         let out = run_command!("ip", "link", "add", "test1", "type", "dummy");
         eprintln!("{}", String::from_utf8(out.stderr).unwrap());
@@ -110,7 +113,7 @@ mod tests {
     #[ignore]
     fn test_del_route() {
         test_setup!();
-        let mut sock = Socket::new().expect("Socket::new()");
+        let mut sock = RouteSocket::new().expect("Socket::new()");
 
         let out = run_command!("ip", "link", "add", "test1", "type", "dummy");
         eprintln!("{}", String::from_utf8(out.stderr).unwrap());
@@ -159,7 +162,7 @@ mod tests {
     #[test]
     fn test_dump_addr() {
         test_setup!();
-        let mut sock = Socket::new().expect("Socket::new()");
+        let mut sock = RouteSocket::new().expect("Socket::new()");
 
         let out = run_command!("ip", "link", "add", "test1", "type", "dummy");
         eprintln!("{}", String::from_utf8(out.stderr).unwrap());
@@ -190,7 +193,7 @@ mod tests {
     #[test]
     fn test_dump_addr_filter() {
         test_setup!();
-        let mut sock = Socket::new().expect("Socket::new()");
+        let mut sock = RouteSocket::new().expect("Socket::new()");
 
         let out = run_command!("ip", "link", "add", "test1", "type", "dummy");
         eprintln!("{}", String::from_utf8(out.stderr).unwrap());


### PR DESCRIPTION
The current `netlink.rs` module only handles `NETLINK_ROUTE` operations. We're about to add support for `NETLINK_NETFILTER` for conntrack, and putting both in the same file would be a bad idea.

This commit renames `netlink.rs` to `netlink_route.rs` to make its purpose clear before the new code is added.

The following changes were made:
- Renamed `src/network/netlink.rs` to `src/network/netlink_route.rs`.
- Renamed the primary `struct Socket` to `struct RouteSocket` to avoid naming conflicts with future netlink sockets.
- Updated all module paths and `use` statements to match.

This is a pure refactoring and introduces no functional changes.