### PR TITLE
fix download artifact action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,8 @@ jobs:
       run: cat $VERSION-release-notes.md
     - name: Download all artifacts
       uses: actions/download-artifact@v6
+      with:
+          path: release-artifacts
     - name: Create release
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -165,4 +167,3 @@ jobs:
       run: make crate-publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-


### PR DESCRIPTION
The v5 update broke the download location, it seems to extarct to the
root now and no longer into the release-artifacts directory. So fix this
by specifying the path explicitly, see
https://github.com/actions/download-artifact/issues/419.

Fixes: https://github.com/containers/netavark/issues/1312