### PR TITLE
Support multiple static IPs per subnet

### DIFF
--- a/plugin-API.md
+++ b/plugin-API.md
@@ -107,6 +107,14 @@ Example JSON input:
 }
 ```
 
+**Note on `static_ips`**: When multiple subnets are configured in the network, you can specify multiple static IP addresses. Each IP will be assigned to the subnet it belongs to. For example, with subnets `10.88.0.0/16` and `10.89.0.0/16`, you could specify:
+
+```
+"static_ips": ["10.88.0.50", "10.88.0.51", "10.89.0.100"]
+```
+
+All IPs matching a subnet's range will be assigned to that subnet. Networks with duplicate or overlapping subnet definitions will result in an error.
+
 Example JSON output:
 ```
 {


### PR DESCRIPTION
Change from index-based IP/subnet pairing to subnet-aware matching. Now all static IPs that belong to a subnet are assigned to that subnet, allowing multiple IPs per subnet and proper multi-subnet distribution.

Fixes: https://issues.redhat.com/browse/RHEL-98277