### PR TITLE
DNM cirrus: Enable Spot instances for ARM64 builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,6 +83,7 @@ build_aarch64_task:
     type: $EC2_INST_TYPE
     region: us-east-1
     architecture: arm64  # CAUTION: This has to be "arm64", not "aarch64"
+    spot: true
   cargo_cache: &cargo_cache_aarch64
     folder: "$CARGO_HOME"
     # N/B: Should exactly match (except for arch) line from build_task (above).


### PR DESCRIPTION
Enable Spot pricing for t4g.xlarge instances used in ARM64
builds and tests