### PR TITLE
routes: Add blackhole route support

### DIFF
--- a/src/dhcp_proxy/dhcp_service.rs
+++ b/src/dhcp_proxy/dhcp_service.rs
@@ -6,6 +6,7 @@ use crate::network::{
 };
 use log::debug;
 use mozim::{DhcpV4Client, DhcpV4Config, DhcpV4Lease as MozimV4Lease, DhcpV4State};
+use netlink_packet_route::route::RouteType;
 use tokio::sync::Mutex;
 use tonic::{Code, Status};
 
@@ -282,8 +283,9 @@ fn update_lease_ip(
             if let Some(gw) = old_gw {
                 let route = Route::Ipv4 {
                     dest: ipnet::Ipv4Net::new(Ipv4Addr::new(0, 0, 0, 0), 0)?,
-                    gw: *gw,
+                    gw: Some(*gw),
                     metric: None,
+                    route_type: RouteType::Unicast,
                 };
                 match sock.del_route(&route) {
                     Ok(_) => {}
@@ -300,8 +302,9 @@ fn update_lease_ip(
             if let Some(gw) = new_gw {
                 let route = Route::Ipv4 {
                     dest: ipnet::Ipv4Net::new(Ipv4Addr::new(0, 0, 0, 0), 0)?,
-                    gw: *gw,
+                    gw: Some(*gw),
                     metric: None,
+                    route_type: RouteType::Unicast,
                 };
                 sock.add_route(&route)?;
             }

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -3,6 +3,7 @@ use crate::network::{constants, internal_types, types};
 use crate::wrap;
 use ipnet::IpNet;
 use netlink_packet_route::link::{IpVlanMode, LinkMessage, MacVlanMode};
+use netlink_packet_route::route::RouteType;
 use nix::sched;
 use sha2::{Digest, Sha512};
 use std::collections::HashMap;
@@ -498,8 +499,9 @@ pub fn add_default_routes(
 
                 Route::Ipv4 {
                     dest: ipnet::Ipv4Net::new(Ipv4Addr::new(0, 0, 0, 0), 0)?,
-                    gw: v4.addr(),
+                    gw: Some(v4.addr()),
                     metric,
+                    route_type: RouteType::Unicast,
                 }
             }
             ipnet::IpNet::V6(v6) => {
@@ -510,8 +512,9 @@ pub fn add_default_routes(
 
                 Route::Ipv6 {
                     dest: ipnet::Ipv6Net::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), 0)?,
-                    gw: v6.addr(),
+                    gw: Some(v6.addr()),
                     metric,
+                    route_type: RouteType::Unicast,
                 }
             }
         };
@@ -519,6 +522,20 @@ pub fn add_default_routes(
             .wrap(format!("add default route {}", &route))?;
     }
     Ok(())
+}
+
+fn parse_route_type(route_type: &Option<String>) -> NetavarkResult<RouteType> {
+    match route_type.as_deref() {
+        None | Some("") | Some("unicast") => Ok(RouteType::Unicast),
+        Some("blackhole") => Ok(RouteType::BlackHole),
+        Some("unreachable") => Ok(RouteType::Unreachable),
+        Some("prohibit") => Ok(RouteType::Prohibit),
+        Some(name) => Err(NetavarkError::msg(format!("invalid route type \"{name}\""))),
+    }
+}
+
+fn route_type_requires_gateway(rt: RouteType) -> bool {
+    matches!(rt, RouteType::Unicast)
 }
 
 pub fn create_route_list(routes: &Option<Vec<types::Route>>) -> NetavarkResult<Vec<Route>> {
@@ -529,24 +546,50 @@ pub fn create_route_list(routes: &Option<Vec<types::Route>>) -> NetavarkResult<V
                 let gw = r.gateway;
                 let dst = r.destination;
                 let mtr = r.metric;
-                match (gw, dst) {
-                    (IpAddr::V4(gw4), IpNet::V4(dst4)) => Ok(Route::Ipv4 {
-                        dest: dst4,
-                        gw: gw4,
-                        metric: mtr,
-                    }),
-                    (IpAddr::V6(gw6), IpNet::V6(dst6)) => Ok(Route::Ipv6 {
-                        dest: dst6,
-                        gw: gw6,
-                        metric: mtr,
-                    }),
-                    (IpAddr::V4(gw4), IpNet::V6(dst6)) => Err(NetavarkError::Message(format!(
-                        "Route with ipv6 destination and ipv4 gateway ({dst6} via {gw4})"
-                    ))),
+                let rt = parse_route_type(&r.route_type)?;
 
-                    (IpAddr::V6(gw6), IpNet::V4(dst4)) => Err(NetavarkError::Message(format!(
-                        "Route with ipv4 destination and ipv6 gateway ({dst4} via {gw6})"
-                    ))),
+                if route_type_requires_gateway(rt) && gw.is_none() {
+                    return Err(NetavarkError::msg(format!(
+                        "route {dst} requires a gateway for type unicast"
+                    )));
+                }
+                if !route_type_requires_gateway(rt) && gw.is_some() {
+                    return Err(NetavarkError::msg(format!(
+                        "route {dst} must not have a gateway for type {rt:?}"
+                    )));
+                }
+
+                match (gw, dst) {
+                    (Some(IpAddr::V4(gw4)), IpNet::V4(dst4)) => Ok(Route::Ipv4 {
+                        dest: dst4,
+                        gw: Some(gw4),
+                        metric: mtr,
+                        route_type: rt,
+                    }),
+                    (Some(IpAddr::V6(gw6)), IpNet::V6(dst6)) => Ok(Route::Ipv6 {
+                        dest: dst6,
+                        gw: Some(gw6),
+                        metric: mtr,
+                        route_type: rt,
+                    }),
+                    (Some(IpAddr::V4(gw4)), IpNet::V6(dst6)) => Err(NetavarkError::Message(
+                        format!("route with ipv6 destination and ipv4 gateway ({dst6} via {gw4})"),
+                    )),
+                    (Some(IpAddr::V6(gw6)), IpNet::V4(dst4)) => Err(NetavarkError::Message(
+                        format!("route with ipv4 destination and ipv6 gateway ({dst4} via {gw6})"),
+                    )),
+                    (None, IpNet::V4(dst4)) => Ok(Route::Ipv4 {
+                        dest: dst4,
+                        gw: None,
+                        metric: mtr,
+                        route_type: rt,
+                    }),
+                    (None, IpNet::V6(dst6)) => Ok(Route::Ipv6 {
+                        dest: dst6,
+                        gw: None,
+                        metric: mtr,
+                        route_type: rt,
+                    }),
                 }
             })
             .collect(),

--- a/src/network/create_config/validation.rs
+++ b/src/network/create_config/validation.rs
@@ -269,7 +269,8 @@ pub fn validate_routes(network: &mut Network) -> NetavarkResult<()> {
 }
 
 /// Validate a single route.
-/// Ensures that the destination is a valid network address (not a host address).
+/// Ensures that the destination is a valid network address (not a host address)
+/// and that the route type and gateway are valid.
 fn validate_route(route: &Route) -> NetavarkResult<()> {
     // Check that destination is a network and not an address
     // The address part of the destination must equal the network address
@@ -283,6 +284,33 @@ fn validate_route(route: &Route) -> NetavarkResult<()> {
             if net_v6.addr() != net_v6.network() {
                 return Err(NetavarkError::msg("route destination invalid"));
             }
+        }
+    }
+
+    // Validate route type and gateway
+    let route_type = route.route_type.as_deref().unwrap_or("unicast");
+    match route_type {
+        "unicast" | "" => {
+            if route.gateway.is_none() {
+                return Err(NetavarkError::msg(format!(
+                    "route {} requires a gateway for type unicast",
+                    route.destination
+                )));
+            }
+        }
+        "blackhole" | "unreachable" | "prohibit" => {
+            if route.gateway.is_some() {
+                return Err(NetavarkError::msg(format!(
+                    "route {} must not have a gateway for type {}",
+                    route.destination, route_type
+                )));
+            }
+        }
+        _ => {
+            return Err(NetavarkError::msg(format!(
+                "invalid route type \"{}\"",
+                route_type
+            )));
         }
     }
 

--- a/src/network/netlink_route.rs
+++ b/src/network/netlink_route.rs
@@ -43,31 +43,49 @@ pub enum LinkID {
 pub enum Route {
     Ipv4 {
         dest: ipnet::Ipv4Net,
-        gw: Ipv4Addr,
+        gw: Option<Ipv4Addr>,
         metric: Option<u32>,
+        route_type: RouteType,
     },
     Ipv6 {
         dest: ipnet::Ipv6Net,
-        gw: Ipv6Addr,
+        gw: Option<Ipv6Addr>,
         metric: Option<u32>,
+        route_type: RouteType,
     },
 }
 
 impl std::fmt::Display for Route {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let (dest, gw, metric) = match self {
-            Route::Ipv4 { dest, gw, metric } => (
+        let (dest, gw, metric, rtype) = match self {
+            Route::Ipv4 {
+                dest,
+                gw,
+                metric,
+                route_type,
+            } => (
                 dest.to_string(),
-                gw.to_string(),
+                gw.map(|g| g.to_string()),
                 metric.unwrap_or(constants::DEFAULT_METRIC),
+                route_type,
             ),
-            Route::Ipv6 { dest, gw, metric } => (
+            Route::Ipv6 {
+                dest,
+                gw,
+                metric,
+                route_type,
+            } => (
                 dest.to_string(),
-                gw.to_string(),
+                gw.map(|g| g.to_string()),
                 metric.unwrap_or(constants::DEFAULT_METRIC),
+                route_type,
             ),
         };
-        write!(f, "(dest: {dest} ,gw: {gw}, metric {metric})")
+        if let Some(gw) = gw {
+            write!(f, "(dest: {dest}, gw: {gw}, metric {metric})")
+        } else {
+            write!(f, "({rtype:?} dest: {dest}, metric {metric})")
+        }
     }
 }
 
@@ -251,38 +269,52 @@ impl Socket<NetlinkRoute> {
         msg.header.table = libc::RT_TABLE_MAIN;
         msg.header.protocol = RouteProtocol::Static;
         msg.header.scope = RouteScope::Universe;
-        msg.header.kind = RouteType::Unicast;
 
-        let (dest, dest_prefix, gateway, final_metric) = match route {
-            Route::Ipv4 { dest, gw, metric } => {
+        let (dest, dest_prefix, gateway, final_metric, rtype) = match route {
+            Route::Ipv4 {
+                dest,
+                gw,
+                metric,
+                route_type,
+            } => {
                 msg.header.address_family = AddressFamily::Inet;
                 (
                     RouteAddress::Inet(dest.addr()),
                     dest.prefix_len(),
-                    RouteAddress::Inet(*gw),
+                    gw.map(RouteAddress::Inet),
                     metric.unwrap_or(constants::DEFAULT_METRIC),
+                    *route_type,
                 )
             }
-            Route::Ipv6 { dest, gw, metric } => {
+            Route::Ipv6 {
+                dest,
+                gw,
+                metric,
+                route_type,
+            } => {
                 msg.header.address_family = AddressFamily::Inet6;
                 (
                     RouteAddress::Inet6(dest.addr()),
                     dest.prefix_len(),
-                    RouteAddress::Inet6(*gw),
+                    gw.map(RouteAddress::Inet6),
                     metric.unwrap_or(constants::DEFAULT_METRIC),
+                    *route_type,
                 )
             }
         };
 
+        msg.header.kind = rtype;
         msg.header.destination_prefix_length = dest_prefix;
         msg.attributes
             .push(netlink_packet_route::route::RouteAttribute::Destination(
                 dest,
             ));
-        msg.attributes
-            .push(netlink_packet_route::route::RouteAttribute::Gateway(
-                gateway,
-            ));
+
+        if let Some(gw) = gateway {
+            msg.attributes
+                .push(netlink_packet_route::route::RouteAttribute::Gateway(gw));
+        }
+
         msg.attributes
             .push(netlink_packet_route::route::RouteAttribute::Priority(
                 final_metric,

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -285,9 +285,12 @@ pub struct Subnet {
 /// Static routes for a network.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Route {
-    /// Gateway IP for this route.
+    /// Gateway IP for this route. Required for unicast routes, must not be
+    /// set for blackhole/unreachable/prohibit routes.
     #[serde(rename = "gateway")]
-    pub gateway: IpAddr,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub gateway: Option<IpAddr>,
 
     /// Destination for this route in CIDR form.
     #[serde(rename = "destination")]
@@ -296,6 +299,13 @@ pub struct Route {
     /// Route Metric
     #[serde(rename = "metric")]
     pub metric: Option<u32>,
+
+    /// Route type, accepts the same values as ip route: unicast, blackhole,
+    /// unreachable, prohibit. Defaults to unicast.
+    #[serde(rename = "route_type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub route_type: Option<String>,
 }
 
 /// LeaseRange contains the range where IP are leased.

--- a/src/test/netlink.rs
+++ b/src/test/netlink.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use netavark::network::netlink::Socket;
     use netavark::network::netlink_route::{CreateLinkOptions, LinkID, NetlinkRoute, Route};
-    use netlink_packet_route::{address, link::InfoKind};
+    use netlink_packet_route::{address, link::InfoKind, route::RouteType};
 
     macro_rules! test_setup {
         () => {
@@ -147,8 +147,9 @@ mod tests {
 
         sock.del_route(&Route::Ipv4 {
             dest: net.parse().unwrap(),
-            gw: gw.parse().unwrap(),
+            gw: Some(gw.parse().unwrap()),
             metric: None,
+            route_type: RouteType::Unicast,
         })
         .expect("del_route failed");
 

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -75,6 +75,25 @@ function setup() {
     assert "$output" "!~" "10.92.0.0/24 via 10.91.0.1" "static route not removed"
 }
 
+@test "$fw_driver - bridge with blackhole routes" {
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-blackholeroutes.json setup $(get_container_netns_path)
+
+    # check blackhole routes
+    run_in_container_netns ip r
+    assert "$output" "=~" "blackhole 10.89.0.0/24" "blackhole route not set"
+    assert "$output" "=~" "blackhole 10.90.0.0/24" "blackhole route not set"
+    # check regular static route is also set
+    assert "$output" "=~" "10.91.0.0/24 via 10.88.0.3" "static route not set"
+
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-blackholeroutes.json teardown $(get_container_netns_path)
+
+    # check routes get removed
+    run_in_container_netns ip r
+    assert "$output" "!~" "blackhole 10.89.0.0/24" "blackhole route not removed"
+    assert "$output" "!~" "blackhole 10.90.0.0/24" "blackhole route not removed"
+    assert "$output" "!~" "10.91.0.0/24 via 10.88.0.3" "static route not removed"
+}
+
 @test "$fw_driver - bridge with no default route" {
     run_netavark --file ${TESTSDIR}/testfiles/bridge-nodefaultroute.json setup $(get_container_netns_path)
 
@@ -153,6 +172,25 @@ function setup() {
     assert "$output" "!~" "fd10:51:b::/64 via fd10:49:b::30" "static route not removed"
 
     run_in_container_netns ip link delete dummy0
+}
+
+@test "$fw_driver - ipv6 bridge with blackhole routes" {
+    run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge-blackholeroutes.json setup $(get_container_netns_path)
+
+    # check blackhole routes
+    run_in_container_netns ip -6 -br r
+    assert "$output" "=~" "blackhole fd10:89:b::/64" "blackhole route not set"
+    assert "$output" "=~" "blackhole fd10:89:c::/64" "blackhole route not set"
+    # check regular static route is also set
+    assert "$output" "=~" "fd10:51:b::/64 via fd10:88:a::ac02" "static route not set"
+
+    run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge-blackholeroutes.json teardown $(get_container_netns_path)
+
+    # check routes get removed
+    run_in_container_netns ip -6 -br r
+    assert "$output" "!~" "blackhole fd10:89:b::/64" "blackhole route not removed"
+    assert "$output" "!~" "blackhole fd10:89:c::/64" "blackhole route not removed"
+    assert "$output" "!~" "fd10:51:b::/64 via fd10:88:a::ac02" "static route not removed"
 }
 
 @test "$fw_driver - dual stack dns with alt port" {

--- a/test/250-bridge-nftables.bats
+++ b/test/250-bridge-nftables.bats
@@ -116,6 +116,25 @@ export NETAVARK_FW=nftables
     assert "$output" "!~" "10.92.0.0/24 via 10.91.0.1" "static route not removed"
 }
 
+@test "$fw_driver - bridge with blackhole routes" {
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-blackholeroutes.json setup $(get_container_netns_path)
+
+    # check blackhole routes
+    run_in_container_netns ip r
+    assert "$output" "=~" "blackhole 10.89.0.0/24" "blackhole route not set"
+    assert "$output" "=~" "blackhole 10.90.0.0/24" "blackhole route not set"
+    # check regular static route is also set
+    assert "$output" "=~" "10.91.0.0/24 via 10.88.0.3" "static route not set"
+
+    run_netavark --file ${TESTSDIR}/testfiles/bridge-blackholeroutes.json teardown $(get_container_netns_path)
+
+    # check routes get removed
+    run_in_container_netns ip r
+    assert "$output" "!~" "blackhole 10.89.0.0/24" "blackhole route not removed"
+    assert "$output" "!~" "blackhole 10.90.0.0/24" "blackhole route not removed"
+    assert "$output" "!~" "10.91.0.0/24 via 10.88.0.3" "static route not removed"
+}
+
 @test "$fw_driver - bridge with no default route" {
     run_netavark --file ${TESTSDIR}/testfiles/bridge-nodefaultroute.json setup $(get_container_netns_path)
 
@@ -244,6 +263,25 @@ export NETAVARK_FW=nftables
     assert "$output" "!~" "fd10:51:b::/64 via fd10:49:b::30" "static route not removed"
 
     run_in_container_netns ip link delete dummy0
+}
+
+@test "$fw_driver - ipv6 bridge with blackhole routes" {
+    run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge-blackholeroutes.json setup $(get_container_netns_path)
+
+    # check blackhole routes
+    run_in_container_netns ip -6 -br r
+    assert "$output" "=~" "blackhole fd10:89:b::/64" "blackhole route not set"
+    assert "$output" "=~" "blackhole fd10:89:c::/64" "blackhole route not set"
+    # check regular static route is also set
+    assert "$output" "=~" "fd10:51:b::/64 via fd10:88:a::ac02" "static route not set"
+
+    run_netavark --file ${TESTSDIR}/testfiles/ipv6-bridge-blackholeroutes.json teardown $(get_container_netns_path)
+
+    # check routes get removed
+    run_in_container_netns ip -6 -br r
+    assert "$output" "!~" "blackhole fd10:89:b::/64" "blackhole route not removed"
+    assert "$output" "!~" "blackhole fd10:89:c::/64" "blackhole route not removed"
+    assert "$output" "!~" "fd10:51:b::/64 via fd10:88:a::ac02" "static route not removed"
 }
 
 @test "$fw_driver - bridge driver must generate config for aardvark with custom dns server" {

--- a/test/700-create.bats
+++ b/test/700-create.bats
@@ -136,7 +136,6 @@ function setup() {
     assert_json "$result" ".subnets[0].subnet" =~ "^10\\.89\\." "Output subnet is within the pool range"
 }
 
-
 # Subnet and Gateway Tests
 
 @test "create - bridge with subnet and custom gateway" {
@@ -368,4 +367,35 @@ function setup() {
 @test "create - fail when subnets are duplicated within same network" {
     expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/subnet-duplicate-within.json
     assert_json "$output" ".error" "=~" "duplicate subnet defined: 10.100.0.0/24" "Error message about duplicate subnets"
+}
+
+@test "create - network with unicast routes" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/routes-unicast.json
+    result="$output"
+
+    assert_json "$result" ".name" == "routetest" "Network name matches"
+    assert_json "$result" '.routes | length' == "1" "One route is present"
+    assert_json "$result" '.routes[0].destination' == "10.89.0.0/24" "Route destination matches"
+    assert_json "$result" '.routes[0].gateway' == "10.88.0.2" "Route gateway matches"
+}
+
+@test "create - network with blackhole routes" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/routes-blackhole.json
+    result="$output"
+
+    assert_json "$result" ".name" == "blackholetest" "Network name matches"
+    assert_json "$result" '.routes | length' == "1" "One route is present"
+    assert_json "$result" '.routes[0].destination' == "10.89.0.0/24" "Route destination matches"
+    assert_json "$result" '.routes[0].route_type' == "blackhole" "Route type is blackhole"
+    assert_json "$result" '.routes[0] | has("gateway")' == "false" "Blackhole route has no gateway"
+}
+
+@test "create - fail with unicast route missing gateway" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/routes-unicast-no-gateway.json
+    assert_json ".error" "route 10.89.0.0/24 requires a gateway for type unicast" "Error message for missing gateway"
+}
+
+@test "create - fail with blackhole route having gateway" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/routes-blackhole-with-gateway.json
+    assert_json ".error" "route 10.89.0.0/24 must not have a gateway for type blackhole" "Error message for gateway on blackhole"
 }

--- a/test/testfiles/bridge-blackholeroutes.json
+++ b/test/testfiles/bridge-blackholeroutes.json
@@ -1,0 +1,43 @@
+{
+    "container_id": "6ce776ea58b5",
+    "container_name": "testcontainer",
+    "networks": {
+        "podman": {
+            "interface_name": "eth0",
+            "static_ips": [
+                "10.88.0.2"
+            ]
+        }
+    },
+    "network_info": {
+        "podman": {
+            "dns_enabled": false,
+            "driver": "bridge",
+            "id": "53ce4390f2adb1681eb1a90ec8b48c49c015e0a8d336c197637e7f65e365fa9e",
+            "internal": false,
+            "ipv6_enabled": false,
+            "name": "podman",
+            "network_interface": "podman0",
+            "subnets": [
+                {
+                    "gateway": "10.88.0.1",
+                    "subnet": "10.88.0.0/16"
+                }
+            ],
+            "routes": [
+                {
+                    "destination": "10.89.0.0/24",
+                    "route_type": "blackhole"
+                },
+                {
+                    "destination": "10.90.0.0/24",
+                    "route_type": "blackhole"
+                },
+                {
+                    "destination": "10.91.0.0/24",
+                    "gateway": "10.88.0.3"
+                }
+            ]
+        }
+    }
+}

--- a/test/testfiles/create/routes-blackhole-with-gateway.json
+++ b/test/testfiles/create/routes-blackhole-with-gateway.json
@@ -1,0 +1,33 @@
+{
+  "network": {
+    "name": "badblackhole",
+    "id": "abc123def4567890123456789012345678901234567890123456789012345678",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.88.0.0/16",
+        "gateway": "10.88.0.1"
+      }
+    ],
+    "routes": [
+      {
+        "destination": "10.89.0.0/24",
+        "route_type": "blackhole",
+        "gateway": "10.88.0.2"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/routes-blackhole.json
+++ b/test/testfiles/create/routes-blackhole.json
@@ -1,0 +1,32 @@
+{
+  "network": {
+    "name": "blackholetest",
+    "id": "abc123def4567890123456789012345678901234567890123456789012345678",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.88.0.0/16",
+        "gateway": "10.88.0.1"
+      }
+    ],
+    "routes": [
+      {
+        "destination": "10.89.0.0/24",
+        "route_type": "blackhole"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/routes-unicast-no-gateway.json
+++ b/test/testfiles/create/routes-unicast-no-gateway.json
@@ -1,0 +1,31 @@
+{
+  "network": {
+    "name": "badunicast",
+    "id": "abc123def4567890123456789012345678901234567890123456789012345678",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.88.0.0/16",
+        "gateway": "10.88.0.1"
+      }
+    ],
+    "routes": [
+      {
+        "destination": "10.89.0.0/24"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/routes-unicast.json
+++ b/test/testfiles/create/routes-unicast.json
@@ -1,0 +1,32 @@
+{
+  "network": {
+    "name": "routetest",
+    "id": "abc123def4567890123456789012345678901234567890123456789012345678",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.88.0.0/16",
+        "gateway": "10.88.0.1"
+      }
+    ],
+    "routes": [
+      {
+        "destination": "10.89.0.0/24",
+        "gateway": "10.88.0.2"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/ipv6-bridge-blackholeroutes.json
+++ b/test/testfiles/ipv6-bridge-blackholeroutes.json
@@ -1,0 +1,46 @@
+{
+    "container_id": "f031bf33eecba75d0d84952337b1ceef6a239eb8e94b48aee0993d0791345325",
+    "container_name": "somename",
+    "networks": {
+        "podman1": {
+            "static_ips": [
+                "fd10:88:a::2"
+            ],
+            "interface_name": "eth0"
+        }
+    },
+    "network_info": {
+        "podman1": {
+            "name": "podman1",
+            "id": "ec79dd0cad82083c8ac5cc23e9542e4ddea813dff60d68258d36e84f6393b63b",
+            "driver": "bridge",
+            "network_interface": "podman1",
+            "subnets": [
+                {
+                    "subnet": "fd10:88:a::/64",
+                    "gateway": "fd10:88:a::1"
+                }
+            ],
+            "routes": [
+                {
+                    "destination": "fd10:89:b::/64",
+                    "route_type": "blackhole"
+                },
+                {
+                    "destination": "fd10:89:c::/64",
+                    "route_type": "blackhole"
+                },
+                {
+                    "destination": "fd10:51:b::/64",
+                    "gateway": "fd10:88:a::ac02"
+                }
+            ],
+            "ipv6_enabled": true,
+            "internal": false,
+            "dns_enabled": false,
+            "ipam_options": {
+                "driver": "host-local"
+            }
+        }
+    }
+}


### PR DESCRIPTION
When the gateway field is omitted from a route definition, a blackhole route is created instead of a unicast route. Blackhole routes silently discard packets destined for the specified network.

The gateway field in the Route type is now Optional.

Closes #930