### PR TITLE
Add more Netavark create tests

### DIFF
--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -62,7 +62,7 @@ where
     Ok(Some(val))
 }
 
-fn validate_subnets(subnets: &Option<Vec<types::Subnet>>) -> NetavarkResult<()> {
+pub fn validate_subnets(subnets: &Option<Vec<types::Subnet>>) -> NetavarkResult<()> {
     for (i, subnet1) in subnets.iter().flatten().enumerate() {
         for subnet2 in subnets.iter().flatten().skip(i + 1) {
             // Check for exact duplicate

--- a/src/network/create_config/driver.rs
+++ b/src/network/create_config/driver.rs
@@ -240,7 +240,7 @@ fn get_free_device_name(
 pub fn exec_plugin_driver(
     network: &mut Network,
     plugin_directories: &Option<Vec<OsString>>,
-) -> NetavarkResult<Vec<u8>> {
+) -> NetavarkResult<()> {
     // Find the plugin binary
     let driver_name = &network.driver;
     let plugin_path = if let Some(dirs) = plugin_directories {
@@ -265,10 +265,43 @@ pub fn exec_plugin_driver(
         ));
     };
 
+    let original_name = network.name.clone();
+    let original_id = network.id.clone();
+    let original_driver = network.driver.clone();
+
     // Clone the network since we need to send it via JSON
     let input = network.clone();
 
-    exec_plugin_common(&plugin_path, &["create"], &input, plugin_path.file_name())
+    let buffer = exec_plugin_common(&plugin_path, &["create"], &input, plugin_path.file_name())?;
+
+    let plugin_network: Network = serde_json::from_slice(&buffer)?;
+
+    // Validate that the plugin didn't change name, id, or driver
+    if plugin_network.name != original_name {
+        return Err(NetavarkError::msg(format!(
+            "{} plugin invalid result: changed network name",
+            driver_name,
+        )));
+    }
+
+    if plugin_network.id != original_id {
+        return Err(NetavarkError::msg(format!(
+            "{} plugin invalid result: changed network ID",
+            driver_name
+        )));
+    }
+
+    if plugin_network.driver != original_driver {
+        return Err(NetavarkError::msg(format!(
+            "{} plugin invalid result: changed network driver",
+            driver_name
+        )));
+    }
+
+    // Validation passed, use the plugin's network
+    *network = plugin_network;
+
+    Ok(())
 }
 
 fn get_link_names() -> Option<Vec<String>> {

--- a/src/network/create_config/validation.rs
+++ b/src/network/create_config/validation.rs
@@ -119,6 +119,11 @@ pub fn validate_subnets(
 
     for subnet in subnets {
         validate_subnet(subnet, add_gateway, check_used, used_networks)?;
+
+        // Auto-detect IPv6 and set ipv6_enabled flag
+        if subnet.subnet.addr().is_ipv6() {
+            network.ipv6_enabled = true;
+        }
     }
 
     Ok(())

--- a/src/network/create_config/validation.rs
+++ b/src/network/create_config/validation.rs
@@ -1,5 +1,6 @@
 use crate::error::{NetavarkError, NetavarkResult};
 use crate::network::constants;
+use crate::network::core_utils;
 use crate::network::create_config::subnet::network_intersects_with_networks;
 use crate::network::types::{Network, Route, Subnet};
 use ipnet::IpNet;
@@ -113,6 +114,9 @@ pub fn validate_subnets(
     check_used: bool,
     used_networks: &[IpNet],
 ) -> NetavarkResult<()> {
+    // Check for duplicate and overlapping subnets within the same network
+    core_utils::validate_subnets(&network.subnets)?;
+
     let Some(subnets) = &mut network.subnets else {
         return Ok(());
     };

--- a/test/700-create.bats
+++ b/test/700-create.bats
@@ -5,6 +5,13 @@
 
 load helpers
 
+function setup() {
+    basic_setup
+
+    # create a extra interface which we can use to connect the macvlan/ipvlan to
+    run_in_host_netns ip link add dummy0 type dummy
+}
+
 @test "create - basic network create" {
     # Create a basic network configuration
     run_netavark create < ${TESTSDIR}/testfiles/create/basic.json
@@ -45,18 +52,6 @@ load helpers
     expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/duplicate-name-same.json
 
     assert_json ".error"  "network already exists testnet1" "Error message contains 'network already exists testnet1'"
-}
-
-@test "create - bridge config" {
-    run_netavark create < ${TESTSDIR}/testfiles/create/bridge.json
-    result="$output"
-    
-    assert_json "$result" ".name" == "bridge-net" "Network name matches"
-    assert_json "$result" ".driver" == "bridge" "Driver is bridge"
-    assert_json "$result" ".ipam_options.driver" == "host-local" "IPAM driver is host-local"
-    assert_json "$result" ".subnets | length" -ge "1" "At least one subnet exists"
-    assert_json "$result" ".dns_enabled" == "false" "DNS is disabled"
-    assert_json "$result" ".internal" == "false" "Network is not internal"
 }
 
 @test "create - network with used interface name" {
@@ -115,14 +110,6 @@ load helpers
     assert_json "$result" ".labels.key2" == "value2" "Second label matches"
 }
 
-@test "create - network with options" {
-    run_netavark create < ${TESTSDIR}/testfiles/create/options.json
-    result="$output"
-    
-    assert_json "$result" 'has("options")' == "true" "Options are present"
-    assert_json "$result" ".options.mtu" == "1500" "MTU option matches"
-}
-
 @test "create - network with IPv6 enabled" {
     run_netavark create < ${TESTSDIR}/testfiles/create/ipv6-enabled.json
     result="$output"
@@ -149,3 +136,217 @@ load helpers
     assert_json "$result" ".subnets[0].subnet" =~ "^10\\.89\\." "Output subnet is within the pool range"
 }
 
+
+# Subnet and Gateway Tests
+
+@test "create - bridge with subnet and custom gateway" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/subnet-with-gateway.json
+    result="$output"
+    
+    assert_json "$result" ".subnets[0].subnet" == "10.100.0.0/24" "Subnet matches"
+    assert_json "$result" ".subnets[0].gateway" == "10.100.0.50" "Custom gateway matches"
+}
+
+@test "create - fail with gateway not in subnet" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/gateway-not-in-subnet.json
+    assert_json "$output" ".error" "=~" "gateway 10.200.0.1 not in subnet 10.100.0.0/24" "Error message about gateway not in subnet"
+}
+
+@test "create - bridge with lease range start_ip" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/lease-range-start.json
+    result="$output"
+    
+    assert_json "$result" ".subnets[0].subnet" == "10.100.0.0/24" "Subnet matches"
+    assert_json "$result" ".subnets[0].lease_range.start_ip" == "10.100.0.20" "Lease range start_ip matches"
+}
+
+@test "create - bridge with lease range start_ip and end_ip" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/lease-range-both.json
+    result="$output"
+    
+    assert_json "$result" ".subnets[0].lease_range.start_ip" == "10.100.0.20" "Lease range start_ip matches"
+    assert_json "$result" ".subnets[0].lease_range.end_ip" == "10.100.0.50" "Lease range end_ip matches"
+}
+
+@test "create - fail with invalid lease range" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/lease-range-invalid.json
+    assert_json "$output" ".error" "=~" "lease range start_ip 10.200.0.20 not in subnet 10.100.0.0/24" "Error message about lease range start_ip not in subnet"
+}
+
+# IPv6 Auto-generation Tests
+@test "create - ipv6_enabled auto-generates dual-stack" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/ipv6-auto-dualstack.json
+    result="$output"
+    
+    assert_json "$result" ".ipv6_enabled" == "true" "IPv6 is enabled"
+    assert_json "$result" ".subnets | length" == "2" "Two subnets created"
+    
+    # Check one is IPv4 and one is IPv6
+    ipv4_count=$(echo "$result" | jq '[.subnets[].subnet | select(contains("."))] | length')
+    ipv6_count=$(echo "$result" | jq '[.subnets[].subnet | select(contains(":"))] | length')
+
+    assert "$ipv4_count" == "1" "Expected 1 IPv4 subnet"
+    assert "$ipv6_count" == "1" "Expected 1 IPv6 subnet"
+}
+
+@test "create - ipv6_enabled with ipv4 subnet adds ipv6" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/ipv6-with-ipv4-subnet.json
+    result="$output"
+    
+    assert_json "$result" ".ipv6_enabled" == "true" "IPv6 is enabled"
+    assert_json "$result" ".subnets | length" == "2" "Two subnets created"
+    assert_json "$result" ".subnets[0].subnet" == "10.100.0.0/24" "IPv4 subnet matches"
+
+    # Check second subnet is IPv6
+    assert_json "$result" ".subnets[1].subnet" "=~" ":" "Second subnet should be IPv6"
+}
+
+# NetworkDNSServers Tests
+@test "create - network_dns_servers with valid IPs" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/network-dns-servers-valid.json
+    result="$output"
+    
+    assert_json "$result" ".network_dns_servers[0]" == "8.8.8.8" "First DNS server matches"
+    assert_json "$result" ".network_dns_servers[1]" == "1.1.1.1" "Second DNS server matches"
+    assert_json "$result" ".dns_enabled" == "true" "DNS is enabled"
+}
+
+@test "create - fail with invalid IP in network_dns_servers" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/network-dns-servers-invalid-ip.json
+    assert_json "$output" ".error" "=~" "invalid IP address syntax" "Error message about invalid IP"
+}
+
+@test "create - fail with network_dns_servers when dns_enabled=false" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/network-dns-servers-dns-disabled.json
+    assert_json "$output" ".error" "=~" "DNS is not enabled" "Error message about DNS not enabled"
+}
+
+# MTU Option Tests
+@test "create - network with mtu option" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/mtu-option.json
+    result="$output"
+    
+    assert_json "$result" ".options.mtu" == "1500" "MTU option is set"
+}
+
+@test "create - fail with invalid mtu option" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/mtu-invalid.json
+    assert_json "$output" ".error" "=~" "unable to parse \"mtu\": invalid digit found in string" "Error message about unable to parse mtu"
+}
+
+# VLAN Option Tests
+@test "create - network with vlan option" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/vlan-option.json
+    result="$output"
+    
+    assert_json "$result" ".options.vlan" == "100" "VLAN option is set"
+}
+
+@test "create - fail with invalid vlan option" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/vlan-invalid.json
+    assert_json "$output" ".error" "=~" "vlan must be between 0 and 4094" "Error message about vlan range"
+}
+
+# Isolate Option Tests
+@test "create - network with isolate=true" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/isolate-true.json
+    result="$output"
+    
+    assert_json "$result" ".options.isolate" == "true" "Isolate option is set to true"
+}
+
+@test "create - network with isolate=strict" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/isolate-strict.json
+    result="$output"
+    
+    assert_json "$result" ".options.isolate" == "strict" "Isolate option is set to strict"
+}
+
+# IPAM Driver Tests
+@test "create - ipam driver none disables DNS" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/ipam-none.json
+    result="$output"
+    
+    assert_json "$result" ".ipam_options.driver" == "none" "IPAM driver is none"
+    assert_json "$result" ".dns_enabled" == "false" "DNS is disabled when ipam is none"
+}
+
+@test "create - fail ipam driver none with subnets" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/ipam-none-with-subnets.json
+    assert_json "$output" ".error" "=~" "None ipam driver is set but subnets are given" "Error about none ipam with subnets"
+}
+
+# MACVLAN Tests
+@test "create - macvlan without subnet defaults to dhcp" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/macvlan-dhcp.json
+    result="$output"
+    
+    assert_json "$result" ".driver" == "macvlan" "Driver is macvlan"
+    assert_json "$result" ".ipam_options.driver" == "dhcp" "IPAM driver is dhcp"
+    assert_json "$result" ".dns_enabled" == "false" "DNS is disabled for macvlan"
+}
+
+@test "create - macvlan with subnet" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/macvlan-subnet.json
+    result="$output"
+    
+    assert_json "$result" ".driver" == "macvlan" "Driver is macvlan"
+    assert_json "$result" ".ipam_options.driver" == "host-local" "IPAM driver is host-local"
+    assert_json "$result" ".subnets[0].subnet" == "10.200.0.0/24" "Subnet matches"
+    assert_json "$result" ".dns_enabled" == "false" "DNS is disabled for macvlan"
+}
+
+@test "create - macvlan with mode option" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/macvlan-mode.json
+    result="$output"
+    
+    assert_json "$result" ".driver" == "macvlan" "Driver is macvlan"
+    assert_json "$result" ".options.mode" == "bridge" "Mode option is set"
+}
+
+# IPVLAN Tests
+@test "create - fail ipvlan without subnet (no dhcp support)" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/ipvlan-no-subnet.json
+    assert_json "$output" ".error" == "ipam driver dhcp is not supported with ipvlan" "Error about ipvlan dhcp"
+}
+
+@test "create - ipvlan with subnet" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/ipvlan-subnet.json
+    result="$output"
+    
+    assert_json "$result" ".driver" == "ipvlan" "Driver is ipvlan"
+    assert_json "$result" ".ipam_options.driver" == "host-local" "IPAM driver is host-local"
+    assert_json "$result" ".subnets[0].subnet" == "10.200.0.0/24" "Subnet matches"
+    assert_json "$result" ".dns_enabled" == "false" "DNS is disabled for ipvlan"
+}
+
+# Static Route Tests
+@test "create - bridge with static route" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/static-route.json
+    result="$output"
+    
+    assert_json "$result" ".routes | length" == "1" "One route is present"
+    assert_json "$result" ".routes[0].destination" == "192.168.0.0/24" "Route destination matches"
+    assert_json "$result" ".routes[0].gateway" == "10.100.0.254" "Route gateway matches"
+}
+
+@test "create - fail with invalid route destination (not CIDR)" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/route-invalid-dest.json
+    assert_json "$output" ".error" "=~" "invalid IP address syntax" "Error message about invalid IP"
+}
+
+@test "create - fail with invalid route gateway" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/route-invalid-gw.json
+    assert_json "$output" ".error" "=~" "invalid IP address syntax" "Error message about invalid IP"
+}
+
+# Tests for subnet validation against used.subnets
+@test "create - fail when explicit subnet overlaps with used.subnets" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/subnet-overlaps-used.json
+    assert_json "$output" ".error" "=~" "subnet 10.1.3.248/30 is already used" "Error message about subnet already used"
+}
+
+@test "create - fail when explicit subnet duplicates used.subnets" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/subnet-duplicate-used.json
+    assert_json "$output" ".error" "=~" "subnet 10.89.0.0/24 is already used" "Error message about subnet already used"
+}

--- a/test/700-create.bats
+++ b/test/700-create.bats
@@ -192,13 +192,21 @@ function setup() {
 @test "create - ipv6_enabled with ipv4 subnet adds ipv6" {
     run_netavark create < ${TESTSDIR}/testfiles/create/ipv6-with-ipv4-subnet.json
     result="$output"
-    
+
     assert_json "$result" ".ipv6_enabled" == "true" "IPv6 is enabled"
     assert_json "$result" ".subnets | length" == "2" "Two subnets created"
     assert_json "$result" ".subnets[0].subnet" == "10.100.0.0/24" "IPv4 subnet matches"
 
     # Check second subnet is IPv6
     assert_json "$result" ".subnets[1].subnet" "=~" ":" "Second subnet should be IPv6"
+}
+
+@test "create - ipv6 subnet auto-detects and sets ipv6_enabled" {
+    run_netavark create < ${TESTSDIR}/testfiles/create/ipv6-subnet.json
+    result="$output"
+
+    assert_json "$result" ".ipv6_enabled" == "true" "IPv6 is auto-detected and enabled"
+    assert_json "$result" ".subnets[0].subnet" == "fdcc::/64" "IPv6 subnet matches"
 }
 
 # NetworkDNSServers Tests

--- a/test/700-create.bats
+++ b/test/700-create.bats
@@ -358,3 +358,14 @@ function setup() {
     expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/subnet-duplicate-used.json
     assert_json "$output" ".error" "=~" "subnet 10.89.0.0/24 is already used" "Error message about subnet already used"
 }
+
+# Tests for subnet validation within same network
+@test "create - fail when subnets overlap within same network" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/subnet-overlap-within.json
+    assert_json "$output" ".error" "=~" "overlapping subnets: 10.1.2.0/23 and 10.1.3.248/30" "Error message about overlapping subnets"
+}
+
+@test "create - fail when subnets are duplicated within same network" {
+    expected_rc=1 run_netavark create < ${TESTSDIR}/testfiles/create/subnet-duplicate-within.json
+    assert_json "$output" ".error" "=~" "duplicate subnet defined: 10.100.0.0/24" "Error message about duplicate subnets"
+}

--- a/test/testfiles/create/gateway-not-in-subnet.json
+++ b/test/testfiles/create/gateway-not-in-subnet.json
@@ -1,0 +1,26 @@
+{
+  "network": {
+    "name": "badgw",
+    "id": "3234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24",
+        "gateway": "10.200.0.1"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/ipam-none-with-subnets.json
+++ b/test/testfiles/create/ipam-none-with-subnets.json
@@ -1,0 +1,28 @@
+{
+  "network": {
+    "name": "noneipamsubnet",
+    "id": "5334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "ipam_options": {
+      "driver": "none"
+    },
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/ipam-none.json
+++ b/test/testfiles/create/ipam-none.json
@@ -1,0 +1,23 @@
+{
+  "network": {
+    "name": "noneipam",
+    "id": "4334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": true,
+    "internal": false,
+    "ipv6_enabled": false,
+    "ipam_options": {
+      "driver": "none"
+    }
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/ipv6-auto-dualstack.json
+++ b/test/testfiles/create/ipv6-auto-dualstack.json
@@ -1,0 +1,23 @@
+{
+  "network": {
+    "name": "dualstack",
+    "id": "9234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": true
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [
+      {"base": "10.89.0.0/16", "size": 24},
+      {"base": "fd10::/8", "size": 64}
+    ],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/ipv6-subnet.json
+++ b/test/testfiles/create/ipv6-subnet.json
@@ -1,0 +1,25 @@
+{
+  "network": {
+    "name": "ipv6net",
+    "id": "1234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "fdcc::/64"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/ipv6-with-ipv4-subnet.json
+++ b/test/testfiles/create/ipv6-with-ipv4-subnet.json
@@ -1,0 +1,28 @@
+{
+  "network": {
+    "name": "ipv6addv4",
+    "id": "a234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": true,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [
+      {"base": "10.89.0.0/16", "size": 24},
+      {"base": "fd10::/8", "size": 64}
+    ],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/ipvlan-invalid-parent.json
+++ b/test/testfiles/create/ipvlan-invalid-parent.json
@@ -1,0 +1,26 @@
+{
+  "network": {
+    "name": "ipvlaninvalidparent",
+    "id": "c434567890123456789012345678901234567890123456789012345678901234",
+    "driver": "ipvlan",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_interface": "eth999",
+    "subnets": [
+      {
+        "subnet": "10.202.0.0/24"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/ipvlan-no-subnet.json
+++ b/test/testfiles/create/ipvlan-no-subnet.json
@@ -1,0 +1,21 @@
+{
+  "network": {
+    "name": "ipvlannosubnet",
+    "id": "9334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "ipvlan",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_interface": "dummy0"
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/ipvlan-subnet.json
+++ b/test/testfiles/create/ipvlan-subnet.json
@@ -1,0 +1,27 @@
+{
+  "network": {
+    "name": "ipvlansubnet",
+    "id": "a334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "ipvlan",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_interface": "dummy0",
+    "subnets": [
+      {
+        "subnet": "10.200.0.0/24",
+        "gateway": "10.200.0.1"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/isolate-strict.json
+++ b/test/testfiles/create/isolate-strict.json
@@ -1,0 +1,23 @@
+{
+  "network": {
+    "name": "isolatestrict",
+    "id": "3334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "options": {
+      "isolate": "strict"
+    }
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/isolate-true.json
+++ b/test/testfiles/create/isolate-true.json
@@ -1,0 +1,23 @@
+{
+  "network": {
+    "name": "isolatenet",
+    "id": "2334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "options": {
+      "isolate": "true"
+    }
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/lease-range-both.json
+++ b/test/testfiles/create/lease-range-both.json
@@ -1,0 +1,29 @@
+{
+  "network": {
+    "name": "leasenet2",
+    "id": "5234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24",
+        "lease_range": {
+          "start_ip": "10.100.0.20",
+          "end_ip": "10.100.0.50"
+        }
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/lease-range-invalid.json
+++ b/test/testfiles/create/lease-range-invalid.json
@@ -1,0 +1,28 @@
+{
+  "network": {
+    "name": "badlease",
+    "id": "6234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24",
+        "lease_range": {
+          "start_ip": "10.200.0.20"
+        }
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/lease-range-start.json
+++ b/test/testfiles/create/lease-range-start.json
@@ -1,0 +1,28 @@
+{
+  "network": {
+    "name": "leasenet",
+    "id": "4234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24",
+        "lease_range": {
+          "start_ip": "10.100.0.20"
+        }
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/macvlan-dhcp.json
+++ b/test/testfiles/create/macvlan-dhcp.json
@@ -1,0 +1,21 @@
+{
+  "network": {
+    "name": "macvlandhcp",
+    "id": "6334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "macvlan",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_interface": "dummy0"
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/macvlan-invalid-parent.json
+++ b/test/testfiles/create/macvlan-invalid-parent.json
@@ -1,0 +1,26 @@
+{
+  "network": {
+    "name": "macvlaninvalidparent",
+    "id": "b334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "macvlan",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_interface": "eth999",
+    "subnets": [
+      {
+        "subnet": "10.201.0.0/24"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/macvlan-mode.json
+++ b/test/testfiles/create/macvlan-mode.json
@@ -1,0 +1,29 @@
+{
+  "network": {
+    "name": "macvlanmode",
+    "id": "8334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "macvlan",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_interface": "dummy0",
+    "options": {
+      "mode": "bridge"
+    },
+    "subnets": [
+      {
+        "subnet": "10.200.0.0/24"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/macvlan-subnet.json
+++ b/test/testfiles/create/macvlan-subnet.json
@@ -1,0 +1,27 @@
+{
+  "network": {
+    "name": "macvlansubnet",
+    "id": "7334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "macvlan",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_interface": "dummy0",
+    "subnets": [
+      {
+        "subnet": "10.200.0.0/24",
+        "gateway": "10.200.0.1"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/mtu-invalid.json
+++ b/test/testfiles/create/mtu-invalid.json
@@ -1,0 +1,23 @@
+{
+  "network": {
+    "name": "badmtu",
+    "id": "f234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "options": {
+      "mtu": "abc"
+    }
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/mtu-option.json
+++ b/test/testfiles/create/mtu-option.json
@@ -1,0 +1,23 @@
+{
+  "network": {
+    "name": "mtunet",
+    "id": "e234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "options": {
+      "mtu": "1500"
+    }
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/network-dns-servers-dns-disabled.json
+++ b/test/testfiles/create/network-dns-servers-dns-disabled.json
@@ -1,0 +1,21 @@
+{
+  "network": {
+    "name": "dnsdisabled",
+    "id": "d234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_dns_servers": ["8.8.8.8"]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/network-dns-servers-invalid-ip.json
+++ b/test/testfiles/create/network-dns-servers-invalid-ip.json
@@ -1,0 +1,21 @@
+{
+  "network": {
+    "name": "baddns",
+    "id": "c234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": true,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_dns_servers": ["not.an.ip.address"]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/network-dns-servers-valid.json
+++ b/test/testfiles/create/network-dns-servers-valid.json
@@ -1,0 +1,21 @@
+{
+  "network": {
+    "name": "dnsservers",
+    "id": "b234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": true,
+    "internal": false,
+    "ipv6_enabled": false,
+    "network_dns_servers": ["8.8.8.8", "1.1.1.1"]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/route-invalid-dest.json
+++ b/test/testfiles/create/route-invalid-dest.json
@@ -1,0 +1,31 @@
+{
+  "network": {
+    "name": "badroutedest",
+    "id": "c334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24"
+      }
+    ],
+    "routes": [
+      {
+        "destination": "192.168.0.1",
+        "gateway": "10.100.0.254"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/route-invalid-gw.json
+++ b/test/testfiles/create/route-invalid-gw.json
@@ -1,0 +1,31 @@
+{
+  "network": {
+    "name": "badroutegw",
+    "id": "d334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24"
+      }
+    ],
+    "routes": [
+      {
+        "destination": "192.168.0.0/24",
+        "gateway": "notanip"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/static-route.json
+++ b/test/testfiles/create/static-route.json
@@ -1,0 +1,31 @@
+{
+  "network": {
+    "name": "routenet",
+    "id": "b334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24"
+      }
+    ],
+    "routes": [
+      {
+        "destination": "192.168.0.0/24",
+        "gateway": "10.100.0.254"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/subnet-duplicate-used.json
+++ b/test/testfiles/create/subnet-duplicate-used.json
@@ -1,0 +1,25 @@
+{
+  "network": {
+    "name": "duplicate-with-used",
+    "id": "8234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.89.0.0/24"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": ["10.89.0.0/24"]
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": true
+  }
+}

--- a/test/testfiles/create/subnet-duplicate-within.json
+++ b/test/testfiles/create/subnet-duplicate-within.json
@@ -1,0 +1,28 @@
+{
+  "network": {
+    "name": "duplicatewithin",
+    "id": "f434567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24"
+      },
+      {
+        "subnet": "10.100.0.0/24"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/subnet-overlap-within.json
+++ b/test/testfiles/create/subnet-overlap-within.json
@@ -1,0 +1,28 @@
+{
+  "network": {
+    "name": "overlapwithin",
+    "id": "e434567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.1.2.0/23"
+      },
+      {
+        "subnet": "10.1.3.248/30"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/subnet-overlaps-used.json
+++ b/test/testfiles/create/subnet-overlaps-used.json
@@ -1,0 +1,25 @@
+{
+  "network": {
+    "name": "overlap-with-used",
+    "id": "7234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.1.3.248/30"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": ["10.1.2.0/23"]
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": true
+  }
+}

--- a/test/testfiles/create/subnet-with-gateway.json
+++ b/test/testfiles/create/subnet-with-gateway.json
@@ -1,0 +1,26 @@
+{
+  "network": {
+    "name": "gwnet",
+    "id": "2234567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "subnets": [
+      {
+        "subnet": "10.100.0.0/24",
+        "gateway": "10.100.0.50"
+      }
+    ]
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/vlan-invalid.json
+++ b/test/testfiles/create/vlan-invalid.json
@@ -1,0 +1,23 @@
+{
+  "network": {
+    "name": "badvlan",
+    "id": "1334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "options": {
+      "vlan": "5000"
+    }
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}

--- a/test/testfiles/create/vlan-option.json
+++ b/test/testfiles/create/vlan-option.json
@@ -1,0 +1,23 @@
+{
+  "network": {
+    "name": "vlannet",
+    "id": "0334567890123456789012345678901234567890123456789012345678901234",
+    "driver": "bridge",
+    "dns_enabled": false,
+    "internal": false,
+    "ipv6_enabled": false,
+    "options": {
+      "vlan": "100"
+    }
+  },
+  "used": {
+    "interfaces": [],
+    "names": {},
+    "subnets": []
+  },
+  "options": {
+    "subnet_pools": [{"base": "10.89.0.0/16", "size": 24}],
+    "default_interface_name": "podman",
+    "check_used_subnets": false
+  }
+}


### PR DESCRIPTION
Asked Claude to adapt missing tests from container-libs/common/libnetwork/netavark/create.go for more test coverage. In the process, it found two differences in validation, so now we validate subnet overlap and auto-detect ipv6 networks. 