### PR TITLE
macvlan: use a default metric of 99

### DIFF
--- a/src/network/vlan.rs
+++ b/src/network/vlan.rs
@@ -100,7 +100,9 @@ impl driver::NetworkDriver for Vlan<'_> {
 
         let mode: Option<String> = opts.mode.clone();
         let mtu = opts.mtu.unwrap_or(0);
-        let metric = opts.metric.unwrap_or(100);
+        // use lower than default (100) metric for macvlan
+        // https://github.com/containers/podman/issues/23984
+        let metric = opts.metric.unwrap_or(99);
         let no_default_route: bool = opts.no_default_route.unwrap_or(false);
         let bclim = opts.bclim;
 

--- a/test/300-macvlan.bats
+++ b/test/300-macvlan.bats
@@ -34,6 +34,11 @@ function setup() {
     assert "$output" "=~" "default via 10.88.0.1" "gateway must be there in default route"
     assert_json "$result" ".podman.interfaces.eth0.subnets[0].gateway" == "10.88.0.1" "Result contains gateway address"
 
+    run_in_container_netns ip -j route list match 0.0.0.0
+    default_route="$output"
+    assert_json "$default_route" '.[0].dst' == "default" "Default route was selected"
+    assert_json "$default_route" '.[0].metric' == "99" "Default macvlan metric was chosen"
+
     run_in_container_netns cat /proc/sys/net/ipv6/conf/eth0/autoconf
     assert "0" "autoconf is disabled"
 


### PR DESCRIPTION
Having the same default metric of 100 for bridge and macvlan is confusing when a container is joined to two networks due the round robin routing.

Now this does not fix the problem when we have two macvlan networks but at least prevents weird routing via macvlan and bridge at the same time and this fix seems easy enough to do now.

Fixes: containers/podman#23984