### PR TITLE
Added a "set_link_ns_pid" in netlink_route.rs

### DIFF
--- a/src/network/netlink_route.rs
+++ b/src/network/netlink_route.rs
@@ -151,6 +151,16 @@ impl Socket<NetlinkRoute> {
         Ok(())
     }
 
+    pub fn set_link_ns_pid(&mut self, link_id: u32, pid: u32) -> NetavarkResult<()> {
+        let mut msg = LinkMessage::default();
+        msg.header.index = link_id;
+        msg.attributes.push(LinkAttribute::NetNsPid(pid));
+
+        let result = self.make_netlink_request(RouteNetlinkMessage::SetLink(msg), NLM_F_ACK)?;
+        expect_netlink_result!(result, 0);
+        Ok(())
+    }
+
     pub fn set_link_ns<Fd: AsFd>(&mut self, link_id: u32, netns: Fd) -> NetavarkResult<()> {
         let mut msg = LinkMessage::default();
         msg.header.index = link_id;


### PR DESCRIPTION
Added a "set_link_ns_pid" function in netlink_route to expose the corresponding way to change the network namespace by a pid. The file descriptor option already exists in the code. I'm working on implementing a network plugin and noticed that this option isn't currently exposed through the netavark netlink internals. The change is quite small and straightforward and open to whatever changes you think are best, thanks ! 