### PR TITLE
docs: document minimum Linux kernel version (4.20+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Netavark is a tool for configuring networking for Linux containers. Its features
 - [Podman](https://podman.io/docs) 4.0+
 - [protoc](https://grpc.io/docs/protoc-installation/)
 
+At runtime, Netavark supports Linux kernel 4.20 or newer. Netavark relies on
+`NETLINK_GET_STRICT_CHK` strict netlink checking, which is unavailable on older
+kernels. Running on older kernels can result in a netlink `Protocol not
+available` (EPROTONOSUPPORT) error.
+
 ## MSRV (Minimum Supported Rust Version)
 
 v1.88


### PR DESCRIPTION
## Summary

Documents netavark's minimum runtime kernel requirement (Linux 4.20+) in the README.

## Why this matters

A user hit `EPROTONOSUPPORT` at runtime and bisected it to `NETLINK_GET_STRICT_CHK`, which requires Linux 4.20+ (#1433). Maintainer @Luap99 agreed that documenting the 4.20+ minimum is the right resolution. This adds that note to the README so users on older kernels understand the requirement instead of hitting an opaque error.

## Testing

Documentation only.

Closes #1433
