### PR TITLE
update sha2 to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,11 +288,11 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -406,6 +412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,9 +425,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -428,12 +440,11 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -483,11 +494,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -723,16 +735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +840,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1094,6 +1105,7 @@ name = "netavark"
 version = "2.0.0-dev"
 dependencies = [
  "anyhow",
+ "base16ct",
  "chrono",
  "clap",
  "env_logger",
@@ -1707,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2077,9 +2089,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -2120,12 +2132,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,8 @@ serde_json = "1.0.146"
 zbus = { version = "5.13.1" }
 nix = { version = "0.30.1", features = ["net", "sched", "signal", "socket", "user"] }
 rand = "0.9.2"
-sha2 = "0.10.9"
+sha2 = "0.11.0"
+base16ct = "1.0.0"
 netlink-packet-route = "0.30.0"
 netlink-packet-core = "0.8.1"
 netlink-sys = "0.8.8"

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -1,6 +1,7 @@
 use crate::error::{ErrorWrap, NetavarkError, NetavarkResult};
 use crate::network::{constants, internal_types, types};
 use crate::wrap;
+use base16ct::HexDisplay;
 use ipnet::IpNet;
 use netlink_packet_route::link::{IpVlanMode, LinkMessage, MacVlanMode};
 use netlink_packet_route::route::RouteType;
@@ -283,12 +284,11 @@ impl CoreUtils {
     }
 
     pub fn create_network_hash(network_name: &str, length: usize) -> String {
-        let mut hasher = Sha512::new();
-        hasher.update(network_name.as_bytes());
-        let result = hasher.finalize();
-        let hash_string = format!("{result:X}");
-        let response = &hash_string[0..length];
-        response.to_string()
+        let sha = Sha512::digest(network_name.as_bytes());
+        let display = HexDisplay(&sha);
+        let mut hash_string = format!("{display:X}");
+        hash_string.truncate(length);
+        hash_string
     }
 }
 

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -652,4 +652,12 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_create_network_hash() {
+        let hex = CoreUtils::create_network_hash("testnet", 13);
+        assert_eq!(hex, "C5964C6794A11");
+        let hex = CoreUtils::create_network_hash("net1", 20);
+        assert_eq!(hex, "8E48F37D5DE60467E164");
+    }
 }

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -87,137 +87,6 @@ pub fn validate_subnets(subnets: &Option<Vec<types::Subnet>>) -> NetavarkResult<
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    struct TestCase {
-        name: &'static str,
-        subnets: Option<Vec<(&'static str, &'static str)>>,
-        should_pass: bool,
-        expected_error: Option<&'static str>,
-    }
-
-    #[test]
-    fn test_validate_subnets() {
-        let test_cases = vec![
-            TestCase {
-                name: "empty subnets",
-                subnets: None,
-                should_pass: true,
-                expected_error: None,
-            },
-            TestCase {
-                name: "single subnet",
-                subnets: Some(vec![("10.0.0.0/24", "10.0.0.1")]),
-                should_pass: true,
-                expected_error: None,
-            },
-            TestCase {
-                name: "two non-overlapping subnets",
-                subnets: Some(vec![
-                    ("10.0.0.0/24", "10.0.0.1"),
-                    ("10.0.1.0/24", "10.0.1.1"),
-                ]),
-                should_pass: true,
-                expected_error: None,
-            },
-            TestCase {
-                name: "ipv4 and ipv6 subnets",
-                subnets: Some(vec![("10.0.0.0/24", "10.0.0.1"), ("fd00::/64", "fd00::1")]),
-                should_pass: true,
-                expected_error: None,
-            },
-            TestCase {
-                name: "duplicate subnets",
-                subnets: Some(vec![
-                    ("10.0.0.0/24", "10.0.0.1"),
-                    ("10.0.0.0/24", "10.0.0.1"),
-                ]),
-                should_pass: false,
-                expected_error: Some("duplicate subnet"),
-            },
-            TestCase {
-                name: "overlapping subnets",
-                subnets: Some(vec![
-                    ("10.0.0.0/16", "10.0.0.1"),
-                    ("10.0.1.0/24", "10.0.1.1"),
-                ]),
-                should_pass: false,
-                expected_error: Some("overlapping subnets"),
-            },
-            TestCase {
-                name: "ipv6 overlapping subnets",
-                subnets: Some(vec![
-                    ("fd00::/48", "fd00::1"),
-                    ("fd00:0:0:1::/64", "fd00:0:0:1::1"),
-                ]),
-                should_pass: false,
-                expected_error: Some("overlapping subnets"),
-            },
-            TestCase {
-                name: "ipv6 duplicate subnets",
-                subnets: Some(vec![("fd00::/48", "fd00::1"), ("fd00::/48", "fd00::1")]),
-                should_pass: false,
-                expected_error: Some("duplicate subnet"),
-            },
-            TestCase {
-                name: "single ipv6 subnet",
-                subnets: Some(vec![("fd00::/48", "fd00::1")]),
-                should_pass: true,
-                expected_error: None,
-            },
-            TestCase {
-                name: "two non-overlapping ipv6 subnets",
-                subnets: Some(vec![
-                    ("fd00:0:0:1::/64", "fd00:0:0:1::1"),
-                    ("fd00:0:0:2::/64", "fd00:0:0:2::1"),
-                ]),
-                should_pass: true,
-                expected_error: None,
-            },
-        ];
-
-        for tc in test_cases {
-            let subnets: Option<Vec<_>> = tc.subnets.as_ref().map(|subnet_strs| {
-                subnet_strs
-                    .iter()
-                    .map(|(subnet_str, gw_str)| types::Subnet {
-                        subnet: subnet_str.parse().unwrap(),
-                        gateway: Some(gw_str.parse().unwrap()),
-                        lease_range: None,
-                    })
-                    .collect()
-            });
-
-            let result = validate_subnets(&subnets);
-
-            if tc.should_pass {
-                assert!(
-                    result.is_ok(),
-                    "Test case '{}' should pass but failed with: {:?}",
-                    tc.name,
-                    result.err()
-                );
-            } else {
-                assert!(
-                    result.is_err(),
-                    "Test case '{}' should fail but passed",
-                    tc.name
-                );
-                if let Some(expected_msg) = tc.expected_error {
-                    assert!(
-                        result.unwrap_err().to_string().contains(expected_msg),
-                        "Test case '{}' error message doesn't contain '{}'",
-                        tc.name,
-                        expected_msg
-                    );
-                }
-            }
-        }
-    }
-}
-
 pub fn get_ipam_addresses<'a>(
     per_network_opts: &'a types::PerNetworkOptions,
     network: &'a types::Network,
@@ -652,4 +521,135 @@ pub fn get_mtu_from_iface_attributes(attributes: &[LinkAttribute]) -> NetavarkRe
     Err(NetavarkError::msg(
         "no MTU attribute in netlink message, possible kernel issue",
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestCase {
+        name: &'static str,
+        subnets: Option<Vec<(&'static str, &'static str)>>,
+        should_pass: bool,
+        expected_error: Option<&'static str>,
+    }
+
+    #[test]
+    fn test_validate_subnets() {
+        let test_cases = vec![
+            TestCase {
+                name: "empty subnets",
+                subnets: None,
+                should_pass: true,
+                expected_error: None,
+            },
+            TestCase {
+                name: "single subnet",
+                subnets: Some(vec![("10.0.0.0/24", "10.0.0.1")]),
+                should_pass: true,
+                expected_error: None,
+            },
+            TestCase {
+                name: "two non-overlapping subnets",
+                subnets: Some(vec![
+                    ("10.0.0.0/24", "10.0.0.1"),
+                    ("10.0.1.0/24", "10.0.1.1"),
+                ]),
+                should_pass: true,
+                expected_error: None,
+            },
+            TestCase {
+                name: "ipv4 and ipv6 subnets",
+                subnets: Some(vec![("10.0.0.0/24", "10.0.0.1"), ("fd00::/64", "fd00::1")]),
+                should_pass: true,
+                expected_error: None,
+            },
+            TestCase {
+                name: "duplicate subnets",
+                subnets: Some(vec![
+                    ("10.0.0.0/24", "10.0.0.1"),
+                    ("10.0.0.0/24", "10.0.0.1"),
+                ]),
+                should_pass: false,
+                expected_error: Some("duplicate subnet"),
+            },
+            TestCase {
+                name: "overlapping subnets",
+                subnets: Some(vec![
+                    ("10.0.0.0/16", "10.0.0.1"),
+                    ("10.0.1.0/24", "10.0.1.1"),
+                ]),
+                should_pass: false,
+                expected_error: Some("overlapping subnets"),
+            },
+            TestCase {
+                name: "ipv6 overlapping subnets",
+                subnets: Some(vec![
+                    ("fd00::/48", "fd00::1"),
+                    ("fd00:0:0:1::/64", "fd00:0:0:1::1"),
+                ]),
+                should_pass: false,
+                expected_error: Some("overlapping subnets"),
+            },
+            TestCase {
+                name: "ipv6 duplicate subnets",
+                subnets: Some(vec![("fd00::/48", "fd00::1"), ("fd00::/48", "fd00::1")]),
+                should_pass: false,
+                expected_error: Some("duplicate subnet"),
+            },
+            TestCase {
+                name: "single ipv6 subnet",
+                subnets: Some(vec![("fd00::/48", "fd00::1")]),
+                should_pass: true,
+                expected_error: None,
+            },
+            TestCase {
+                name: "two non-overlapping ipv6 subnets",
+                subnets: Some(vec![
+                    ("fd00:0:0:1::/64", "fd00:0:0:1::1"),
+                    ("fd00:0:0:2::/64", "fd00:0:0:2::1"),
+                ]),
+                should_pass: true,
+                expected_error: None,
+            },
+        ];
+
+        for tc in test_cases {
+            let subnets: Option<Vec<_>> = tc.subnets.as_ref().map(|subnet_strs| {
+                subnet_strs
+                    .iter()
+                    .map(|(subnet_str, gw_str)| types::Subnet {
+                        subnet: subnet_str.parse().unwrap(),
+                        gateway: Some(gw_str.parse().unwrap()),
+                        lease_range: None,
+                    })
+                    .collect()
+            });
+
+            let result = validate_subnets(&subnets);
+
+            if tc.should_pass {
+                assert!(
+                    result.is_ok(),
+                    "Test case '{}' should pass but failed with: {:?}",
+                    tc.name,
+                    result.err()
+                );
+            } else {
+                assert!(
+                    result.is_err(),
+                    "Test case '{}' should fail but passed",
+                    tc.name
+                );
+                if let Some(expected_msg) = tc.expected_error {
+                    assert!(
+                        result.unwrap_err().to_string().contains(expected_msg),
+                        "Test case '{}' error message doesn't contain '{}'",
+                        tc.name,
+                        expected_msg
+                    );
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
The update removed the default UpperHex implementation from the returned
type so we now need to explicitly import another crate to give a type
that implements the conversion.

base16ct seems to be recommended by the RustCrypto maintainers, see
https://github.com/RustCrypto/hashes/issues/185#issuecomment-4313220182

Also while at it rework the code a bit to use Sha512::digest() directly
and truncate the string in place with truncate() do not need a second
copy.