### PR TITLE
rpm: drop unused protobuf-c dependency

### DIFF
--- a/rpm/netavark.spec
+++ b/rpm/netavark.spec
@@ -48,7 +48,6 @@ Requires: aardvark-dns >=  %{epoch}:%{major_minor}
 Provides: container-network-stack = 2
 Requires: nftables
 BuildRequires: make
-BuildRequires: protobuf-c
 BuildRequires: protobuf-compiler
 %if %{defined rhel}
 # rust-toolset requires the `local` repo enabled on non-koji ELN build environments

--- a/test/tmt/main.fmf
+++ b/test/tmt/main.fmf
@@ -6,7 +6,6 @@
         - clippy
         - go-md2man
         - make
-        - protobuf-c
         - protobuf-compiler
         - rustfmt
     adjust:
@@ -19,7 +18,6 @@
     require:
         - cargo
         - make
-        - protobuf-c
         - protobuf-compiler
     adjust:
         enabled: false


### PR DESCRIPTION
protobuf-c is just a library; the intention was probably the protoc binary,
which is packaged as protobuf-compiler.
