### PR TITLE
Add dns_names field

### DIFF
--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -280,18 +280,30 @@ impl driver::NetworkDriver for Bridge<'_> {
                 }
             }
 
-            // get size so we can preallocate the vector which is more efficient
-            let len = match &self.info.per_network_opts.aliases {
-                Some(n) => n.len() + 1,
-                None => 1,
-            };
-            let mut names = Vec::with_capacity(len);
-            maybe_add_alias(&mut names, self.info.container_name);
-            if let Some(aliases) = &self.info.per_network_opts.aliases {
-                for name in aliases {
-                    maybe_add_alias(&mut names, name);
+            // Prefer dns_names when present; fall back to container_name + aliases.
+            let names = match &self.info.per_network_opts.dns_names {
+                Some(dns_names) if !dns_names.is_empty() => {
+                    let mut names = Vec::with_capacity(dns_names.len());
+                    for name in dns_names {
+                        maybe_add_alias(&mut names, name);
+                    }
+                    names
                 }
-            }
+                _ => {
+                    let len = match &self.info.per_network_opts.aliases {
+                        Some(n) => n.len() + 1,
+                        None => 1,
+                    };
+                    let mut names = Vec::with_capacity(len);
+                    maybe_add_alias(&mut names, self.info.container_name);
+                    if let Some(aliases) = &self.info.per_network_opts.aliases {
+                        for name in aliases {
+                            maybe_add_alias(&mut names, name);
+                        }
+                    }
+                    names
+                }
+            };
 
             // Fixes #1177: In unmanaged mode, the gateway IP may not be on the host.
             // We need to find an IP on the bridge itself for aardvark-dns to bind to.

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -165,6 +165,13 @@ pub struct PerNetworkOptions {
     #[serde(rename = "aliases")]
     pub aliases: Option<Vec<String>>,
 
+    /// DNSNames contains the complete list of DNS names that should resolve
+    /// to this container, including container name, user aliases, short ID,
+    /// and hostname. When set, this takes priority over aliases for DNS
+    /// resolution. When empty or not set, falls back to aliases.
+    #[serde(rename = "dns_names")]
+    pub dns_names: Option<Vec<String>>,
+
     /// InterfaceName for this container. Required.
     #[serde(rename = "interface_name")]
     pub interface_name: String,

--- a/test/250-bridge-nftables.bats
+++ b/test/250-bridge-nftables.bats
@@ -1331,6 +1331,17 @@ function check_simple_bridge_nftables() {
     assert "${lines[1]}" =~ ".*aardvark-dns --config $NETAVARK_TMPDIR/config/aardvark-dns -p 53 run" "aardvark not running or bad options"
 }
 
+@test "$fw_driver - dns_names preferred over aliases" {
+    run_netavark --file ${TESTSDIR}/testfiles/dns-names.json \
+        setup $(get_container_netns_path)
+
+    # check aardvark config uses dns_names (somename,myalias,f031bf33eecb,myhostname)
+    # instead of falling back to container_name + aliases (somename,myalias)
+    run_helper cat "$NETAVARK_TMPDIR/config/aardvark-dns/podman1"
+    assert "${lines[1]}" =~ "^[0-9a-f]{64} 10.89.3.2  somename,myalias,f031bf33eecb,myhostname$" "aardvark config uses dns_names"
+    assert "${#lines[@]}" = 2 "too many lines in aardvark config"
+}
+
 @test "$fw_driver - nft error" {
     local nft="$NETAVARK_TMPDIR/nft"
     cat > "$nft" <<EOF

--- a/test/testfiles/dns-names.json
+++ b/test/testfiles/dns-names.json
@@ -1,0 +1,41 @@
+{
+  "container_id": "f031bf33eecba75d0d84952337b1ceef6a239eb8e94b48aee0993d0791345325",
+  "container_name": "somename",
+  "networks": {
+    "podman1": {
+      "static_ips": [
+        "10.89.3.2"
+      ],
+      "aliases": [
+        "myalias"
+      ],
+      "dns_names": [
+        "somename",
+        "myalias",
+        "f031bf33eecb",
+        "myhostname"
+      ],
+      "interface_name": "eth0"
+    }
+  },
+  "network_info": {
+    "podman1": {
+      "name": "podman1",
+      "id": "ec79dd0cad82083c8ac5cc23e9542e4ddea813dff60d68258d36e84f6393b63b",
+      "driver": "bridge",
+      "network_interface": "podman1",
+      "subnets": [
+        {
+          "subnet": "10.89.3.0/24",
+          "gateway": "10.89.3.1"
+        }
+      ],
+      "ipv6_enabled": false,
+      "internal": false,
+      "dns_enabled": true,
+      "ipam_options": {
+        "driver": "host-local"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Alias now contains user-set aliases only. dns_names should contain the complete set of names. Use values from both for temp backwards compat.