### PR TITLE
fix new lint warnings in 1.97

### DIFF
--- a/src/commands/dhcp_proxy.rs
+++ b/src/commands/dhcp_proxy.rs
@@ -177,7 +177,7 @@ impl<W: Write + Clear + Send + 'static> NetavarkProxy for NetavarkProxyService<W
             if let Err(e) = service.release_lease().await {
                 warn!(
                     "Failed to send DHCPRELEASE for {}: {}",
-                    &nc.container_mac_addr, e
+                    nc.container_mac_addr, e
                 );
             }
         }
@@ -256,7 +256,7 @@ pub async fn serve(opts: Opts) -> NetavarkResult<()> {
         Duration::from_secs(opts.activity_timeout.unwrap_or(DEFAULT_INACTIVITY_TIMEOUT));
 
     let uds_path = get_proxy_sock_fqname(optional_run_dir);
-    debug!("socket path: {}", &uds_path.display());
+    debug!("socket path: {}", uds_path.display());
 
     let mut is_systemd_activated = false;
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -74,7 +74,7 @@ impl Setup {
                 .ok_or_else(|| {
                     NetavarkError::Message(format!(
                         "network info for network {} not found",
-                        &named_network_opts.name
+                        named_network_opts.name
                     ))
                 })?;
 
@@ -155,7 +155,7 @@ impl Setup {
             } else {
                 info!(
                     "dns disabled because aardvark-dns path {:?} does not exists",
-                    &aardvark_bin
+                    aardvark_bin
                 );
             }
         }

--- a/src/commands/teardown.rs
+++ b/src/commands/teardown.rs
@@ -102,7 +102,7 @@ impl Teardown {
                 None => {
                     error_list.push(NetavarkError::Message(format!(
                         "network info for network {} not found",
-                        &named_network_opts.name
+                        named_network_opts.name
                     )));
                     continue;
                 }

--- a/src/dhcp_proxy/dhcp_service.rs
+++ b/src/dhcp_proxy/dhcp_service.rs
@@ -121,7 +121,7 @@ impl DhcpV4Service {
                     netavark_lease.add_mac_address(&self.network_config.container_mac_addr);
                     debug!(
                         "found a lease for {:?}, {:?}",
-                        &self.network_config.container_mac_addr, &netavark_lease
+                        self.network_config.container_mac_addr, netavark_lease
                     );
                     self.previous_lease = Some(*lease);
                     return Ok(netavark_lease);
@@ -158,7 +158,7 @@ impl DhcpV4Service {
         if let Some(lease) = &self.previous_lease {
             debug!(
                 "Attempting to release lease for MAC: {}",
-                &self.network_config.container_mac_addr
+                self.network_config.container_mac_addr
             );
             // Directly call the release function on the underlying mozim
             // client.
@@ -171,7 +171,7 @@ impl DhcpV4Service {
             // succeed silently.
             debug!(
                 "No previous lease to release for MAC: {}",
-                &self.network_config.container_mac_addr
+                self.network_config.container_mac_addr
             );
             Ok(())
         }
@@ -204,8 +204,8 @@ pub async fn process_client_stream(service_arc: Arc<Mutex<DhcpV4Service>>) {
             Ok(DhcpV4State::Done(lease)) => {
                 log::info!(
                     "got new lease for mac {}: {:?}",
-                    &client.network_config.container_mac_addr,
-                    &lease
+                    client.network_config.container_mac_addr,
+                    lease
                 );
 
                 if let Some(old_lease) = &client.previous_lease {
@@ -215,7 +215,7 @@ pub async fn process_client_stream(service_arc: Arc<Mutex<DhcpV4Service>>) {
                     {
                         log::info!(
                             "ip or gateway for mac {} changed, update address",
-                            &client.network_config.container_mac_addr
+                            client.network_config.container_mac_addr
                         );
                         if let Err(err) = update_lease_ip(
                             &client.network_config.ns_path,
@@ -239,11 +239,11 @@ pub async fn process_client_stream(service_arc: Arc<Mutex<DhcpV4Service>>) {
             Err(err) => {
                 log::error!(
                     "Failed to acquire DHCPv4 lease for {}: {err}",
-                    &client.network_config.container_mac_addr
+                    client.network_config.container_mac_addr
                 );
                 log::info!(
                     "Retrying DHCPv4 proxy for {}",
-                    &client.network_config.container_mac_addr
+                    client.network_config.container_mac_addr
                 );
                 client.client.clean_up();
             }

--- a/src/dhcp_proxy/lib.rs
+++ b/src/dhcp_proxy/lib.rs
@@ -184,7 +184,7 @@ impl NetworkConfig {
         // We know this is safe and if it ever fails test will catch it
         let endpoint = Endpoint::try_from("http://[::1]").unwrap();
 
-        debug!("using uds path: {}", &p);
+        debug!("using uds path: {}", p);
         let path = p.clone();
         let channel = endpoint
             .connect_with_connector(service_fn(move |_| {
@@ -202,7 +202,7 @@ impl NetworkConfig {
                             .and_then(|e| e.downcast_ref::<std::io::Error>())
                             .and_then(|e| {
                                 if e.kind() == std::io::ErrorKind::NotFound || e.kind() == std::io::ErrorKind::ConnectionRefused {
-                                    Some(format!("socket \"{}\": {e}, is the netavark-dhcp-proxy.socket unit enabled?", &path))
+                                    Some(format!("socket \"{}\": {e}, is the netavark-dhcp-proxy.socket unit enabled?", path))
                                 } else {
                                     None
                                 }
@@ -288,9 +288,9 @@ impl VectorConv for Vec<String> {
         }
         let mut out_addrs = Vec::new();
         for ip in self {
-            match Ipv4Addr::from_str(ip) {
-                Ok(i) => out_addrs.push(i),
-                Err(e) => return Err(e),
+            {
+                let i = Ipv4Addr::from_str(ip)?;
+                out_addrs.push(i)
             };
         }
         Ok(Some(out_addrs))

--- a/src/dns/aardvark.rs
+++ b/src/dns/aardvark.rs
@@ -249,7 +249,7 @@ impl Aardvark {
             Err(e) => {
                 return Err(NetavarkError::msg(format!(
                     "Failed to open/create lockfile {:?}: {}",
-                    &lockfile_path, e
+                    lockfile_path, e
                 )));
             }
         };

--- a/src/firewall/state.rs
+++ b/src/firewall/state.rs
@@ -152,7 +152,7 @@ pub fn write_fw_config(
         Err(ref e) if e.kind() == ErrorKind::AlreadyExists => (),
         Err(e) => {
             return Err(NetavarkError::wrap(
-                format!("create network config {:?}", &paths.net_conf_file.display()),
+                format!("create network config {:?}", paths.net_conf_file.display()),
                 e.into(),
             ));
         }

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -344,7 +344,7 @@ impl driver::NetworkDriver for Bridge<'_> {
                     is_internal: self.info.network.internal,
                 }),
                 Err(err) => {
-                    log::warn!("invalid container id {}: {err}", &self.info.container_id);
+                    log::warn!("invalid container id {}: {err}", self.info.container_id);
                     None
                 }
             }
@@ -739,9 +739,9 @@ fn create_interfaces(
                     // Disable duplicate address detection if ipv6 enabled
                     // Do not accept Router Advertisements if ipv6 is enabled
                     let br_accept_dad =
-                        format!("net/ipv6/conf/{}/accept_dad", &data.bridge_interface_name);
+                        format!("net/ipv6/conf/{}/accept_dad", data.bridge_interface_name);
                     let br_accept_ra =
-                        format!("net/ipv6/conf/{}/accept_ra", &data.bridge_interface_name);
+                        format!("net/ipv6/conf/{}/accept_ra", data.bridge_interface_name);
                     sysctls.push((br_accept_dad, "0"));
                     sysctls.push((br_accept_ra, "0"));
                 }
@@ -752,7 +752,7 @@ fn create_interfaces(
                 // As documented for the sysctl for complicated or asymmetric routing loose mode (2)
                 // is recommended.
                 let br_rp_filter =
-                    format!("net/ipv4/conf/{}/rp_filter", &data.bridge_interface_name);
+                    format!("net/ipv4/conf/{}/rp_filter", data.bridge_interface_name);
                 sysctls.push((br_rp_filter, "2"));
 
                 // writer must be create before the bridge is created
@@ -931,20 +931,16 @@ fn create_veth_pair<'fd>(
             disable_ipv6_autoconf(&data.container_interface_name)?;
             if data.ipam.ipv6_enabled {
                 //  Disable dad inside the container too
-                let disable_dad_in_container = format!(
-                    "net/ipv6/conf/{}/accept_dad",
-                    &data.container_interface_name
-                );
+                let disable_dad_in_container =
+                    format!("net/ipv6/conf/{}/accept_dad", data.container_interface_name);
                 sysctl::apply_sysctl_value(disable_dad_in_container, "0")?;
             }
-            let enable_arp_notify = format!(
-                "net/ipv4/conf/{}/arp_notify",
-                &data.container_interface_name
-            );
+            let enable_arp_notify =
+                format!("net/ipv4/conf/{}/arp_notify", data.container_interface_name);
             sysctl::apply_sysctl_value(enable_arp_notify, "1")?;
 
             // disable strict reverse path search validation
-            let rp_filter = format!("net/ipv4/conf/{}/rp_filter", &data.container_interface_name);
+            let rp_filter = format!("net/ipv4/conf/{}/rp_filter", data.container_interface_name);
             sysctl::apply_sysctl_value(rp_filter, "2")?;
             Ok::<(), NetavarkError>(())
         })?;

--- a/src/network/core_utils.rs
+++ b/src/network/core_utils.rs
@@ -388,7 +388,7 @@ pub fn add_default_routes(
             }
         };
         sock.add_route(&route)
-            .wrap(format!("add default route {}", &route))?;
+            .wrap(format!("add default route {}", route))?;
     }
     Ok(())
 }

--- a/src/network/create_config/validation.rs
+++ b/src/network/create_config/validation.rs
@@ -256,7 +256,7 @@ pub fn validate_subnet(
         if !s.subnet.contains(gateway) {
             return Err(NetavarkError::msg(format!(
                 "gateway {} not in subnet {}",
-                gateway, &s.subnet
+                gateway, s.subnet
             )));
         }
     } else if add_gateway {

--- a/src/network/dhcp.rs
+++ b/src/network/dhcp.rs
@@ -171,7 +171,7 @@ pub fn dhcp_teardown(info: &DriverInfo, sock: &mut Socket<NetlinkRoute>) -> Neta
     if ipam.dhcp_enabled {
         let dev = sock.get_link(LinkID::Name(if_name)).wrap(format!(
             "get container interface {}",
-            &info.per_network_opts.interface_name
+            info.per_network_opts.interface_name
         ))?;
 
         let container_mac_address = core_utils::get_mac_address(dev.attributes)?;

--- a/src/network/plugin.rs
+++ b/src/network/plugin.rs
@@ -109,7 +109,7 @@ impl NetworkDriver for PluginDriver<'_> {
     ) -> NetavarkResult<(types::StatusBlock, Option<AardvarkEntry<'_>>)> {
         let result = self.exec_plugin(true, self.info.netns_path).wrap(format!(
             "plugin {:?} failed",
-            &self.path.file_name().unwrap_or_default()
+            self.path.file_name().unwrap_or_default()
         ))?;
         // The unwrap should be safe, only if the exec_plugin has a bug this
         // could fail, in which case the test should catch it.
@@ -122,7 +122,7 @@ impl NetworkDriver for PluginDriver<'_> {
     ) -> NetavarkResult<()> {
         self.exec_plugin(false, self.info.netns_path).wrap(format!(
             "plugin {:?} failed",
-            &self.path.file_name().unwrap_or_default()
+            self.path.file_name().unwrap_or_default()
         ))?;
         Ok(())
     }


### PR DESCRIPTION
Mainly the new useless_borrows_in_formatting lint.

https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting