### PR TITLE
allow published ports to be accessed by isolated networks

### DIFF
--- a/src/firewall/nft.rs
+++ b/src/firewall/nft.rs
@@ -29,9 +29,12 @@ const ISOLATION1CHAIN: &str = "NETAVARK-ISOLATION-1";
 const ISOLATION2CHAIN: &str = "NETAVARK-ISOLATION-2";
 const ISOLATION3CHAIN: &str = "NETAVARK-ISOLATION-3";
 
+const CT_MARK_NAME: Cow<'_, str> = Cow::Borrowed("mark");
+
 pub(crate) const MAX_HASH_SIZE: usize = 13;
 
-const MASK: u32 = 0x2000;
+const MASQUERADE_MASK: u32 = 0x2000;
+const DNAT_MASK: u32 = 0x1000;
 
 const MULTICAST_NET_V4: &str = "224.0.0.0/4";
 const MULTICAST_NET_V6: &str = "ff00::/8";
@@ -118,13 +121,13 @@ impl firewall::FirewallDriver for Nftables {
 
         // Postrouting chain needs a single rule to masquerade if mask is set.
         // But only one copy of that rule. So check if such a rule exists.
-        let match_meta_masq = |r: &schema::Rule| -> bool {
+        let match_masquerade_masq = |r: &schema::Rule| -> bool {
             // Match on any rule that matches against 0x2000
             for statement in r.expr.deref() {
                 match statement {
                     stmt::Statement::Match(m) => match &m.right {
                         expr::Expression::Number(n) => {
-                            if *n == MASK {
+                            if *n == MASQUERADE_MASK {
                                 return true;
                             }
                         }
@@ -135,7 +138,7 @@ impl firewall::FirewallDriver for Nftables {
             }
             false
         };
-        if get_matching_rules_in_chain(&existing_rules, POSTROUTINGCHAIN, match_meta_masq)
+        if get_matching_rules_in_chain(&existing_rules, POSTROUTINGCHAIN, match_masquerade_masq)
             .is_empty()
         {
             // Postrouting: meta mark & 0x2000 == 0x2000 masquerade
@@ -148,10 +151,10 @@ impl firewall::FirewallDriver for Nftables {
                                 expr::Expression::Named(expr::NamedExpression::Meta(expr::Meta {
                                     key: expr::MetaKey::Mark,
                                 })),
-                                expr::Expression::Number(MASK),
+                                expr::Expression::Number(MASQUERADE_MASK),
                             ),
                         )),
-                        right: expr::Expression::Number(MASK),
+                        right: expr::Expression::Number(MASQUERADE_MASK),
                         op: stmt::Operator::EQ,
                     }),
                     stmt::Statement::Masquerade(None),
@@ -184,7 +187,7 @@ impl firewall::FirewallDriver for Nftables {
                             expr::Expression::Named(expr::NamedExpression::Meta(expr::Meta {
                                 key: expr::MetaKey::Mark,
                             })),
-                            expr::Expression::Number(MASK),
+                            expr::Expression::Number(MASQUERADE_MASK),
                         ],
                     ))),
                 })]),
@@ -248,6 +251,49 @@ impl firewall::FirewallDriver for Nftables {
                         op: stmt::Operator::IN,
                     }),
                     stmt::Statement::Drop(None),
+                ]),
+            ));
+        }
+
+        let match_dnat_mask = |r: &schema::Rule| -> bool {
+            // Match on any rule that matches against DNAT_MASK
+            for statement in r.expr.deref() {
+                match statement {
+                    stmt::Statement::Match(m) => match &m.right {
+                        expr::Expression::Number(n) => {
+                            if *n == DNAT_MASK {
+                                return true;
+                            }
+                        }
+                        _ => continue,
+                    },
+                    _ => continue,
+                }
+            }
+            false
+        };
+
+        if get_matching_rules_in_chain(&existing_rules, FORWARDCHAIN, match_dnat_mask).is_empty() {
+            // Ensure we allow the DNAT packets before we consult the isolation chains
+            // Forward: ct mark & 0x1000 == 0x1000 accept
+            batch.add(make_rule(
+                Cow::Borrowed(FORWARDCHAIN),
+                Cow::Owned(vec![
+                    stmt::Statement::Match(stmt::Match {
+                        left: expr::Expression::BinaryOperation(Box::new(
+                            expr::BinaryOperation::AND(
+                                expr::Expression::Named(expr::NamedExpression::CT(expr::CT {
+                                    key: CT_MARK_NAME,
+                                    family: None,
+                                    dir: None,
+                                })),
+                                expr::Expression::Number(DNAT_MASK),
+                            ),
+                        )),
+                        right: expr::Expression::Number(DNAT_MASK),
+                        op: stmt::Operator::EQ,
+                    }),
+                    stmt::Statement::Accept(None),
                 ]),
             ));
         }
@@ -1038,6 +1084,19 @@ fn get_dnat_port_rules<'a>(
             )),
             right: expr::Expression::Number(host_port),
             op: stmt::Operator::EQ,
+        }));
+        statements.push(stmt::Statement::Mangle(stmt::Mangle {
+            key: expr::Expression::Named(expr::NamedExpression::CT(expr::CT {
+                key: CT_MARK_NAME,
+                family: None,
+                dir: None,
+            })),
+            value: expr::Expression::BinaryOperation(Box::new(expr::BinaryOperation::OR(vec![
+                expr::Expression::Named(expr::NamedExpression::Meta(expr::Meta {
+                    key: expr::MetaKey::Mark,
+                })),
+                expr::Expression::Number(DNAT_MASK),
+            ]))),
         }));
         statements.push(stmt::Statement::DNAT(Some(stmt::NAT {
             addr: Some(expr::Expression::String(Cow::Owned(ip.to_string()))),

--- a/test/250-bridge-nftables.bats
+++ b/test/250-bridge-nftables.bats
@@ -80,7 +80,8 @@ export NETAVARK_FW=nftables
     # check FORWARD rules
     run_in_host_netns nft list chain inet netavark FORWARD
     assert "${lines[3]}" =~ "ct state invalid drop" "CT state invalid rule"
-    assert "${#lines[@]}" = 7 "too many FORWARD rules after teardown"
+    assert "${lines[4]}" =~ "ct mark & 0x00001000 == 0x00001000 accept" "accept dnat traffic"
+    assert "${#lines[@]}" = 8 "too many FORWARD rules after teardown"
 
     # check POSTROUTING rules
     run_in_host_netns nft list chain inet netavark POSTROUTING
@@ -744,7 +745,7 @@ EOF
 
     # check nftables FORWARD chain
     run_in_host_netns nft list chain inet netavark FORWARD
-    assert "${lines[4]}" =~ "jump NETAVARK-ISOLATION-1" "forward chain jumps to ISOLATION1"
+    assert "${lines[5]}" =~ "jump NETAVARK-ISOLATION-1" "forward chain jumps to ISOLATION1"
 
     # check nftables NETAVARK-ISOLATION-2 chain
     run_in_host_netns nft list chain inet netavark NETAVARK-ISOLATION-2
@@ -827,6 +828,21 @@ EOF
     expected_rc=1 run_in_container_netns 3 ping -w 1 -c 1 fd99::2
     # from network isolate4 to isolate3
     expected_rc=1 run_in_container_netns 3 ping -w 1 -c 1 fd92::2
+
+    # verify we can do port forwarding across isoalted networks
+    for proto in tcp udp sctp; do
+        if [[ "$proto" == "sctp" ]]; then
+            # if sctp is not aviable skip that protocol
+            modprobe sctp || continue
+        fi
+
+        data=$(random_string)
+        run_in_container_netns 1 $NETAVARK_CONNECTION_TESTER --$proto "$(get_container_netns_path 3)" "10.89.0.1:8080" 80 <<<"$data"
+        assert "${lines[1]}" == "Message: $data" "ipv4 ($proto) host port from isolate=true to isloate=strict"
+
+        run_in_container_netns 2 $NETAVARK_CONNECTION_TESTER --$proto "$(get_container_netns_path 3)" "[fd90::1]:8080" 80 <<<"$data"
+        assert "${lines[1]}" == "Message: $data" "ipv6 ($proto) host port from isolate=strict to isloate=strict"
+    done
 
     # create container/network without isolation
 
@@ -1026,10 +1042,10 @@ net/ipv4/conf/podman1/rp_filter = 2"
     # check FORWARD rules
     run_in_host_netns nft list chain inet netavark FORWARD
     assert "${lines[3]}" =~ "ct state invalid drop" "CT state invalid rule"
-    assert "${lines[4]}" =~ "jump NETAVARK-ISOLATION-1"
-    assert "${lines[5]}" =~ "ip daddr 10.88.0.0/16 ct state established,related accept" "Related,established rule"
-    assert "${lines[6]}" =~ "ip saddr 10.88.0.0/16 accept" "Subnet saddr accept rule"
-    assert "${#lines[@]}" = 9 "too many FORWARD rules"
+    assert "${lines[5]}" =~ "jump NETAVARK-ISOLATION-1"
+    assert "${lines[6]}" =~ "ip daddr 10.88.0.0/16 ct state established,related accept" "Related,established rule"
+    assert "${lines[7]}" =~ "ip saddr 10.88.0.0/16 accept" "Subnet saddr accept rule"
+    assert "${#lines[@]}" = 10 "too many FORWARD rules"
 
     run_netavark teardown $(get_container_netns_path 1) <<<"${configs[1]}"
     # bridge should be removed
@@ -1040,7 +1056,7 @@ net/ipv4/conf/podman1/rp_filter = 2"
 
     run_in_host_netns nft list chain inet netavark FORWARD
     assert "${lines[3]}" =~ "ct state invalid drop" "forward rule 1"
-    assert "${#lines[@]}" = 7 "too many NETAVARK_FORWARD rules"
+    assert "${#lines[@]}" = 8 "too many NETAVARK_FORWARD rules"
 
     run_in_host_netns ip -o link
     assert "${#lines[@]}" == 1 "only loopback adapter"
@@ -1230,7 +1246,7 @@ net/ipv4/conf/podman1/rp_filter = 2"
     # leak without this fix)
     run_in_host_netns nft list chain inet netavark nv_53ce4390_10_88_0_0_nm16
     run_in_host_netns nft list chain inet netavark FORWARD
-    assert "${#lines[@]}" = 9 "FORWARD rules should still exist before teardown"
+    assert "${#lines[@]}" = 10 "FORWARD rules should still exist before teardown"
     run_in_host_netns nft list chain inet netavark POSTROUTING
     assert "${#lines[@]}" = 7 "POSTROUTING rules should still exist before teardown"
     run_in_host_netns ip link show podman0
@@ -1250,7 +1266,7 @@ net/ipv4/conf/podman1/rp_filter = 2"
 
     # FORWARD rules should be back to baseline
     run_in_host_netns nft list chain inet netavark FORWARD
-    assert "${#lines[@]}" = 7 "too many FORWARD rules after teardown with missing netns"
+    assert "${#lines[@]}" = 8 "too many FORWARD rules after teardown with missing netns"
 
     # POSTROUTING rules should be back to baseline
     run_in_host_netns nft list chain inet netavark POSTROUTING
@@ -1277,10 +1293,11 @@ function check_simple_bridge_nftables() {
     # check FORWARD rules
     run_in_host_netns nft list chain inet netavark FORWARD
     assert "${lines[3]}" =~ "ct state invalid drop" "CT state invalid rule"
-    assert "${lines[4]}" =~ "jump NETAVARK-ISOLATION-1"
-    assert "${lines[5]}" =~ "ip daddr 10.88.0.0/16 ct state established,related accept" "Related,established rule"
-    assert "${lines[6]}" =~ "ip saddr 10.88.0.0/16 accept" "Subnet saddr accept rule"
-    assert "${#lines[@]}" = 9 "too many FORWARD rules"
+    assert "${lines[4]}" =~ "ct mark & 0x00001000 == 0x00001000 accept" "accept dnat traffic"
+    assert "${lines[5]}" =~ "jump NETAVARK-ISOLATION-1"
+    assert "${lines[6]}" =~ "ip daddr 10.88.0.0/16 ct state established,related accept" "Related,established rule"
+    assert "${lines[7]}" =~ "ip saddr 10.88.0.0/16 accept" "Subnet saddr accept rule"
+    assert "${#lines[@]}" = 10 "too many FORWARD rules"
 
     run_in_host_netns nft list chain inet netavark NETAVARK-ISOLATION-1
     assert "${lines[2]}" =~ "iifname \"podman0\" oifname != \"podman0\" jump NETAVARK-ISOLATION-3" "strict isolation as default chain"
@@ -1296,10 +1313,10 @@ function check_simple_bridge_nftables() {
     # extra check so we can be sure that these rules exists before checking later of they are removed
     assert "$output" =~ "ip saddr 10.88.0.0/16 ip daddr 192.168.188.25 tcp dport 8080 jump NETAVARK-HOSTPORT-SETMARK"
     assert "$output" =~ "ip saddr 127.0.0.1 ip daddr 192.168.188.25 tcp dport 8080 jump NETAVARK-HOSTPORT-SETMARK"
-    assert "$output" =~ "ip daddr 192.168.188.25 tcp dport 8080 dnat ip to 10.88.0.14:8080"
+    assert "$output" =~ "ip daddr 192.168.188.25 tcp dport 8080 ct mark set meta mark | 0x00001000 dnat ip to 10.88.0.14:8080"
     assert "$output" =~ "ip saddr 10.88.0.0/16 ip daddr 192.168.188.25 udp dport 8080 jump NETAVARK-HOSTPORT-SETMARK"
     assert "$output" =~ "ip saddr 127.0.0.1 ip daddr 192.168.188.25 udp dport 8080 jump NETAVARK-HOSTPORT-SETMARK"
-    assert "$output" =~ "ip daddr 192.168.188.25 udp dport 8080 dnat ip to 10.88.0.14:8080"
+    assert "$output" =~ "ip daddr 192.168.188.25 udp dport 8080 ct mark set meta mark | 0x00001000 dnat ip to 10.88.0.14:8080"
 
     run_netavark --file ${TESTSDIR}/testfiles/bridge-port-tcp-udp.json teardown $(get_container_netns_path)
 
@@ -1318,10 +1335,10 @@ function check_simple_bridge_nftables() {
     # extra check so we can be sure that these rules exists before checking later of they are removed
     assert "$output" =~ "ip saddr 10.88.0.0/16 ip daddr 192.168.188.25 tcp dport 8080 jump NETAVARK-HOSTPORT-SETMARK"
     assert "$output" =~ "ip saddr 127.0.0.1 ip daddr 192.168.188.25 tcp dport 8080 jump NETAVARK-HOSTPORT-SETMARK"
-    assert "$output" =~ "ip daddr 192.168.188.25 tcp dport 8080 dnat ip to 10.88.0.14:8080"
+    assert "$output" =~ "ip daddr 192.168.188.25 tcp dport 8080 ct mark set meta mark | 0x00001000 dnat ip to 10.88.0.14:8080"
     assert "$output" =~ "ip saddr 10.88.0.0/16 ip daddr 192.168.188.24 tcp dport 8080 jump NETAVARK-HOSTPORT-SETMARK"
     assert "$output" =~ "ip saddr 127.0.0.1 ip daddr 192.168.188.24 tcp dport 8080 jump NETAVARK-HOSTPORT-SETMARK"
-    assert "$output" =~ "ip daddr 192.168.188.24 tcp dport 8080 dnat ip to 10.88.0.14:8080"
+    assert "$output" =~ "ip daddr 192.168.188.24 tcp dport 8080 ct mark set meta mark | 0x00001000 dnat ip to 10.88.0.14:8080"
 
     run_netavark --file ${TESTSDIR}/testfiles/bridge-port-hostip.json teardown $(get_container_netns_path)
 

--- a/test/testfiles/isolate4.json
+++ b/test/testfiles/isolate4.json
@@ -1,6 +1,29 @@
 {
     "container_id": "01f0b94d5f4c1",
     "container_name": "isolatedcontainer1",
+    "port_mappings": [
+        {
+            "host_ip": "",
+            "container_port": 80,
+            "host_port": 8080,
+            "range": 1,
+            "protocol": "tcp"
+        },
+        {
+            "host_ip": "",
+            "container_port": 80,
+            "host_port": 8080,
+            "range": 1,
+            "protocol": "udp"
+        },
+        {
+            "host_ip": "",
+            "container_port": 80,
+            "host_port": 8080,
+            "range": 1,
+            "protocol": "sctp"
+        }
+    ],
     "networks": {
         "isolate4": {
             "interface_name": "eth4",


### PR DESCRIPTION
Currently the NETAVARK-ISOLATION-1 in FORWARDING drops all traffic from bridge A to B, however when bridge A reaches a port on the host that gets than forwarded to bridge B that also gets dropped. Isolate should only prevent direct connections. If the port is published on the host we should still allow that so services can be reached.

The main issue is that we need a way to accept only that traffic before it reaches the isolation chain. To do so we add a custom mark to the conntrack entry in the dnat hit. Knowing that mark we can then accept the traffic for these conntrack connections in forwarding before jumping into the isolation chains. So anything not going through the dnat rule will not be accepted.

Fixes: #709