### PR TITLE
fix: allow broadcast and multicast traffic to reach container via por…

### DIFF
--- a/src/firewall/nft.rs
+++ b/src/firewall/nft.rs
@@ -197,34 +197,27 @@ impl firewall::FirewallDriver for Nftables {
         // We need rules in Prerouting and Output pointing to our dnat chain.
         // But only if they do not exist.
         let match_jump_dnat = get_rule_matcher_jump_to(DNATCHAIN.to_string());
-        // Prerouting: fib daddr type local jump <dnat_chain>
-        // Output: fib daddr type local jump <dnat_chain>
+        // Prerouting: fib daddr type { local, broadcast, multicast } jump <dnat_chain>
+        // Output: fib daddr type { local, broadcast, multicast } jump <dnat_chain>
         let mut rules_hash: HashSet<expr::FibFlag> = HashSet::new();
         rules_hash.insert(expr::FibFlag::Daddr);
-        let base_conditions = [
-            stmt::Statement::Match(stmt::Match {
-                left: expr::Expression::Named(expr::NamedExpression::Fib(expr::Fib {
-                    result: expr::FibResult::Type,
-                    flags: rules_hash,
-                })),
-                right: expr::Expression::String(Cow::Borrowed("local")),
-                op: stmt::Operator::EQ,
-            }),
-            get_jump_action(Cow::Borrowed(DNATCHAIN)),
-        ];
-        if get_matching_rules_in_chain(&existing_rules, PREROUTINGCHAIN, &match_jump_dnat)
-            .is_empty()
-        {
-            batch.add(make_rule(
-                Cow::Borrowed(PREROUTINGCHAIN),
-                Cow::Borrowed(&base_conditions),
-            ));
-        }
-        if get_matching_rules_in_chain(&existing_rules, OUTPUTCHAIN, &match_jump_dnat).is_empty() {
-            batch.add(make_rule(
-                Cow::Borrowed(OUTPUTCHAIN),
-                Cow::Borrowed(&base_conditions),
-            ));
+        for chain in [PREROUTINGCHAIN, OUTPUTCHAIN] {
+            if get_matching_rules_in_chain(&existing_rules, chain, &match_jump_dnat).is_empty() {
+                for fib_type in ["local", "broadcast", "multicast"] {
+                    let base_conditions = vec![
+                        stmt::Statement::Match(stmt::Match {
+                            left: expr::Expression::Named(expr::NamedExpression::Fib(expr::Fib {
+                                result: expr::FibResult::Type,
+                                flags: rules_hash.clone(),
+                            })),
+                            right: expr::Expression::String(Cow::Borrowed(fib_type)),
+                            op: stmt::Operator::EQ,
+                        }),
+                        get_jump_action(Cow::Borrowed(DNATCHAIN)),
+                    ];
+                    batch.add(make_rule(Cow::Borrowed(chain), Cow::Owned(base_conditions)));
+                }
+            }
         }
 
         // Forward chain: ct state invalid drop

--- a/src/test/main.rs
+++ b/src/test/main.rs
@@ -103,6 +103,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .expect("connect socket");
 
+    if sock_type == socket::SockType::Datagram {
+        socket::setsockopt(&connect_sock, socket::sockopt::Broadcast, &true)
+            .expect("set SO_BROADCAST");
+    }
+
     let mut send_buf = Vec::new();
     std::io::stdin()
         .read_to_end(&mut send_buf)

--- a/test/250-bridge-nftables.bats
+++ b/test/250-bridge-nftables.bats
@@ -517,6 +517,62 @@ export NETAVARK_FW=nftables
     test_port_fw ip=dual proto=udp
 }
 
+@test "$fw_driver - port forwarding ipv4 - udp broadcast" {
+    local host_port=$(random_port)
+    local container_port=$(random_port)
+    local container_id=$(random_string 64)
+    local container_name="name-$(random_string 10)"
+    local ipv4_subnet=$(random_subnet)
+    local ipv4_gateway=$(gateway_from_subnet $ipv4_subnet)
+    local ipv4_container_ip=$(random_ip_in_subnet $ipv4_subnet)
+    local broadcast_ip=$(echo $ipv4_subnet | sed "s/\.0\/24/.255/")
+
+    read -r -d '\0' config <<EOF
+{
+   "container_id": "$container_id",
+   "container_name": "$container_name",
+   "port_mappings": [
+     {
+       "host_ip": "",
+       "container_port": $container_port,
+       "host_port": $host_port,
+       "range": 1,
+       "protocol": "udp"
+     }
+   ],
+   "networks": {
+      "podman": {
+         "static_ips": ["$ipv4_container_ip"],
+         "interface_name": "eth0"
+      }
+   },
+   "network_info": {
+      "podman": {
+         "name": "podman",
+         "id": "$(random_string 64)",
+         "driver": "bridge",
+         "network_interface": "podman0",
+         "subnets": [{"subnet": "$ipv4_subnet", "gateway": "$ipv4_gateway"}],
+         "ipv6_enabled": false,
+         "internal": false,
+         "dns_enabled": false,
+         "ipam_options": {
+            "driver": "host-local"
+         }
+      }
+   }
+}
+\0
+EOF
+
+    run_netavark setup $(get_container_netns_path) <<<"$config"
+
+    # Use netavark-connection-tester instead of socat since socat may not be installed in CI
+    run_connection_test "0" "udp" $container_port $broadcast_ip $host_port
+
+    run_netavark teardown $(get_container_netns_path) <<<"$config"
+}
+
 @test "$fw_driver - port forwarding ipv4 - sctp" {
     setup_sctp_kernel_module
     test_port_fw proto=sctp
@@ -1278,6 +1334,12 @@ net/ipv4/conf/podman1/rp_filter = 2"
 }
 
 function check_simple_bridge_nftables() {
+    # check nftables PREROUTING chain
+    run_in_host_netns nft list chain inet netavark PREROUTING
+    assert "$output" =~ "fib daddr type local jump NETAVARK-HOSTPORT-DNAT" "Prerouting local jump rule"
+    assert "$output" =~ "fib daddr type broadcast jump NETAVARK-HOSTPORT-DNAT" "Prerouting broadcast jump rule"
+    assert "$output" =~ "fib daddr type multicast jump NETAVARK-HOSTPORT-DNAT" "Prerouting multicast jump rule"
+
     # check nftables POSTROUTING chain
     run_in_host_netns nft list chain inet netavark POSTROUTING
     assert "${lines[3]}" =~ "meta mark & 0x00002000 == 0x00002000 masquerade" "Mark-masquerade rule"


### PR DESCRIPTION
Fixes #1466

### Context & Problem Statement
Currently, when a system broadcasts UDP packets on a network, rootful containers cannot receive that traffic via port forwarding (e.g., `-p 10600:10600/udp`). This occurs because the `netavark` nftables rules use `fib daddr type local` for the PREROUTING and OUTPUT chains, which drops broadcast and multicast traffic before it reaches the DNAT chain for evaluation.

### Proposed Solution
This PR updates the FIB match rule to use an anonymous set `{ local, broadcast, multicast }`. This allows broadcast and multicast packets to successfully route to the `NETAVARK-HOSTPORT-DNAT` chain. Security isolation is fully preserved because the DNAT chain acts as the primary filter—only packets that map to an explicitly published container port will be forwarded.

### Impact & Benefits
Containers can now natively receive broadcast and multicast UDP traffic via standard port publishing. This aligns rootful container behavior with user expectations and eliminates the need for complex host-level workarounds (such as modifying `route_localnet` sysctls or relying on `socat` for unicast redirection).