### PR TITLE
bridge: add DNS firewall rules for internal networks

### DIFF
--- a/src/firewall/firewalld.rs
+++ b/src/firewall/firewalld.rs
@@ -38,6 +38,10 @@ impl firewall::FirewallDriver for FirewallD {
         network_setup: internal_types::SetupNetwork,
         _dbus_con: &Option<Connection>,
     ) -> NetavarkResult<()> {
+        if network_setup.internal {
+            return Ok(());
+        }
+
         let mut need_reload = false;
 
         need_reload |= match create_zone_if_not_exist(&self.conn, ZONENAME) {
@@ -141,6 +145,9 @@ impl firewall::FirewallDriver for FirewallD {
     }
 
     fn teardown_network(&self, tear: TearDownNetwork) -> NetavarkResult<()> {
+        if tear.config.internal {
+            return Ok(());
+        }
         if !tear.complete_teardown {
             return Ok(());
         }
@@ -172,6 +179,10 @@ impl firewall::FirewallDriver for FirewallD {
         // Because of Podman's locking, this should be safe in the typical
         // case.
         // I don't think there's a safer way, unfortunately.
+
+        if setup_portfw.internal {
+            return Ok(());
+        }
 
         let sig_ssss = match Signature::try_from("(ssss)") {
             Ok(s) => s,
@@ -377,6 +388,10 @@ impl firewall::FirewallDriver for FirewallD {
     }
 
     fn teardown_port_forward(&self, teardown_pf: TeardownPortForward) -> NetavarkResult<()> {
+        if teardown_pf.config.internal {
+            return Ok(());
+        }
+
         // Get the current configuration for the policy
         let policy_config = get_policy_config(&self.conn, PORTPOLICYNAME.to_string())?;
         let localhost_policy_config = get_policy_config(&self.conn, HOSTFWDPOLICYNAME.to_string())?;

--- a/src/firewall/nft.rs
+++ b/src/firewall/nft.rs
@@ -417,100 +417,107 @@ impl firewall::FirewallDriver for Nftables {
                 }
 
                 log::info!("Creating container chain {chain}");
+
                 // We don't. Make one.
                 batch.add(make_basic_chain(chain.clone()));
 
-                // Subnet chain: ip daddr <subnet> accept
-                batch.add(make_rule(
-                    chain.clone(),
-                    Cow::Owned(vec![
-                        get_subnet_match(&subnet, "daddr", stmt::Operator::EQ),
-                        stmt::Statement::Accept(None),
-                    ]),
-                ));
+                if !network_setup.internal {
+                    // Subnet chain: ip daddr <subnet> accept
+                    batch.add(make_rule(
+                        chain.clone(),
+                        Cow::Owned(vec![
+                            get_subnet_match(&subnet, "daddr", stmt::Operator::EQ),
+                            stmt::Statement::Accept(None),
+                        ]),
+                    ));
 
-                // Subnet chain: ip daddr != 224.0.0.0/4 snat/masquerade
-                let multicast_address: IpNet = match subnet {
-                    IpNet::V4(_) => MULTICAST_NET_V4.parse()?,
-                    IpNet::V6(_) => MULTICAST_NET_V6.parse()?,
-                };
+                    // Subnet chain: ip daddr != 224.0.0.0/4 snat/masquerade
+                    let multicast_address: IpNet = match subnet {
+                        IpNet::V4(_) => MULTICAST_NET_V4.parse()?,
+                        IpNet::V6(_) => MULTICAST_NET_V6.parse()?,
+                    };
 
-                // Use appropriate outbound address based on subnet type
-                match subnet {
-                    IpNet::V4(_) => {
-                        if let Some(addr4) = network_setup.outbound_addr4 {
-                            log::trace!("Creating IPv4 SNAT rule with outbound address {addr4}");
-                            batch.add(make_rule(
-                                chain.clone(),
-                                Cow::Owned(vec![
-                                    get_subnet_match(
-                                        &multicast_address,
-                                        "daddr",
-                                        stmt::Operator::NEQ,
-                                    ),
-                                    stmt::Statement::SNAT(Some(stmt::NAT {
-                                        addr: Some(expr::Expression::String(
-                                            addr4.to_string().into(),
-                                        )),
-                                        family: Some(stmt::NATFamily::IP),
-                                        port: None,
-                                        flags: None,
-                                    })),
-                                ]),
-                            ));
-                        } else {
-                            log::trace!(
-                                "No IPv4 outbound address set, using default MASQUERADE rule"
-                            );
-                            batch.add(make_rule(
-                                chain.clone(),
-                                Cow::Owned(vec![
-                                    get_subnet_match(
-                                        &multicast_address,
-                                        "daddr",
-                                        stmt::Operator::NEQ,
-                                    ),
-                                    stmt::Statement::Masquerade(None),
-                                ]),
-                            ));
+                    // Use appropriate outbound address based on subnet type
+                    match subnet {
+                        IpNet::V4(_) => {
+                            if let Some(addr4) = network_setup.outbound_addr4 {
+                                log::trace!(
+                                    "Creating IPv4 SNAT rule with outbound address {addr4}"
+                                );
+                                batch.add(make_rule(
+                                    chain.clone(),
+                                    Cow::Owned(vec![
+                                        get_subnet_match(
+                                            &multicast_address,
+                                            "daddr",
+                                            stmt::Operator::NEQ,
+                                        ),
+                                        stmt::Statement::SNAT(Some(stmt::NAT {
+                                            addr: Some(expr::Expression::String(
+                                                addr4.to_string().into(),
+                                            )),
+                                            family: Some(stmt::NATFamily::IP),
+                                            port: None,
+                                            flags: None,
+                                        })),
+                                    ]),
+                                ));
+                            } else {
+                                log::trace!(
+                                    "No IPv4 outbound address set, using default MASQUERADE rule"
+                                );
+                                batch.add(make_rule(
+                                    chain.clone(),
+                                    Cow::Owned(vec![
+                                        get_subnet_match(
+                                            &multicast_address,
+                                            "daddr",
+                                            stmt::Operator::NEQ,
+                                        ),
+                                        stmt::Statement::Masquerade(None),
+                                    ]),
+                                ));
+                            }
                         }
-                    }
-                    IpNet::V6(_) => {
-                        if let Some(addr6) = network_setup.outbound_addr6 {
-                            log::trace!("Creating IPv6 SNAT rule with outbound address {addr6}");
-                            batch.add(make_rule(
-                                chain.clone(),
-                                Cow::Owned(vec![
-                                    get_subnet_match(
-                                        &multicast_address,
-                                        "daddr",
-                                        stmt::Operator::NEQ,
-                                    ),
-                                    stmt::Statement::SNAT(Some(stmt::NAT {
-                                        addr: Some(expr::Expression::String(
-                                            addr6.to_string().into(),
-                                        )),
-                                        family: Some(stmt::NATFamily::IP6),
-                                        port: None,
-                                        flags: None,
-                                    })),
-                                ]),
-                            ));
-                        } else {
-                            log::trace!(
-                                "No IPv6 outbound address set, using default MASQUERADE rule"
-                            );
-                            batch.add(make_rule(
-                                chain.clone(),
-                                Cow::Owned(vec![
-                                    get_subnet_match(
-                                        &multicast_address,
-                                        "daddr",
-                                        stmt::Operator::NEQ,
-                                    ),
-                                    stmt::Statement::Masquerade(None),
-                                ]),
-                            ));
+                        IpNet::V6(_) => {
+                            if let Some(addr6) = network_setup.outbound_addr6 {
+                                log::trace!(
+                                    "Creating IPv6 SNAT rule with outbound address {addr6}"
+                                );
+                                batch.add(make_rule(
+                                    chain.clone(),
+                                    Cow::Owned(vec![
+                                        get_subnet_match(
+                                            &multicast_address,
+                                            "daddr",
+                                            stmt::Operator::NEQ,
+                                        ),
+                                        stmt::Statement::SNAT(Some(stmt::NAT {
+                                            addr: Some(expr::Expression::String(
+                                                addr6.to_string().into(),
+                                            )),
+                                            family: Some(stmt::NATFamily::IP6),
+                                            port: None,
+                                            flags: None,
+                                        })),
+                                    ]),
+                                ));
+                            } else {
+                                log::trace!(
+                                    "No IPv6 outbound address set, using default MASQUERADE rule"
+                                );
+                                batch.add(make_rule(
+                                    chain.clone(),
+                                    Cow::Owned(vec![
+                                        get_subnet_match(
+                                            &multicast_address,
+                                            "daddr",
+                                            stmt::Operator::NEQ,
+                                        ),
+                                        stmt::Statement::Masquerade(None),
+                                    ]),
+                                ));
+                            }
                         }
                     }
                 }
@@ -550,42 +557,48 @@ impl firewall::FirewallDriver for Nftables {
                         stmt::Statement::Accept(None),
                     ]),
                 ));
-                // Forward chain: ip daddr <subnet> ct state related,established accept
-                batch.add(make_rule(
-                    Cow::Borrowed(FORWARDCHAIN),
-                    Cow::Owned(vec![
-                        get_subnet_match(&subnet, "daddr", stmt::Operator::EQ),
-                        stmt::Statement::Match(stmt::Match {
-                            left: expr::Expression::Named(expr::NamedExpression::CT(expr::CT {
-                                key: Cow::Borrowed("state"),
-                                family: None,
-                                dir: None,
-                            })),
-                            right: expr::Expression::List(vec![
-                                expr::Expression::String(Cow::Borrowed("established")),
-                                expr::Expression::String(Cow::Borrowed("related")),
-                            ]),
-                            op: stmt::Operator::IN,
-                        }),
-                        stmt::Statement::Accept(None),
-                    ]),
-                ));
-                // Forward chain: ip saddr <subnet> accept
-                batch.add(make_rule(
-                    Cow::Borrowed(FORWARDCHAIN),
-                    Cow::Owned(vec![
-                        get_subnet_match(&subnet, "saddr", stmt::Operator::EQ),
-                        stmt::Statement::Accept(None),
-                    ]),
-                ));
-                // Postrouting chain: ip saddr <subnet> jump <chain>
-                batch.add(make_rule(
-                    Cow::Borrowed(POSTROUTINGCHAIN),
-                    Cow::Owned(vec![
-                        get_subnet_match(&subnet, "saddr", stmt::Operator::EQ),
-                        get_jump_action(chain.clone()),
-                    ]),
-                ));
+                if !network_setup.internal {
+                    // Forward chain: ip daddr <subnet> ct state related,established accept
+                    batch.add(make_rule(
+                        Cow::Borrowed(FORWARDCHAIN),
+                        Cow::Owned(vec![
+                            get_subnet_match(&subnet, "daddr", stmt::Operator::EQ),
+                            stmt::Statement::Match(stmt::Match {
+                                left: expr::Expression::Named(expr::NamedExpression::CT(
+                                    expr::CT {
+                                        key: Cow::Borrowed("state"),
+                                        family: None,
+                                        dir: None,
+                                    },
+                                )),
+                                right: expr::Expression::List(vec![
+                                    expr::Expression::String(Cow::Borrowed("established")),
+                                    expr::Expression::String(Cow::Borrowed("related")),
+                                ]),
+                                op: stmt::Operator::IN,
+                            }),
+                            stmt::Statement::Accept(None),
+                        ]),
+                    ));
+
+                    // Forward chain: ip saddr <subnet> accept
+                    batch.add(make_rule(
+                        Cow::Borrowed(FORWARDCHAIN),
+                        Cow::Owned(vec![
+                            get_subnet_match(&subnet, "saddr", stmt::Operator::EQ),
+                            stmt::Statement::Accept(None),
+                        ]),
+                    ));
+
+                    // Postrouting chain: ip saddr <subnet> jump <chain>
+                    batch.add(make_rule(
+                        Cow::Borrowed(POSTROUTINGCHAIN),
+                        Cow::Owned(vec![
+                            get_subnet_match(&subnet, "saddr", stmt::Operator::EQ),
+                            get_jump_action(chain.clone()),
+                        ]),
+                    ));
+                }
             }
         }
 
@@ -761,33 +774,34 @@ impl firewall::FirewallDriver for Nftables {
             }
         }
 
-        if let Some(ip_v4) = setup_portfw.container_ip_v4 {
-            if let Some(subnet_v4) = setup_portfw.subnet_v4 {
-                for rule in get_dnat_rules_for_addr_family(
-                    ip_v4,
-                    subnet_v4,
-                    &setup_portfw.network_id,
-                    &existing_rules,
-                    &setup_portfw,
-                )? {
-                    batch.add(rule);
+        if !setup_portfw.internal {
+            if let Some(ip_v4) = setup_portfw.container_ip_v4 {
+                if let Some(subnet_v4) = setup_portfw.subnet_v4 {
+                    for rule in get_dnat_rules_for_addr_family(
+                        ip_v4,
+                        subnet_v4,
+                        &setup_portfw.network_id,
+                        &existing_rules,
+                        &setup_portfw,
+                    )? {
+                        batch.add(rule);
+                    }
+                }
+            }
+            if let Some(ip_v6) = setup_portfw.container_ip_v6 {
+                if let Some(subnet_v6) = setup_portfw.subnet_v6 {
+                    for rule in get_dnat_rules_for_addr_family(
+                        ip_v6,
+                        subnet_v6,
+                        &setup_portfw.network_id,
+                        &existing_rules,
+                        &setup_portfw,
+                    )? {
+                        batch.add(rule);
+                    }
                 }
             }
         }
-        if let Some(ip_v6) = setup_portfw.container_ip_v6 {
-            if let Some(subnet_v6) = setup_portfw.subnet_v6 {
-                for rule in get_dnat_rules_for_addr_family(
-                    ip_v6,
-                    subnet_v6,
-                    &setup_portfw.network_id,
-                    &existing_rules,
-                    &setup_portfw,
-                )? {
-                    batch.add(rule);
-                }
-            }
-        }
-
         let rules = batch.to_nftables();
 
         helper::apply_ruleset(&rules)?;

--- a/src/firewall/state.rs
+++ b/src/firewall/state.rs
@@ -272,10 +272,11 @@ mod tests {
             network_hash_name: "hash".to_string(),
             isolation: IsolateOption::Never,
             dns_port: 53,
+            internal: false,
             outbound_addr4: None,
             outbound_addr6: None,
         };
-        let net_conf_json = r#"{"subnets":["10.0.0.0/24"],"bridge_name":"bridge","network_id":"c2c8a073252874648259997d53b0a1bffa491e21f04bc1bf8609266359931395","network_hash_name":"hash","isolation":"Never","dns_port":53}"#;
+        let net_conf_json = r#"{"subnets":["10.0.0.0/24"],"bridge_name":"bridge","network_id":"c2c8a073252874648259997d53b0a1bffa491e21f04bc1bf8609266359931395","network_hash_name":"hash","isolation":"Never","dns_port":53,"internal":false}"#;
 
         let port_conf = PortForwardConfig {
             container_id: container_id.to_string(),
@@ -290,8 +291,9 @@ mod tests {
             subnet_v6: None,
             dns_port: 53,
             dns_server_ips: &vec![],
+            internal: false,
         };
-        let port_conf_json = r#"{"container_id":"123","network_id":"c2c8a073252874648259997d53b0a1bffa491e21f04bc1bf8609266359931395","port_mappings":null,"network_name":"name","network_hash_name":"hash","container_ip_v4":"10.0.0.2","subnet_v4":"10.0.0.0/24","container_ip_v6":null,"subnet_v6":null,"dns_port":53,"dns_server_ips":[]}"#;
+        let port_conf_json = r#"{"container_id":"123","network_id":"c2c8a073252874648259997d53b0a1bffa491e21f04bc1bf8609266359931395","port_mappings":null,"network_name":"name","network_hash_name":"hash","container_ip_v4":"10.0.0.2","subnet_v4":"10.0.0.0/24","container_ip_v6":null,"subnet_v6":null,"dns_port":53,"dns_server_ips":[],"internal":false}"#;
 
         let res = write_fw_config(
             config_dir,

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -362,8 +362,9 @@ impl driver::NetworkDriver for Bridge<'_> {
         };
 
         if let BridgeMode::Managed = data.mode {
-            // if the network is internal do not setup firewall rules
-            if !self.info.network.internal {
+            // Internal networks normally skip firewall setup, but when DNS is
+            // enabled, we still need the DNS rules so aardvark-dns is reachable.
+            if !self.info.network.internal || self.info.network.dns_enabled {
                 self.setup_firewall(data)?
             }
         }
@@ -484,7 +485,9 @@ impl<'a> Bridge<'a> {
         };
 
         // 2. Tear down firewall & sysctl FIRST (while routes still exist)
-        if !self.info.network.internal && mode == BridgeMode::Managed {
+        if (!self.info.network.internal || self.info.network.dns_enabled)
+            && mode == BridgeMode::Managed
+        {
             match self.teardown_firewall(complete_teardown, bridge_name.clone()) {
                 Ok(_) => {}
                 Err(err) => {
@@ -543,6 +546,7 @@ impl<'a> Bridge<'a> {
             network_hash_name: id_network_hash.clone(),
             isolation: isolate,
             dns_port: self.info.dns_port,
+            internal: self.info.network.internal,
             outbound_addr4,
             outbound_addr6,
         };
@@ -586,6 +590,7 @@ impl<'a> Bridge<'a> {
             subnet_v6: net_v6,
             dns_port: self.info.dns_port,
             dns_server_ips: nameservers,
+            internal: self.info.network.internal,
         };
         Ok((sn, spf))
     }

--- a/src/network/internal_types.rs
+++ b/src/network/internal_types.rs
@@ -26,6 +26,9 @@ pub struct SetupNetwork {
     pub isolation: IsolateOption,
     /// port used for the dns server
     pub dns_port: u16,
+    /// whether the network is internal, only DNS firewall rules are applied for these networks
+    #[serde(default)]
+    pub internal: bool,
     /// outbound IPv4 address for SNAT
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -76,6 +79,9 @@ pub struct PortForwardConfigGeneric<Ports, IpAddresses> {
     pub dns_port: u16,
     /// dns servers IPs where forwarding rule to port 53 from dns_port are necessary
     pub dns_server_ips: IpAddresses,
+    // whether network is internal; skip container port forwarding rules
+    #[serde(default)]
+    pub internal: bool,
 }
 
 // Some trickery to define two struct one with references and one with owned data,
@@ -100,6 +106,7 @@ impl<'a> From<&'a PortForwardConfigOwned> for PortForwardConfig<'a> {
             subnet_v6: p.subnet_v6,
             dns_port: p.dns_port,
             dns_server_ips: &p.dns_server_ips,
+            internal: p.internal,
         }
     }
 }

--- a/test/200-bridge-firewalld.bats
+++ b/test/200-bridge-firewalld.bats
@@ -488,3 +488,17 @@ function strict_port_forwarding_invalid_value_should_warn_and_allow_port_forward
 @test "nftables - strict port forwarding invalid value should warn and allow port forwarding" {
     strict_port_forwarding_invalid_value_should_warn_and_allow_port_forwarding nftables
 }
+
+@test "$fw_driver - internal network does not create firewalld rules" {
+    run_netavark --file ${TESTSDIR}/testfiles/internal-dns.json setup $(get_container_netns_path)
+
+    expected_rc=2 run_in_host_netns firewall-cmd --get-zone-of-source=10.89.3.0/24
+    assert "$output" == "no zone" "internal ipv4 subnet must not be in a netavark zone"
+    expected_rc=2 run_in_host_netns firewall-cmd --get-zone-of-source=fd10:88:a::/64
+    assert "$output" == "no zone" "internal ipv6 subnet must not be in a netavark zone"
+
+    run_in_host_netns firewall-cmd --get-policies
+    assert "$output" "!~" "netavark" "no netavark policies created for internal network"
+
+    run_netavark --file ${TESTSDIR}/testfiles/internal-dns.json teardown $(get_container_netns_path)
+}

--- a/test/250-bridge-nftables.bats
+++ b/test/250-bridge-nftables.bats
@@ -1426,3 +1426,115 @@ EOF
     run_helper ls "$NETAVARK_TMPDIR/config/aardvark-dns"
     assert "$output" == "" "no aardvark entries written on rejection"
 }
+
+# https://github.com/containers/netavark/issues/1055
+@test "$fw_driver - internal network dns with default drop policy" {
+    run_netavark --file ${TESTSDIR}/testfiles/internal-dns.json setup $(get_container_netns_path)
+
+    # internal networks get ONLY the DNS input accept rules, no routing/NAT rules
+
+    # INPUT: base chain + one DNS accept per subnet (v4, v6), nothing else
+    run_in_host_netns nft list chain inet netavark INPUT
+    assert "${lines[3]}" =~ "ip saddr 10.89.3.0/24 meta l4proto \{ tcp, udp \} th dport 53 accept" "ipv4 DNS accept rule"
+    assert "${lines[4]}" =~ "ip6 saddr fd10:88:a::/64 meta l4proto \{ tcp, udp \} th dport 53 accept" "ipv6 DNS accept rule"
+    assert "${#lines[@]}" = 7 "only DNS accept rules in INPUT chain"
+
+    # per-subnet chains must be empty: no daddr accept, no masquerade/SNAT
+    run_in_host_netns nft list chain inet netavark nv_ec79dd0c_10_89_3_0_nm24
+    assert "${#lines[@]}" = 4 "ipv4 subnet chain is empty for internal network"
+    run_in_host_netns nft list chain inet netavark nv_ec79dd0c_fd10-88-a--_nm64
+    assert "${#lines[@]}" = 4 "ipv6 subnet chain is empty for internal network"
+
+    # FORWARD: only base rules, no per-network accept rules
+    run_in_host_netns nft list chain inet netavark FORWARD
+    assert "${lines[3]}" =~ "ct state invalid drop" "CT state invalid rule"
+    assert "${lines[4]}" =~ "ct mark & 0x00001000 == 0x00001000 accept" "accept dnat traffic"
+    assert "${lines[5]}" =~ "jump NETAVARK-ISOLATION-1" "jump to isolation chain"
+    assert "${#lines[@]}" = 8 "no per-network FORWARD rules for internal network"
+
+    # POSTROUTING: only the base mark-masquerade rule, no per-network jump
+    run_in_host_netns nft list chain inet netavark POSTROUTING
+    assert "${lines[3]}" =~ "meta mark & 0x00002000 == 0x00002000 masquerade" "Mark-masquerade rule"
+    assert "${#lines[@]}" = 6 "no per-network POSTROUTING rule for internal network"
+
+    # a port is published, but internal networks must skip container port-forwarding
+    # (and there is no DNS redirect on the default port), so the chain stays empty
+    run_in_host_netns nft list chain inet netavark NETAVARK-HOSTPORT-DNAT
+    assert "${#lines[@]}" = 4 "no port-forwarding rules for internal network"
+
+    # internal isolation is still enforced: no default route
+    run_in_container_netns ip route show
+    assert "$output" "!~" "default" "No default route for internal networks"
+    run_in_container_netns ip -6 route show
+    assert "$output" "!~" "default" "No default route for internal networks (ipv6)"
+
+    # enforce a default drop policy and make sure DNS still resolves
+    run_in_host_netns nft add chain inet netavark INPUT \{ type filter hook input priority 0 \; policy drop \; \}
+    run_in_host_netns nft add rule inet netavark INPUT ct state related,established accept
+    run_in_host_netns nft add rule inet netavark INPUT meta l4proto ipv6-icmp accept
+
+    run_in_container_netns dig +short "somename.dns.podman" @10.89.3.1 A "somename.dns.podman" @10.89.3.1 AAAA
+    assert "${lines[0]}" =~ "10.89.3.2" "ipv4 dns resolution works 1/2"
+    assert "${lines[1]}" =~ "fd10:88:a::2" "ipv6 dns resolution works 2/2"
+
+    run_in_container_netns dig +short "somename.dns.podman" @fd10:88:a::1
+    assert "${lines[0]}" =~ "10.89.3.2" "ipv6 dns resolution works"
+
+    run_netavark --file ${TESTSDIR}/testfiles/internal-dns.json teardown $(get_container_netns_path)
+}
+
+# https://github.com/containers/netavark/issues/1051
+@test "$fw_driver - internal network dns with default drop policy and non-default dns port" {
+    dns_port=$((RANDOM+10000))
+
+    NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/internal-dns.json setup $(get_container_netns_path)
+
+    # the DNS redirect (dport 53 -> dns_port) is created even for internal networks,
+    # but the published container port is still skipped: only the two DNS rules exist
+    run_in_host_netns nft list chain inet netavark NETAVARK-HOSTPORT-DNAT
+    assert "${lines[2]}" =~ "ip6 daddr fd10:88:a::1 meta l4proto \{ tcp, udp \} th dport 53 dnat ip6 to \[fd10:88:a::1\]:$dns_port" "DNS redirect rule ip6"
+    assert "${lines[3]}" =~ "ip daddr 10.89.3.1 meta l4proto \{ tcp, udp \} th dport 53 dnat ip to 10.89.3.1:$dns_port" "DNS redirect rule ip4"
+    assert "${#lines[@]}" = 6 "only the DNS redirect rules, no container port-forwarding"
+
+    # everything else is identical to the default-port case: only DNS rules, no routing/NAT
+
+    # INPUT: base chain + one DNS accept per subnet (v4, v6), nothing else
+    run_in_host_netns nft list chain inet netavark INPUT
+    assert "${lines[3]}" =~ "ip saddr 10.89.3.0/24 meta l4proto \{ tcp, udp \} th dport 53 accept" "ipv4 DNS accept rule"
+    assert "${lines[4]}" =~ "ip6 saddr fd10:88:a::/64 meta l4proto \{ tcp, udp \} th dport 53 accept" "ipv6 DNS accept rule"
+    assert "${#lines[@]}" = 7 "only DNS accept rules in INPUT chain"
+
+    # per-subnet chains must be empty: no daddr accept, no masquerade/SNAT
+    run_in_host_netns nft list chain inet netavark nv_ec79dd0c_10_89_3_0_nm24
+    assert "${#lines[@]}" = 4 "ipv4 subnet chain is empty for internal network"
+    run_in_host_netns nft list chain inet netavark nv_ec79dd0c_fd10-88-a--_nm64
+    assert "${#lines[@]}" = 4 "ipv6 subnet chain is empty for internal network"
+
+    # FORWARD: only base rules, no per-network accept rules
+    run_in_host_netns nft list chain inet netavark FORWARD
+    assert "${lines[3]}" =~ "ct state invalid drop" "CT state invalid rule"
+    assert "${lines[4]}" =~ "ct mark & 0x00001000 == 0x00001000 accept" "accept dnat traffic"
+    assert "${lines[5]}" =~ "jump NETAVARK-ISOLATION-1" "jump to isolation chain"
+    assert "${#lines[@]}" = 8 "no per-network FORWARD rules for internal network"
+
+    # POSTROUTING: only the base mark-masquerade rule, no per-network jump
+    run_in_host_netns nft list chain inet netavark POSTROUTING
+    assert "${lines[3]}" =~ "meta mark & 0x00002000 == 0x00002000 masquerade" "Mark-masquerade rule"
+    assert "${#lines[@]}" = 6 "no per-network POSTROUTING rule for internal network"
+
+    # after the redirect DNS arrives on dns_port, so accept that under the drop policy
+    run_in_host_netns nft add chain inet netavark INPUT \{ type filter hook input priority 0 \; policy drop \; \}
+    run_in_host_netns nft add rule inet netavark INPUT ip saddr 10.89.3.0/24 meta l4proto \{ tcp, udp \} th dport $dns_port accept
+    run_in_host_netns nft add rule inet netavark INPUT ip6 saddr fd10:88:a::/64 meta l4proto \{ tcp, udp \} th dport $dns_port accept
+    run_in_host_netns nft add rule inet netavark INPUT ct state related,established accept
+    run_in_host_netns nft add rule inet netavark INPUT meta l4proto ipv6-icmp accept
+
+    run_in_container_netns dig +short "somename.dns.podman" @10.89.3.1 A "somename.dns.podman" @10.89.3.1 AAAA
+    assert "${lines[0]}" =~ "10.89.3.2" "ipv4 dns resolution works 1/2"
+    assert "${lines[1]}" =~ "fd10:88:a::2" "ipv6 dns resolution works 2/2"
+
+    run_in_container_netns dig +short "somename.dns.podman" @fd10:88:a::1
+    assert "${lines[0]}" =~ "10.89.3.2" "ipv6 dns resolution works"
+
+    NETAVARK_DNS_PORT="$dns_port" run_netavark --file ${TESTSDIR}/testfiles/internal-dns.json teardown $(get_container_netns_path)
+}

--- a/test/testfiles/internal-dns.json
+++ b/test/testfiles/internal-dns.json
@@ -1,0 +1,39 @@
+{
+      "container_id": "f031bf33eecba75d0d84952337b1ceef6a239eb8e94b48aee0993d0791345325",
+      "container_name": "somename",
+      "port_mappings": [
+        {
+            "host_ip": "",
+            "container_port": 8080,
+            "host_port": 8080,
+            "range": 1,
+            "protocol": "tcp"
+        }
+      ],
+      "networks": {
+          "podman1": {
+              "static_ips": [
+                  "10.89.3.2",
+                  "fd10:88:a::2"
+              ],
+              "interface_name": "eth0"
+          }
+      },
+      "network_info": {
+          "podman1": {
+              "name": "podman1",
+              "id": "ec79dd0cad82083c8ac5cc23e9542e4ddea813dff60d68258d36e84f6393b63b",
+              "driver": "bridge",
+              "network_interface": "podman1",
+              "subnets": [
+                  { "subnet": "10.89.3.0/24", "gateway": "10.89.3.1" },
+                  { "subnet": "fd10:88:a::/64", "gateway": "fd10:88:a::1" }
+              ],
+              "ipv6_enabled": true,
+              "internal": true,
+              "dns_enabled": true,
+              "ipam_options": { "driver": "host-local" }
+          }
+      }
+  }
+


### PR DESCRIPTION
Internal networks skipped firewall setup entirely, so the DNS input-accept rule was never created: container `hostname` resolution didn't work in internal networks. The DNS redirect (dport 53 -> dns_port) was never created, so a non-default `dns-port` didn't work. 

For nftables, internal networks will get the DNS accept and redirect redirect rules, but will still skip all 
masquerade/forward/port forwarding rules to keep the network isolation. 

For firewalld, internal networks will skip setup/tear down. 

### Tests
`sudo bats -f "internal network dns with default drop policy" test/250-bridge-nftables.bats`

Fixes: https://github.com/containers/netavark/issues/1051
Fixes: https://github.com/containers/netavark/issues/1055